### PR TITLE
feat(dashboard): real-data API bridge + live/mock toggle

### DIFF
--- a/dashboard/api_server.py
+++ b/dashboard/api_server.py
@@ -22,19 +22,19 @@ Endpoints
 import json
 import sys
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 # ── Make coherence_ops importable ────────────────────────────────────────────
 REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-import uvicorn
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
+import uvicorn  # noqa: E402
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 
-from coherence_ops import (
+from coherence_ops import (  # noqa: E402
     DLRBuilder,
     DriftSignalCollector,
     IRISEngine,

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
-    BarChart, Bar, LineChart, Line, AreaChart, Area, XAxis, YAxis,
+    BarChart, Bar, AreaChart, Area, XAxis, YAxis,
     CartesianGrid, Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell,
     RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis
 } from 'recharts';

--- a/dashboard/src/mockData.ts
+++ b/dashboard/src/mockData.ts
@@ -298,7 +298,7 @@ function resolveWhy(query: IRISQueryInput, queryId: string): IRISResponse {
   };
 }
 
-function resolveWhatChanged(query: IRISQueryInput, queryId: string): IRISResponse {
+function resolveWhatChanged(_query: IRISQueryInput, queryId: string): IRISResponse {
     const totalEntries = 20 + Math.floor(Math.random() * 80);
     const provenance: IRISProvenanceLink[] = [];
     const parts: string[] = [];
@@ -356,7 +356,7 @@ function resolveWhatChanged(query: IRISQueryInput, queryId: string): IRISRespons
   };
 }
 
-function resolveWhatDrifted(query: IRISQueryInput, queryId: string): IRISResponse {
+function resolveWhatDrifted(_query: IRISQueryInput, queryId: string): IRISResponse {
     const totalSignals = 8 + Math.floor(Math.random() * 40);
     const provenance: IRISProvenanceLink[] = [];
     const parts: string[] = [];
@@ -476,7 +476,7 @@ function resolveRecall(query: IRISQueryInput, queryId: string): IRISResponse {
   };
 }
 
-function resolveStatus(query: IRISQueryInput, queryId: string): IRISResponse {
+function resolveStatus(_query: IRISQueryInput, queryId: string): IRISResponse {
     const provenance: IRISProvenanceLink[] = [];
     const parts: string[] = [];
 


### PR DESCRIPTION
## Summary

- **`dashboard/api_server.py`** — new FastAPI server (port 8000) that loads real `DecisionEpisodes` and `DriftEvents` from `examples/`, runs the full `DLR → RS → DS → MG → CoherenceScorer` pipeline, and exposes:
  - `GET /api/episodes` — real episodes in dashboard format
  - `GET /api/drifts` — real drift events
  - `GET /api/agents` — per-agent metric aggregates
  - `GET /api/coherence` — full coherence score report (grade + dimensions)
  - `POST /api/iris` — live IRIS query resolution
- **`dashboard/src/mockData.ts`** — added `fetchRealEpisodes()`, `fetchRealDrifts()`, `fetchRealAgents()`, `fetchRealIRIS()` helpers that hit the API with a 2s timeout and return `null` if offline
- **`dashboard/src/App.tsx`** — `loadData` is now async; tries the API first, falls back to 100 generated mock episodes; shows a `● live` / `○ mock` badge in the header

## Test plan

- [ ] `pip install fastapi uvicorn && python dashboard/api_server.py` — server starts on port 8000
- [ ] `GET http://localhost:8000/api/health` returns `{"status":"ok","episode_count":7,"drift_count":8}`
- [ ] `cd dashboard && npm run dev` — dashboard shows `● live` badge and real episode data
- [ ] Stop the API server — dashboard falls back to mock data and shows `○ mock`
- [ ] `POST /api/iris` with `{"query_type":"STATUS"}` returns a valid IRIS response

🤖 Generated with [Claude Code](https://claude.com/claude-code)