### PR TITLE
Exhaust LLM Extraction — Anthropic-backed extraction with rule-based fallback

### DIFF
--- a/dashboard/server/exhaust_api.py
+++ b/dashboard/server/exhaust_api.py
@@ -247,7 +247,8 @@ if HAS_FASTAPI:
         # Import refiner (lazy to avoid circular deps)
         try:
             from engine.exhaust_refiner import refine_episode as do_refine
-            refined = do_refine(episode)
+            use_llm = os.environ.get("EXHAUST_USE_LLM", "0") == "1"
+            refined = do_refine(episode, use_llm=use_llm)
         except ImportError:
             # Fallback: minimal stub refinement
             refined = RefinedEpisode(

--- a/docs/exhaust-quickstart.md
+++ b/docs/exhaust-quickstart.md
@@ -128,6 +128,37 @@ python -m adapters.azure_openai_exhaust \
 | ≥ 65 | C |
 | < 65 | D |
 
+## LLM Extraction (optional)
+
+By default the refiner uses fast rule-based extraction. For higher-quality
+TRUTH/REASONING/MEMORY output, enable Anthropic-backed extraction:
+
+```bash
+pip install -e ".[exhaust-llm]"
+export ANTHROPIC_API_KEY="sk-ant-..."
+export EXHAUST_USE_LLM="1"
+```
+
+When `EXHAUST_USE_LLM=1`, each `/refine` call sends the episode transcript
+to `claude-haiku-4-5-20251001` and parses structured JSON back into buckets.
+If the API is unavailable or the key is missing, the rule-based extractor
+runs automatically as a fallback — no episode is lost.
+
+To verify LLM extraction is active:
+
+```bash
+curl -s http://localhost:8000/api/exhaust/episodes/<id>/refine | jq '.grade'
+# LLM extraction typically yields higher coherence scores (B/A vs C/D)
+```
+
+The model is configurable in code:
+
+```python
+from engine.exhaust_llm_extractor import LLMExtractor
+extractor = LLMExtractor(model="claude-sonnet-4-5-20250929")
+buckets = extractor.extract(episode)
+```
+
 ## Storage (MVP)
 
 All data is file-based under `/app/data`:

--- a/engine/exhaust_llm_extractor.py
+++ b/engine/exhaust_llm_extractor.py
@@ -1,0 +1,168 @@
+"""LLM-based extraction engine for the Exhaust Inbox.
+
+Wraps the Anthropic Messages API to extract Truth/Reasoning/Memory
+buckets from DecisionEpisodes. Falls back silently to empty buckets
+if the API is unavailable, the key is missing, or the response is
+unparseable — the rule-based extractor takes over transparently.
+
+Install optional dep:
+    pip install -e ".[exhaust-llm]"
+
+Enable:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    export EXHAUST_USE_LLM="1"
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dashboard.server.models_exhaust import (
+    DecisionEpisode,
+    MemoryItem,
+    ReasoningItem,
+    TruthItem,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_PROMPT_CHARS = 6000
+
+_SYSTEM_PROMPT = (
+    "You are an institutional knowledge extractor for Σ OVERWATCH. "
+    "Given an AI decision episode transcript, extract structured knowledge. "
+    "Return ONLY valid JSON matching the schema below. "
+    "No explanation, no markdown fences.\n\n"
+    "Schema:\n"
+    '{"truth": [{"claim": str, "confidence": float, "evidence": str}], '
+    '"reasoning": [{"decision": str, "confidence": float, "rationale": str}], '
+    '"memory": [{"entity": str, "entity_type": str, "relations": [str], "confidence": float}]}\n\n'
+    "Rules:\n"
+    "- confidence must be a float in [0.0, 1.0]\n"
+    "- truth: verifiable factual claims (metrics, observed states, counts)\n"
+    "- reasoning: decisions, recommendations, and their rationale\n"
+    "- memory: entities, tools, models, and services mentioned\n"
+    '- Return {"truth": [], "reasoning": [], "memory": []} if nothing found'
+)
+
+
+class LLMExtractor:
+    """Extract truth/reasoning/memory via the Anthropic Messages API.
+
+    Usage::
+
+        extractor = LLMExtractor()
+        buckets = extractor.extract(episode)
+        # buckets = {"truth": [...], "reasoning": [...], "memory": [...]}
+    """
+
+    def __init__(
+        self,
+        model: str = "claude-haiku-4-5-20251001",
+        max_tokens: int = 2048,
+    ) -> None:
+        self.model = model
+        self.max_tokens = max_tokens
+
+    def extract(self, episode: DecisionEpisode) -> Dict[str, List]:
+        """Return ``{"truth": [...], "reasoning": [...], "memory": [...]}``.
+
+        Falls back to empty buckets on any failure so the rule-based
+        extractor can take over transparently.
+        """
+        try:
+            prompt = self._build_prompt(episode)
+            text = self._call_api(prompt)
+            return self._parse_response(text)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("LLM extraction failed, falling back to rule-based: %s", exc)
+            return {"truth": [], "reasoning": [], "memory": []}
+
+    # ── Internal methods ──────────────────────────────────────────
+
+    def _build_prompt(self, episode: DecisionEpisode) -> str:
+        """Summarize episode events as a readable transcript."""
+        lines = [f"Episode: {episode.episode_id}  project={episode.project}"]
+        for ev in episode.events:
+            payload_str = json.dumps(ev.payload)[:400]
+            lines.append(
+                f"[{ev.event_type.value}] {ev.timestamp} "
+                f"source={ev.source.value} payload={payload_str}"
+            )
+        transcript = "\n".join(lines)
+        if len(transcript) > _MAX_PROMPT_CHARS:
+            transcript = transcript[:_MAX_PROMPT_CHARS] + "\n...(truncated)"
+        return f"Episode transcript:\n\n{transcript}\n\nExtract knowledge:"
+
+    def _call_api(self, prompt: str) -> str:
+        """Call Anthropic Messages API and return raw response text."""
+        try:
+            import anthropic  # optional dep
+        except ImportError as exc:
+            raise ImportError(
+                "anthropic package required: pip install -e '.[exhaust-llm]'"
+            ) from exc
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
+
+        client = anthropic.Anthropic(api_key=api_key)
+        message = client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text
+
+    def _parse_response(self, text: str) -> Dict[str, List]:
+        """Parse and validate the LLM JSON response into bucket objects."""
+        # Strip markdown fences if LLM ignored instructions
+        stripped = text.strip()
+        if stripped.startswith("```"):
+            lines = stripped.splitlines()
+            inner = lines[1:-1] if lines and lines[-1].strip() == "```" else lines[1:]
+            stripped = "\n".join(inner)
+
+        data: Dict[str, Any] = json.loads(stripped)
+
+        def _clamp(v: Any, default: float = 0.5) -> float:
+            try:
+                return max(0.0, min(1.0, float(v)))
+            except (TypeError, ValueError):
+                return default
+
+        truth: List[TruthItem] = []
+        for item in data.get("truth", []):
+            truth.append(TruthItem(
+                claim=str(item.get("claim", "")),
+                evidence=str(item.get("evidence", "llm_extracted")),
+                confidence=_clamp(item.get("confidence")),
+                truth_type="derived",
+            ))
+
+        reasoning: List[ReasoningItem] = []
+        for item in data.get("reasoning", []):
+            reasoning.append(ReasoningItem(
+                decision=str(item.get("decision", "")),
+                rationale=str(item.get("rationale", "")),
+                confidence=_clamp(item.get("confidence")),
+            ))
+
+        memory: List[MemoryItem] = []
+        for item in data.get("memory", []):
+            memory.append(MemoryItem(
+                entity=str(item.get("entity", "")),
+                artifact_type=str(item.get("entity_type", "")),
+                relation="mentioned_in",
+                confidence=_clamp(item.get("confidence")),
+            ))
+
+        return {"truth": truth, "reasoning": reasoning, "memory": memory}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ otel = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
 ]
+exhaust-llm = [
+    "anthropic>=0.40.0",
+]
 dev = [
     "pytest",
     "pytest-cov",

--- a/tests/test_exhaust_llm_extractor.py
+++ b/tests/test_exhaust_llm_extractor.py
@@ -1,0 +1,170 @@
+"""Tests for engine/exhaust_llm_extractor.py — all mocked, no API key needed.
+
+Run from repo root:
+    pytest tests/test_exhaust_llm_extractor.py -v
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dashboard.server.models_exhaust import (
+    DecisionEpisode,
+    EpisodeEvent,
+    Source,
+)
+from engine.exhaust_llm_extractor import LLMExtractor, _MAX_PROMPT_CHARS
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+def _make_episode(n_events: int = 2) -> DecisionEpisode:
+    events = [
+        EpisodeEvent(
+            event_id=f"ev-{i:02d}",
+            episode_id="ep-llm-test",
+            event_type="metric",
+            timestamp="2026-01-01T00:00:00Z",
+            source="manual",
+            payload={"name": "latency_ms", "value": 240 + i},
+        )
+        for i in range(n_events)
+    ]
+    return DecisionEpisode(
+        episode_id="ep-llm-test",
+        events=events,
+        source=Source.manual,
+        user_hash="u_test",
+        session_id="sess-test",
+        project="test-project",
+        team="test-team",
+    )
+
+
+def _good_llm_response() -> str:
+    return json.dumps({
+        "truth": [
+            {"claim": "latency = 240ms", "confidence": 0.92, "evidence": "metric event"},
+        ],
+        "reasoning": [
+            {"decision": "I recommend rollback", "confidence": 0.8, "rationale": "error rate high"},
+        ],
+        "memory": [
+            {"entity": "service-alpha", "entity_type": "service",
+             "relations": ["monitored"], "confidence": 0.9},
+        ],
+    })
+
+
+def _mock_message(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text)]
+    return msg
+
+
+# ── Tests ─────────────────────────────────────────────────────────
+
+def test_extract_returns_valid_buckets(monkeypatch):
+    """Happy path — LLM JSON response is parsed into typed bucket objects."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+
+    with patch("engine.exhaust_llm_extractor.LLMExtractor._call_api",
+               return_value=_good_llm_response()):
+        buckets = LLMExtractor().extract(_make_episode())
+
+    assert len(buckets["truth"]) == 1
+    assert buckets["truth"][0].claim == "latency = 240ms"
+    assert buckets["truth"][0].confidence == pytest.approx(0.92)
+
+    assert len(buckets["reasoning"]) == 1
+    assert "rollback" in buckets["reasoning"][0].decision.lower()
+
+    assert len(buckets["memory"]) == 1
+    assert buckets["memory"][0].entity == "service-alpha"
+
+
+def test_extract_fallback_on_api_error(monkeypatch):
+    """API raises → empty buckets returned, no exception propagates."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+
+    with patch("engine.exhaust_llm_extractor.LLMExtractor._call_api",
+               side_effect=ConnectionError("network down")):
+        buckets = LLMExtractor().extract(_make_episode())
+
+    assert buckets["truth"] == []
+    assert buckets["reasoning"] == []
+    assert buckets["memory"] == []
+
+
+def test_extract_fallback_on_bad_json(monkeypatch):
+    """LLM returns non-JSON text → empty buckets, no crash."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+
+    with patch("engine.exhaust_llm_extractor.LLMExtractor._call_api",
+               return_value="Sorry, I cannot help with that."):
+        buckets = LLMExtractor().extract(_make_episode())
+
+    assert buckets["truth"] == []
+    assert buckets["reasoning"] == []
+    assert buckets["memory"] == []
+
+
+def test_build_prompt_truncates_long_episode(monkeypatch):
+    """Episode transcript longer than _MAX_PROMPT_CHARS is truncated, not dropped."""
+    # Create episode with many large events
+    events = [
+        EpisodeEvent(
+            event_id=f"ev-{i:03d}",
+            episode_id="ep-long",
+            event_type="completion",
+            timestamp="2026-01-01T00:00:00Z",
+            source="manual",
+            payload={"text": "x" * 500},
+        )
+        for i in range(30)
+    ]
+    episode = DecisionEpisode(
+        episode_id="ep-long",
+        events=events,
+        source=Source.manual,
+        user_hash="u_test",
+        session_id="sess-long",
+        project="test",
+        team="test",
+    )
+
+    extractor = LLMExtractor()
+    prompt = extractor._build_prompt(episode)
+
+    assert len(prompt) <= _MAX_PROMPT_CHARS + 100  # small buffer for suffix
+    assert "...(truncated)" in prompt
+    assert "ep-long" in prompt  # episode ID always present
+
+
+def test_confidence_clamped_0_to_1(monkeypatch):
+    """LLM returning confidence > 1.0 or < 0.0 is clamped to valid range."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+
+    bad_response = json.dumps({
+        "truth": [
+            {"claim": "x > 0", "confidence": 1.5, "evidence": "test"},
+            {"claim": "y < 0", "confidence": -0.3, "evidence": "test"},
+        ],
+        "reasoning": [],
+        "memory": [],
+    })
+
+    with patch("engine.exhaust_llm_extractor.LLMExtractor._call_api",
+               return_value=bad_response):
+        buckets = LLMExtractor().extract(_make_episode())
+
+    confidences = [t.confidence for t in buckets["truth"]]
+    assert all(0.0 <= c <= 1.0 for c in confidences), f"Out-of-range: {confidences}"
+    assert confidences[0] == pytest.approx(1.0)  # 1.5 → clamped to 1.0
+    assert confidences[1] == pytest.approx(0.0)  # -0.3 → clamped to 0.0


### PR DESCRIPTION
## Summary

- **New `engine/exhaust_llm_extractor.py`**: `LLMExtractor` class wraps the Anthropic Messages API (`claude-haiku-4-5-20251001` default) to extract TRUTH/REASONING/MEMORY buckets from episode transcripts. Falls back to empty buckets on any failure — API error, missing key, bad JSON — so the rule-based extractor takes over transparently.
- **`refine_episode()` gets `use_llm: bool = False`**: additive, non-breaking. When `True` and `ANTHROPIC_API_KEY` is set, calls `LLMExtractor`; otherwise (or on any exception) runs the existing rule-based pipeline unchanged.
- **`EXHAUST_USE_LLM` env var**: read per-request in the `/refine` endpoint. Default `"0"` — zero behavior change for existing deployments.
- **`pyproject.toml`**: adds `exhaust-llm = ["anthropic>=0.40.0"]` optional dep. CI passes without it installed.
- **Quickstart docs updated** with install + enable instructions and a note on fallback behavior.

## Architecture

```
POST /episodes/{id}/refine
  → EXHAUST_USE_LLM=1 + ANTHROPIC_API_KEY set?
      YES → LLMExtractor.extract(episode)
              → _build_prompt()   (truncated at 6000 chars)
              → _call_api()       (Anthropic Messages API)
              → _parse_response() (JSON → TruthItem / ReasoningItem / MemoryItem)
              → merge episode node from rule-based extract_memory()
            on any failure → fall through to rule-based
      NO  → existing extract_truth() / extract_reasoning() / extract_memory()
  → detect_drift() + score_coherence()  (always run, same as before)
```

## Test plan

- [x] `pytest tests/test_exhaust_llm_extractor.py -v` → 5/5 passed (all mocked, no API key)
- [x] `EXHAUST_USE_LLM=0` (default) — no behavior change verified by existing test suites
- [x] Happy path, API error fallback, bad JSON fallback, prompt truncation at 6000 chars, confidence clamping 0.0–1.0

## Install & use

```bash
pip install -e ".[exhaust-llm]"
export ANTHROPIC_API_KEY="sk-ant-..."
export EXHAUST_USE_LLM="1"
# POST /api/exhaust/episodes/{id}/refine  → uses LLM extraction
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)