### PR TITLE
Cookbook — runnable MCP/OpenClaw/OTel examples with verification

### DIFF
--- a/NAV.md
+++ b/NAV.md
@@ -109,6 +109,19 @@ last_updated: "2026-02-16"
 
 ---
 
+## 🍳 Cookbook (Runnables)
+
+Runnable, verifiable integration examples with expected output and failure modes.
+
+| Resource | Purpose |
+|----------|---------|
+| [`cookbook/README.md`](cookbook/README.md) | Quick chooser, prerequisites, verification concept |
+| [`cookbook/mcp/hello_deepsigma/`](cookbook/mcp/hello_deepsigma/) | MCP loopback — full 7-message session, run_loopback.py |
+| [`cookbook/openclaw/supervised_run/`](cookbook/openclaw/supervised_run/) | Contract enforcement — PASS, BLOCKED, POSTCONDITION FAILED scenarios |
+| [`cookbook/otel/trace_drift_patch/`](cookbook/otel/trace_drift_patch/) | OTel span export for episodes and drift events |
+
+---
+
 ## 📖 Extended Documentation
 
 | File | Topic |

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,0 +1,59 @@
+# Σ OVERWATCH — Integration Cookbook
+
+Runnable, verifiable examples for each adapter. Every recipe includes prerequisites, steps, expected output, verification, and failure modes.
+
+---
+
+## Quick Chooser
+
+| If you want to… | Use this recipe |
+|-----------------|----------------|
+| Connect an MCP client to OVERWATCH governance | [MCP: Hello DeepSigma](mcp/hello_deepsigma/README.md) |
+| Enforce pre/post action contracts on decisions | [OpenClaw: Supervised Run](openclaw/supervised_run/README.md) |
+| Emit decision spans to Jaeger / Honeycomb / Tempo | [OTel: Trace Drift Patch](otel/trace_drift_patch/README.md) |
+
+---
+
+## Common Prerequisites
+
+All recipes assume:
+
+```bash
+# 1. Clone and enter the repo
+git clone https://github.com/8ryanWh1t3/DeepSigma.git && cd DeepSigma
+
+# 2. Create a virtual environment
+python -m venv .venv && source .venv/bin/activate
+
+# 3. Install the package and dev deps
+pip install -r requirements.txt && pip install -e .
+```
+
+**Python version required:** 3.10+
+
+```bash
+python --version   # Must show 3.10 or higher
+```
+
+---
+
+## Verification Concept
+
+Each recipe produces one or more of:
+- A JSON artifact (DLR entry, drift event, sealed episode)
+- A console output matching an expected pattern
+- A test assertion that passes
+
+Recipes explicitly show what "success" looks like and what the most common failure modes are.
+
+---
+
+## Adapters Overview
+
+| Adapter | Path | Status |
+|---------|------|--------|
+| MCP | `adapters/mcp/` | Scaffold — JSON-RPC stdio loopback |
+| OpenClaw | `adapters/openclaw/` | Alpha — contract verification |
+| OpenTelemetry | `adapters/otel/` | Alpha — span export |
+
+> **MCP note:** The MCP adapter is a scaffold demonstrating the intended contract. It implements the JSON-RPC protocol over stdio and is ready for integration with a real MCP host.

--- a/cookbook/mcp/hello_deepsigma/README.md
+++ b/cookbook/mcp/hello_deepsigma/README.md
@@ -1,0 +1,130 @@
+# Cookbook: MCP — Hello DeepSigma
+
+**Adapter:** `adapters/mcp/mcp_server_scaffold.py`
+**Status:** Scaffold — JSON-RPC 2.0 over stdio. Full MCP handshake (capabilities negotiation) is not yet implemented; the scaffold is ready for integration with any MCP host that speaks JSON-RPC over stdio.
+
+This recipe shows:
+1. What the MCP contract looks like (request/response shapes)
+2. How to run a local loopback to verify the scaffold works
+3. What artifacts are produced (session events, sealed episode)
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- DeepSigma installed: `pip install -e .` (from repo root)
+- No external MCP library required — the scaffold uses stdlib only
+
+---
+
+## Steps
+
+### Step 1 — Understand the contract
+
+The scaffold exposes six tools via `tools/call`:
+
+| Tool | Purpose |
+|------|---------|
+| `overwatch.submit_task` | Start a new decision session |
+| `overwatch.tool_execute` | Execute a tool within the session |
+| `overwatch.action_dispatch` | Dispatch an action |
+| `overwatch.verify_run` | Run verification |
+| `overwatch.episode_seal` | Seal the episode (finalize) |
+| `overwatch.drift_emit` | Emit a drift event |
+
+See `sample_messages.jsonl` in this directory for the full message sequence.
+
+### Step 2 — Run the loopback script
+
+```bash
+# From repo root:
+python cookbook/mcp/hello_deepsigma/run_loopback.py
+```
+
+This script sends the complete message sequence through the MCP scaffold via subprocess and prints each request → response pair.
+
+### Step 3 — Run the scaffold manually (stdin/stdout)
+
+You can also drive the scaffold by hand with `echo` or from another process:
+
+```bash
+# List available tools
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | python adapters/mcp/mcp_server_scaffold.py
+
+# Submit a task (start a session)
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"overwatch.submit_task","arguments":{"decisionType":"LoanApproval"}}}' \
+  | python adapters/mcp/mcp_server_scaffold.py
+```
+
+---
+
+## Expected Output
+
+Running `run_loopback.py` should produce output similar to:
+
+```
+=== MCP Loopback: Hello DeepSigma ===
+
+[1] tools/list
+  → tools: overwatch.submit_task, overwatch.tool_execute, overwatch.action_dispatch,
+           overwatch.verify_run, overwatch.episode_seal, overwatch.drift_emit
+
+[2] overwatch.submit_task (decisionType=LoanApproval)
+  → session_id: sess_a1b2c3d4e5f6
+
+[3] overwatch.tool_execute (tool=credit_check)
+  → result: {echo: {...}, tool: credit_check}
+  → capturedAt: 2026-...Z
+
+[4] overwatch.action_dispatch
+  → ack: {status: accepted}
+
+[5] overwatch.verify_run (method=schema_check)
+  → result: pass
+
+[6] overwatch.episode_seal
+  → sealed: {seal: {sealedAt: ..., sealHash: scaffold}}
+
+[7] overwatch.drift_emit
+  → ok: True
+
+=== PASS: All 7 messages returned jsonrpc responses ===
+```
+
+---
+
+## Verification
+
+After running the loopback:
+
+1. Every response has `"jsonrpc": "2.0"` — confirms JSON-RPC framing is correct.
+2. The `episode_seal` response includes `seal.sealedAt` — confirms the episode was sealed with a timestamp.
+3. No `"error"` keys appear — confirms all tool names and session IDs resolved correctly.
+
+If the loopback script prints `=== PASS ===`, the MCP scaffold is operating correctly.
+
+---
+
+## Failure Modes
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `FileNotFoundError: tool_catalog.json` | Script not run from repo root | `cd /path/to/DeepSigma` first |
+| `json.decoder.JSONDecodeError` | Malformed request JSON | Check `sample_messages.jsonl` for syntax |
+| `"error": {"code": -32000, "message": "Unknown session_id"}` | Session ID from `submit_task` not reused in subsequent calls | The loopback script handles this automatically |
+| `ModuleNotFoundError: coherence_ops` | Package not installed | `pip install -e .` from repo root |
+
+---
+
+## Connecting to a Real MCP Host
+
+To connect the scaffold to a real MCP host (e.g., Claude Desktop, Continue.dev):
+
+1. Configure the host to spawn: `python /path/to/DeepSigma/adapters/mcp/mcp_server_scaffold.py`
+2. Communication is via stdin/stdout (JSON-RPC lines)
+3. The scaffold will respond to `tools/list` and `tools/call` requests
+4. Implement your host-side session management to chain `session_id` through the calls
+
+> **Note:** Full MCP capabilities negotiation (the `initialize` / `initialized` handshake) is not yet implemented. The scaffold skips this phase and responds to tool calls directly.

--- a/cookbook/mcp/hello_deepsigma/run_loopback.py
+++ b/cookbook/mcp/hello_deepsigma/run_loopback.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""MCP loopback runner — sends the full sample_messages.jsonl sequence through
+the MCP scaffold via subprocess and verifies every response.
+
+Usage:
+    python cookbook/mcp/hello_deepsigma/run_loopback.py
+
+Prerequisites:
+    pip install -e .   (from repo root)
+    Python 3.10+
+
+No external dependencies — uses stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAFFOLD = REPO_ROOT / "adapters" / "mcp" / "mcp_server_scaffold.py"
+MESSAGES_FILE = Path(__file__).parent / "sample_messages.jsonl"
+
+
+def send_message(proc: subprocess.Popen, message: dict) -> dict:
+    """Write one JSON-RPC request and read one response."""
+    line = json.dumps(message) + "\n"
+    proc.stdin.write(line)
+    proc.stdin.flush()
+    response_line = proc.stdout.readline()
+    return json.loads(response_line)
+
+
+def main() -> None:
+    print("=== MCP Loopback: Hello DeepSigma ===\n")
+
+    # Load sample messages (raw lines — we'll substitute session_id)
+    raw_lines = [
+        line.strip()
+        for line in MESSAGES_FILE.read_text().splitlines()
+        if line.strip()
+    ]
+
+    # Start the scaffold server as a subprocess
+    proc = subprocess.Popen(
+        [sys.executable, str(SCAFFOLD)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+    session_id: str = ""
+    errors: list[str] = []
+
+    try:
+        for raw_line in raw_lines:
+            # Substitute the session_id placeholder once we have one
+            if session_id:
+                raw_line = raw_line.replace("__SESSION_ID__", session_id)
+
+            request = json.loads(raw_line)
+            response = send_message(proc, request)
+
+            method = request.get("method", "")
+            params = request.get("params", {})
+            tool_name = params.get("name", method)
+
+            print(f"[{request['id']}] {tool_name}")
+
+            if "error" in response:
+                msg = f"  ERROR: {response['error']}"
+                print(msg)
+                errors.append(msg)
+                continue
+
+            result = response.get("result", {})
+
+            # Pretty-print key result fields
+            if tool_name == "tools/list":
+                names = [t["name"] for t in result.get("tools", [])]
+                print(f"  → tools: {', '.join(names)}")
+
+            elif tool_name == "overwatch.submit_task":
+                session_id = result.get("session_id", "")
+                print(f"  → session_id: {session_id}")
+
+            elif tool_name == "overwatch.tool_execute":
+                print(f"  → result tool: {result.get('result', {}).get('tool')}")
+                print(f"  → capturedAt: {result.get('capturedAt')}")
+
+            elif tool_name == "overwatch.action_dispatch":
+                print(f"  → ack: {result.get('ack')}")
+
+            elif tool_name == "overwatch.verify_run":
+                print(f"  → result: {result.get('result')}")
+
+            elif tool_name == "overwatch.episode_seal":
+                sealed = result.get("sealed", {})
+                seal = sealed.get("seal", {})
+                print(f"  → episodeId: {sealed.get('episodeId')}")
+                print(f"  → sealedAt: {seal.get('sealedAt')}")
+                print(f"  → sealHash: {seal.get('sealHash')}")
+
+            elif tool_name == "overwatch.drift_emit":
+                print(f"  → ok: {result.get('ok')}")
+
+            print()
+
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=5)
+
+    if errors:
+        print(f"=== FAIL: {len(errors)} error(s) encountered ===")
+        for e in errors:
+            print(f"  {e}")
+        sys.exit(1)
+    else:
+        print("=== PASS: All messages returned valid jsonrpc responses ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/mcp/hello_deepsigma/sample_messages.jsonl
+++ b/cookbook/mcp/hello_deepsigma/sample_messages.jsonl
@@ -1,0 +1,7 @@
+{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"overwatch.submit_task","arguments":{"decisionType":"LoanApproval","context":{"applicant_id":"cust-001","amount_requested":50000}}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"overwatch.tool_execute","arguments":{"session_id":"__SESSION_ID__","tool":"credit_check","input":{"applicant_id":"cust-001","bureau":"equifax"}}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"overwatch.action_dispatch","arguments":{"session_id":"__SESSION_ID__","action":{"type":"approve_loan","amount":50000},"idempotencyKey":"idem-001"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"overwatch.verify_run","arguments":{"session_id":"__SESSION_ID__","method":"schema_check","target":"loan_approval"}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"overwatch.episode_seal","arguments":{"session_id":"__SESSION_ID__","episode":{"episodeId":"ep-mcp-001","decisionType":"LoanApproval","actor":{"id":"mcp-agent-01"},"outcome":{"code":"success","reason":"all checks passed"}}}}}
+{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"overwatch.drift_emit","arguments":{"driftId":"drift-mcp-001","episodeId":"ep-mcp-001","driftType":"outcome","severity":"green","detectedAt":"2026-01-01T00:00:00Z","delta":0.0,"threshold":0.1}}}

--- a/cookbook/openclaw/supervised_run/README.md
+++ b/cookbook/openclaw/supervised_run/README.md
@@ -1,0 +1,174 @@
+# Cookbook: OpenClaw — Supervised Run
+
+**Adapter:** `adapters/openclaw/adapter.py`
+**Status:** Alpha — contract checking is functional; adapter API may evolve.
+
+This recipe shows how to use `OpenClawSupervisor` to:
+1. Load a policy pack with pre/post action contracts
+2. Run a supervised decision and observe pass/fail outcomes
+3. Verify which artifacts are produced
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- DeepSigma installed: `pip install -e .` (from repo root)
+- PyYAML (included in `requirements.txt`)
+
+```bash
+pip install -r requirements.txt && pip install -e .
+```
+
+---
+
+## Steps
+
+### Step 1 — Review the minimal policy pack
+
+`policy_pack_min.yaml` in this directory defines one contract for `LoanApproval`:
+
+```yaml
+contracts:
+  LoanApproval:
+    contractId: "contract-loan-min"
+    preconditions:
+      - field: "applicant_verified"
+        equals: true
+        message: "Applicant must be verified before loan approval"
+    postconditions:
+      - field: "decision"
+        equals: "approved"
+```
+
+**Precondition:** `context["applicant_verified"]` must be `true` — otherwise the action is blocked.
+**Postcondition:** `result["decision"]` must be `"approved"` — otherwise a contract violation is logged.
+
+### Step 2 — Run the supervised demo
+
+```bash
+bash cookbook/openclaw/supervised_run/run.sh
+```
+
+Or directly with Python:
+
+```bash
+python - <<'EOF'
+import sys, yaml
+sys.path.insert(0, ".")
+from pathlib import Path
+from adapters.openclaw.adapter import OpenClawSupervisor
+
+policy = yaml.safe_load(
+    Path("cookbook/openclaw/supervised_run/policy_pack_min.yaml").read_text()
+)
+supervisor = OpenClawSupervisor(policy_pack=policy)
+
+# --- Scenario 1: PASS (precondition met, action returns approved) ---
+context_ok = {"applicant_verified": True, "amount_requested": 50000}
+result = supervisor.supervise(
+    decision_type="LoanApproval",
+    context=context_ok,
+    action_fn=lambda ctx: {"decision": "approved", "amount": ctx["amount_requested"]},
+)
+print("Scenario 1 (PASS):", result)
+
+# --- Scenario 2: BLOCKED (precondition fails) ---
+context_fail = {"applicant_verified": False, "amount_requested": 50000}
+result = supervisor.supervise(
+    decision_type="LoanApproval",
+    context=context_fail,
+    action_fn=lambda ctx: {"decision": "approved"},
+)
+print("Scenario 2 (BLOCKED):", result)
+EOF
+```
+
+---
+
+## Expected Output
+
+```
+Scenario 1 (PASS): {
+  'outcome': 'success',
+  'result': {'decision': 'approved', 'amount': 50000},
+  'elapsed_ms': 0
+}
+
+Scenario 2 (BLOCKED): {
+  'outcome': 'blocked',
+  'reason': 'precondition_failed',
+  'violations': [{
+    'contract_id': 'contract-loan-min',
+    'condition_type': 'precondition',
+    'field': 'applicant_verified',
+    'expected': True,
+    'actual': False,
+    'message': 'Applicant must be verified before loan approval'
+  }],
+  'elapsed_ms': 0
+}
+```
+
+---
+
+## Artifacts Produced
+
+The `supervise()` method returns a dict — not a sealed DeepSigma episode by itself. To create a full governance record, wrap the supervised call in a `DecisionEpisode`:
+
+```python
+import json
+from datetime import datetime, timezone
+
+episode = {
+    "episodeId": "ep-openclaw-001",
+    "decisionType": "LoanApproval",
+    "actor": {"id": "openclaw-supervisor"},
+    "startedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "outcome": {
+        "code": "success" if result["outcome"] == "success" else "fail",
+        "reason": result.get("reason", ""),
+    },
+    "context": context_ok,
+    "actions": [{"actionType": "LoanApproval", "result": result.get("result", {})}],
+    "seal": {"sealedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"), "sealHash": "openclaw"},
+}
+print(json.dumps(episode, indent=2))
+```
+
+**To validate the episode against the schema:**
+```bash
+python tools/validate_examples.py  # validates files in examples/
+# or manually:
+python -c "
+import json, jsonschema
+from pathlib import Path
+schema = json.loads(Path('specs/episode.schema.json').read_text())
+jsonschema.validate(YOUR_EPISODE_DICT, schema)
+print('Valid')
+"
+```
+
+---
+
+## Verification
+
+After running:
+
+1. `outcome == "success"` → preconditions passed, action ran, postconditions passed
+2. `outcome == "blocked"` → a precondition was `False`; check `violations` for which field
+3. `outcome == "postcondition_failed"` → action ran but its output didn't meet postconditions
+4. `outcome == "error"` → the `action_fn` raised an exception; check `reason`
+
+No files are written — all state is in-memory. Violations are also accessible via `supervisor.violations`.
+
+---
+
+## Failure Modes
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `outcome: blocked` unexpectedly | `context` dict key doesn't match `field` in policy | Check policy YAML field names exactly match context keys |
+| `yaml.parser.ParserError` | Indentation or syntax error in YAML | Use spaces (not tabs); validate with `python -c "import yaml; yaml.safe_load(open('policy_pack_min.yaml'))"` |
+| `ModuleNotFoundError: adapters.openclaw` | Wrong working directory | Run from repo root |
+| `outcome: postcondition_failed` | Action returned wrong value | Check `result` dict key matches postcondition `field` |

--- a/cookbook/openclaw/supervised_run/policy_pack_min.yaml
+++ b/cookbook/openclaw/supervised_run/policy_pack_min.yaml
@@ -1,0 +1,35 @@
+# Minimal OpenClaw Policy Pack
+# Compatible with adapters/openclaw/adapter.py (OpenClawSupervisor)
+#
+# Usage:
+#   import yaml
+#   from adapters.openclaw.adapter import OpenClawSupervisor
+#   policy = yaml.safe_load(open("cookbook/openclaw/supervised_run/policy_pack_min.yaml"))
+#   supervisor = OpenClawSupervisor(policy_pack=policy)
+
+version: "1.0"
+policyPackId: "pp-min-001"
+name: "Minimal Policy Pack (Cookbook Example)"
+description: "One contract demonstrating pre/post condition verification for LoanApproval decisions."
+
+contracts:
+  LoanApproval:
+    contractId: "contract-loan-min"
+    description: "Pre/post verification for loan approval decisions"
+    preconditions:
+      - field: "applicant_verified"
+        equals: true
+        message: "Applicant must be verified before loan approval"
+    postconditions:
+      - field: "decision"
+        equals: "approved"
+        message: "Action must explicitly return decision=approved"
+
+  TradeExecution:
+    contractId: "contract-trade-min"
+    description: "Market open check for trade execution"
+    preconditions:
+      - field: "market_open"
+        equals: true
+        message: "Trades may only be executed while market is open"
+    postconditions: []

--- a/cookbook/openclaw/supervised_run/run.sh
+++ b/cookbook/openclaw/supervised_run/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# OpenClaw Supervised Run — cookbook example
+#
+# Prerequisites:
+#   pip install -r requirements.txt && pip install -e .
+#
+# Usage (from repo root):
+#   bash cookbook/openclaw/supervised_run/run.sh
+
+set -e
+cd "$(dirname "$0")/../../.."   # ensure we're at repo root
+
+echo "=== OpenClaw Supervised Run ==="
+echo ""
+
+python - <<'PYEOF'
+import sys
+import yaml
+sys.path.insert(0, ".")
+from pathlib import Path
+from adapters.openclaw.adapter import OpenClawSupervisor
+
+policy = yaml.safe_load(
+    Path("cookbook/openclaw/supervised_run/policy_pack_min.yaml").read_text()
+)
+supervisor = OpenClawSupervisor(policy_pack=policy)
+
+# ── Scenario 1: PASS ──────────────────────────────────────────────────────────
+print("Scenario 1: Verified applicant → PASS")
+context_ok = {"applicant_verified": True, "amount_requested": 50000}
+result = supervisor.supervise(
+    decision_type="LoanApproval",
+    context=context_ok,
+    action_fn=lambda ctx: {"decision": "approved", "amount": ctx["amount_requested"]},
+)
+assert result["outcome"] == "success", f"Expected success, got: {result['outcome']}"
+print(f"  outcome  : {result['outcome']}")
+print(f"  result   : {result['result']}")
+print(f"  elapsed  : {result['elapsed_ms']}ms")
+print()
+
+# ── Scenario 2: BLOCKED ───────────────────────────────────────────────────────
+print("Scenario 2: Unverified applicant → BLOCKED")
+context_fail = {"applicant_verified": False, "amount_requested": 50000}
+result = supervisor.supervise(
+    decision_type="LoanApproval",
+    context=context_fail,
+    action_fn=lambda ctx: {"decision": "approved"},
+)
+assert result["outcome"] == "blocked", f"Expected blocked, got: {result['outcome']}"
+print(f"  outcome  : {result['outcome']}")
+print(f"  reason   : {result['reason']}")
+violation = result["violations"][0]
+print(f"  violation: field={violation['field']!r}, expected={violation['expected']!r}, actual={violation['actual']!r}")
+print()
+
+# ── Scenario 3: POSTCONDITION FAILED ─────────────────────────────────────────
+print("Scenario 3: Verified applicant, action returns wrong value → POSTCONDITION FAILED")
+result = supervisor.supervise(
+    decision_type="LoanApproval",
+    context=context_ok,
+    action_fn=lambda ctx: {"decision": "pending"},   # wrong value
+)
+assert result["outcome"] == "postcondition_failed", f"Expected postcondition_failed, got: {result['outcome']}"
+print(f"  outcome  : {result['outcome']}")
+violation = result["violations"][0]
+print(f"  violation: field={violation['field']!r}, expected={violation['expected']!r}, actual={violation['actual']!r}")
+print()
+
+print("=== PASS: All three scenarios behaved as expected ===")
+PYEOF

--- a/cookbook/otel/trace_drift_patch/README.md
+++ b/cookbook/otel/trace_drift_patch/README.md
@@ -1,0 +1,210 @@
+# Cookbook: OTel — Trace Drift Patch
+
+**Adapter:** `adapters/otel/exporter.py`
+**Status:** Alpha — span names and attributes may change before v1.0.
+
+This recipe shows how to:
+1. Enable console tracing with minimal environment setup
+2. Export a sealed episode and a drift event as OpenTelemetry spans
+3. Run the Money Demo with tracing enabled
+4. Verify expected span names in console output
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- DeepSigma installed: `pip install -e .`
+- OpenTelemetry SDK:
+  ```bash
+  pip install -e ".[otel]"
+  # or manually:
+  pip install "opentelemetry-api>=1.20.0" "opentelemetry-sdk>=1.20.0"
+  ```
+
+> **No OTel backend required for this recipe** — spans are written to stdout. See `env.example` for remote export configuration.
+
+---
+
+## Steps
+
+### Step 1 — Set environment variables
+
+```bash
+# Source the example env file:
+source cookbook/otel/trace_drift_patch/env.example
+
+# Or set manually (console-only, no backend needed):
+export OTEL_SERVICE_NAME="sigma-overwatch"
+```
+
+### Step 2 — Export a sealed episode
+
+```bash
+python - <<'EOF'
+import sys
+sys.path.insert(0, ".")
+import json
+from pathlib import Path
+from adapters.otel.exporter import OtelExporter
+
+exporter = OtelExporter(service_name="sigma-overwatch")
+
+# Load a real sealed episode
+episode = json.loads(
+    Path("examples/episodes/01_success.json").read_text()
+)
+
+result = exporter.export_episode(episode)
+print("Export result:", result)
+EOF
+```
+
+### Step 3 — Export a drift event
+
+```bash
+python - <<'EOF'
+import sys
+sys.path.insert(0, ".")
+import json
+from pathlib import Path
+from adapters.otel.exporter import OtelExporter
+
+exporter = OtelExporter(service_name="sigma-overwatch")
+
+drift = json.loads(
+    Path("examples/drift/freshness_drift.json").read_text()
+)
+
+exporter.export_drift(drift)
+print("Drift span emitted.")
+EOF
+```
+
+### Step 4 — Run the Money Demo with tracing
+
+```bash
+# With env sourced:
+source cookbook/otel/trace_drift_patch/env.example
+python -m coherence_ops.examples.drift_patch_cycle
+```
+
+The drift_patch_cycle does not call OtelExporter by default, but you can integrate it:
+
+```python
+import sys
+sys.path.insert(0, ".")
+import json
+from pathlib import Path
+from adapters.otel.exporter import OtelExporter
+
+exporter = OtelExporter(service_name="sigma-overwatch")
+
+for ep_file in sorted(Path("examples/episodes").glob("*.json")):
+    episode = json.loads(ep_file.read_text())
+    exporter.export_episode(episode)
+    print(f"Exported: {episode.get('episodeId')}")
+
+for drift_file in sorted(Path("examples/drift").glob("*.json")):
+    drift = json.loads(drift_file.read_text())
+    exporter.export_drift(drift)
+    print(f"Drift exported: {drift.get('driftId')}")
+```
+
+---
+
+## Expected Output (Console Spans)
+
+The `ConsoleSpanExporter` prints spans to stdout in JSON format. You should see:
+
+```
+{
+    "name": "phase.context",
+    "context": { "trace_id": "0x...", "span_id": "0x..." },
+    "parent_id": "0x...",
+    "start_time": "...",
+    "end_time": "...",
+    "attributes": {
+        "phase.name": "context",
+        "phase.duration_ms": 12
+    },
+    ...
+}
+{
+    "name": "phase.plan",
+    ...
+}
+{
+    "name": "phase.act",
+    ...
+}
+{
+    "name": "phase.verify",
+    ...
+}
+{
+    "name": "decision_episode",
+    "attributes": {
+        "episode.id": "ep-001",
+        "episode.decision_type": "LoanApproval",
+        "episode.degrade_step": "none"
+    },
+    "status": { "status_code": "OK" },
+    ...
+}
+```
+
+**Expected span names per episode export:**
+- `phase.context`
+- `phase.plan`
+- `phase.act`
+- `phase.verify`
+- `decision_episode` (root span, appears last due to ConsoleSpanExporter ordering)
+
+**Expected span names per drift export:**
+- `drift_event`
+
+---
+
+## Verification
+
+1. Run `exporter.export_episode(episode)` — check the return value:
+   ```python
+   {"status": "exported", "episodeId": "ep-001", "spansCreated": 5}
+   ```
+2. Console shows exactly 5 span JSON blocks per episode (4 phases + root).
+3. Root span `episode.decision_type` matches the episode's `decisionType` field.
+4. Root span `status.status_code` is `"OK"` for successful episodes, `"ERROR"` for failed.
+
+---
+
+## Sending to a Remote Backend
+
+To send spans to Jaeger, Honeycomb, Grafana Tempo, or any OTLP-compatible backend:
+
+```bash
+# Jaeger (all-in-one, local):
+docker run -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one
+
+# Set env:
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_SERVICE_NAME="sigma-overwatch"
+
+# Then install OTLP exporter:
+pip install opentelemetry-exporter-otlp
+
+# Run your export script — spans will appear in Jaeger UI at http://localhost:16686
+```
+
+See `env.example` for all configurable variables.
+
+---
+
+## Failure Modes
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `WARNING: opentelemetry packages not installed; OtelExporter is a no-op` | OTel SDK not installed | `pip install -e ".[otel]"` |
+| No spans appear in console | `OtelExporter` initialized with `endpoint=` set to a non-console value, or SDK disabled | Check `OTEL_SDK_DISABLED` is not `"true"` |
+| `grpc._channel._InactiveRpcError` | OTLP endpoint set but backend not running | Start backend or unset `OTEL_EXPORTER_OTLP_ENDPOINT` for console-only mode |
+| `AttributeError: NoneType` on export | `OtelExporter._tracer` is None (OTel not installed) | Check import warning at startup |

--- a/cookbook/otel/trace_drift_patch/env.example
+++ b/cookbook/otel/trace_drift_patch/env.example
@@ -1,0 +1,29 @@
+# Σ OVERWATCH — OpenTelemetry Environment Example
+#
+# Usage:
+#   source cookbook/otel/trace_drift_patch/env.example
+#
+# All variables are optional. Without them, the OtelExporter defaults to
+# console output (ConsoleSpanExporter) with no remote backend required.
+
+# ── Required for any OTel output ─────────────────────────────────────────────
+# Service name shown in all spans and trace UIs.
+export OTEL_SERVICE_NAME="sigma-overwatch"
+
+# ── Remote OTLP export (optional) ────────────────────────────────────────────
+# Uncomment and set to send spans to a remote backend.
+# Format: http(s)://host:port  (no trailing slash)
+#
+# Jaeger all-in-one (local):
+# export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+#
+# Grafana Tempo (local):
+# export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+#
+# Honeycomb (cloud):
+# export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
+# export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY"
+
+# ── Disable tracing entirely (optional) ──────────────────────────────────────
+# Set to "true" to make OtelExporter a complete no-op without changing code.
+# export OTEL_SDK_DISABLED="false"

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -16,3 +16,9 @@ Expose these tools:
 - `adapters/mcp/mcp_server_scaffold.py`
 - `adapters/mcp/tool_catalog.json`
 - `examples/mcp/mcp_client_messages.jsonl`
+
+## Runnable Cookbook
+
+For a step-by-step runnable example with expected output, verification, and failure modes:
+
+→ [cookbook/mcp/hello_deepsigma/README.md](../../cookbook/mcp/hello_deepsigma/README.md)


### PR DESCRIPTION
## Summary

Converts thin integration stubs into runnable, verifiable examples for all three adapters.

- **cookbook/README.md** — quick-chooser table, common prerequisites, verification concept
- **cookbook/mcp/hello_deepsigma/** — complete MCP loopback: 7-message JSON-RPC sequence, stdlib-only `run_loopback.py`, expected output, failure modes. Clearly documents scaffold vs. full MCP status.
- **cookbook/openclaw/supervised_run/** — `policy_pack_min.yaml` with LoanApproval + TradeExecution contracts; `run.sh` exercises all three outcomes (PASS, BLOCKED, POSTCONDITION FAILED); shows how to wrap results in a sealed DecisionEpisode
- **cookbook/otel/trace_drift_patch/** — step-by-step span export for episodes and drift events; console-only path requires no backend; `env.example` covers Jaeger/Tempo/Honeycomb remote export

## Acceptance

- [ ] `python cookbook/mcp/hello_deepsigma/run_loopback.py` prints `=== PASS ===`
- [ ] `bash cookbook/openclaw/supervised_run/run.sh` prints `=== PASS: All three scenarios behaved as expected ===`
- [ ] OTel README steps work with `pip install -e ".[otel]"` + console output visible
- [ ] All cookbook docs linked from NAV.md Cookbook section
- [ ] `docs/integrations/mcp.md` links to MCP cookbook
- [ ] No new runtime dependencies added
- [ ] CI remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)