### PR TITLE
Wiki: add 3 missing schema pages (Action-Contract, DTE, Drift)

### DIFF
--- a/wiki/Action-Contract-Schema.md
+++ b/wiki/Action-Contract-Schema.md
@@ -1,0 +1,87 @@
+# Action Contract Schema
+
+The **Safe Action Contract** is the governance contract that an agent must satisfy before any action is dispatched. It encodes blast radius, idempotency, rollback, and authorization so that every tool call can be audited and reversed.
+
+**Schema file**: [`specs/action_contract.schema.json`](../specs/action_contract.schema.json)
+
+---
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actionId` | string | Stable, unique action identifier. Never reused. |
+| `actionType` | string | Logical name of the action (e.g., `quarantine_account`, `send_alert`). |
+| `blastRadiusTier` | enum | Potential impact scope: `tiny` / `small` / `medium` / `large`. |
+| `targetRefs` | array | One or more `{type, id}` objects identifying the affected resources. |
+| `constraints` | object | Policy/budget/scope constraints: rate limits, change windows, scope bounds. |
+| `authorization` | object | Auth mode + optional policy reference and approver. See below. |
+| `idempotencyKey` | string | Stable key ensuring the action has the same effect if replayed. |
+| `rollbackPlan` | object | How the action can be reversed. See below. |
+
+---
+
+## Authorization
+
+| Field | Type | Values / Description |
+|-------|------|---------------------|
+| `mode` | enum | `auto` — dispatch without human approval |
+|        |      | `hitl` — pause for human-in-the-loop approval |
+|        |      | `blocked` — action not permitted under current policy |
+| `policyRef` | string | Optional ID of the policy pack that determined the mode |
+| `approver` | string | Role or identity required for `hitl` approval |
+
+---
+
+## Rollback Plan
+
+| Field | Type | Values / Description |
+|-------|------|---------------------|
+| `type` | enum | `none` — no rollback possible (action is irreversible by design) |
+|        |      | `compensate` — issue a compensating action |
+|        |      | `restore` — restore from snapshot or backup |
+|        |      | `revert` — undo the mutation (e.g., delete a created record) |
+| `instructions` | object | Free-form instructions for the rollback procedure |
+| `timeoutMs` | integer | Maximum time allowed for rollback execution |
+
+---
+
+## Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preconditions` | array | Declarative checks that must pass before dispatch (e.g., TTL ok, resource state matches). |
+| `execution.executionSloMs` | integer | Target execution time (informational SLO). |
+| `execution.timeoutMs` | integer | Hard timeout — abort and rollback if exceeded. |
+| `execution.retryPolicy.maxRetries` | integer | Number of retry attempts on transient failure. |
+| `execution.retryPolicy.backoffMs` | integer | Delay between retries (ms). |
+
+---
+
+## Blast Radius Tiers
+
+| Tier | Scope | Typical Actions |
+|------|-------|----------------|
+| `tiny` | Single record, read-only or append | Log entry, status read |
+| `small` | Single record, mutating | Update flag, soft-delete record |
+| `medium` | Multiple records or single high-value record | Account suspension, batch update |
+| `large` | Cross-system or irreversible at scale | Mass notification, infrastructure change |
+
+Blast radius determines whether verification is required (controlled by the DTE `verification.requiredAboveBlastRadius` field) and whether `hitl` authorization applies.
+
+---
+
+## Relationship to Other Schemas
+
+- **[DTE Schema](DTE-Schema)** — sets `blastRadiusMax` and `requireRollbackAbove` constraints that the action contract must satisfy
+- **[Episode Schema](Episode-Schema)** — the episode's `actions` array embeds the action contract ref
+- **[Drift Schema](Drift-Schema)** — `bypass` drift type fires when an action is dispatched without a valid contract
+
+---
+
+## Related Pages
+
+- [Contracts](Contracts) — overview of all four contract types
+- [Sealing & Episodes](Sealing-and-Episodes) — how action contracts are stamped into sealed episodes
+- [Degrade Ladder](Degrade-Ladder) — how blast radius tiers interact with degrade steps
+- [Schemas](Schemas) — all JSON Schema specs

--- a/wiki/DTE-Schema.md
+++ b/wiki/DTE-Schema.md
@@ -1,0 +1,124 @@
+# DTE Schema — Decision Timing Envelope
+
+The **Decision Timing Envelope (DTE)** is the per-`decisionType` contract that governs time budgets, freshness requirements, blast radius limits, degrade ladder ordering, and verification requirements. DTEs are loaded at runtime — typically from a Policy Pack — and stamped onto every sealed episode.
+
+**Schema file**: [`specs/dte.schema.json`](../specs/dte.schema.json)
+
+---
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `decisionType` | string | The decision class this DTE governs (e.g., `AccountQuarantine`). |
+| `version` | string | Semantic version of this DTE definition. |
+| `deadlineMs` | integer | Total wall-clock budget for the decision (milliseconds). |
+| `stageBudgetsMs` | object | Per-stage time budgets. Must sum to ≤ `deadlineMs`. |
+| `freshness` | object | TTL settings for context data. |
+| `limits` | object | Structural limits on agent behaviour. |
+| `degradeLadder` | array | Ordered steps the runtime uses when deadlines or freshness fail. |
+| `verification` | object | When and how to verify action outcomes. |
+| `safeAction` | object | Blast radius and rollback requirements for dispatched actions. |
+
+---
+
+## Stage Budgets
+
+All four stages are required. Each value is a millisecond integer.
+
+| Stage | Description |
+|-------|-------------|
+| `context` | Gather features, tool outputs, and evidence |
+| `plan` | LLM or rule-based planning |
+| `act` | Action dispatch and execution |
+| `verify` | Postcondition verification |
+
+---
+
+## Freshness
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `defaultTtlMs` | integer | Maximum age of any context feature before TOCTOU breach fires |
+| `featureTtls` | object | Per-feature overrides keyed by feature name (ms) |
+| `allowStaleIfSafe` | boolean | If `true`, stale context is permitted when blast radius is below the configured threshold (default `false`) |
+
+---
+
+## Limits
+
+Structural guardrails to prevent fanout and retry storms.
+
+| Field | Description |
+|-------|-------------|
+| `maxHops` | Maximum number of agent hops in a chain |
+| `maxFanout` | Maximum number of parallel sub-tasks |
+| `maxToolCalls` | Maximum tool invocations per decision |
+| `maxChainDepth` | Maximum chain depth before escalation |
+
+---
+
+## Degrade Ladder
+
+An ordered array of degrade steps. The runtime walks this array when time, freshness, or verifier failures occur.
+
+| Step | Behaviour |
+|------|-----------|
+| `cache_bundle` | Serve context from a pre-computed snapshot; skip live feature fetch |
+| `small_model` | Swap to a smaller, lower-latency model for the plan stage |
+| `rules_only` | Drop LLM entirely; use deterministic rule engine |
+| `hitl` | Pause the decision and request human-in-the-loop approval |
+| `abstain` | Refuse to act; emit a `DriftEvent` and return a safe no-op |
+| `bypass` | Emergency override (logged at elevated severity; audit trail required) |
+
+Each step may carry an optional `maxExtraMs` — additional time the runtime may spend on that step before advancing to the next rung.
+
+---
+
+## Verification
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requiredAboveBlastRadius` | enum | Verification is mandatory for actions with blast radius strictly above this tier (`none` / `tiny` / `small` / `medium` / `large`) |
+| `methods` | array | Allowed verifier identifiers (e.g., `read_after_write`, `invariant_check`) |
+| `verifyTimeoutMs` | integer | Hard timeout for the verify stage |
+
+---
+
+## Safe Action Constraints
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requireIdempotency` | boolean | All dispatched actions must carry an `idempotencyKey` |
+| `requireRollbackAbove` | enum | Rollback plan required for blast radius strictly above this tier |
+| `blastRadiusMax` | enum | Hard upper limit on blast radius — any action exceeding this is blocked |
+| `allowedActionTypes` | array | Optional allowlist of `actionType` values |
+
+---
+
+## Policy Pack Binding
+
+The optional `policyPack` block lets a DTE record the hash and version of the Policy Pack that produced it:
+
+| Field | Description |
+|-------|-------------|
+| `policyPackHash` | SHA-256 of the originating Policy Pack |
+| `policyPackVersion` | Version string of that Policy Pack |
+
+---
+
+## Relationship to Other Schemas
+
+- **[Action Contract Schema](Action-Contract-Schema)** — each dispatched action is validated against the DTE's `safeAction` constraints
+- **[Policy Pack Schema](Policy-Pack-Schema)** — Policy Packs embed DTE defaults per `decisionType`
+- **[Episode Schema](Episode-Schema)** — sealed episodes record the `decisionType` and active degrade step
+- **[Drift Schema](Drift-Schema)** — DTE violations (TTL breach, deadline overage) emit structured drift events
+
+---
+
+## Related Pages
+
+- [Contracts](Contracts) — overview of all four contract types
+- [Degrade Ladder](Degrade-Ladder) — how the runtime walks ladder steps at runtime
+- [Policy Packs](Policy-Packs) — how DTEs are packaged and versioned
+- [Schemas](Schemas) — all JSON Schema specs

--- a/wiki/Drift-Schema.md
+++ b/wiki/Drift-Schema.md
@@ -1,0 +1,107 @@
+# Drift Schema — Drift Event
+
+A **DriftEvent** is a structured signal emitted whenever the runtime detects a variance between expected and observed behaviour. Drift events are typed, fingerprinted, and linked to the episode that triggered them. They feed the Drift → Patch loop and contribute to the `DS` (Drift Scan) artifact in Coherence Ops.
+
+**Schema file**: [`specs/drift.schema.json`](../specs/drift.schema.json)
+
+---
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `driftId` | string | Stable unique ID for this drift signal. |
+| `episodeId` | string | The episode that triggered the drift. |
+| `driftType` | enum | Category of variance. See types below. |
+| `severity` | enum | `green` / `yellow` / `red` |
+| `detectedAt` | string (ISO-8601) | Timestamp of detection. |
+| `evidenceRefs` | array of strings | IDs of the records, claims, or metrics that constitute evidence. |
+| `recommendedPatchType` | enum | Suggested remediation. See patch types below. |
+| `fingerprint` | object | Stable `{key, version}` hash for deduplication across episodes. |
+
+---
+
+## Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `notes` | string | Human-readable context or investigation notes. |
+
+---
+
+## Drift Types
+
+| Type | Trigger | Typical Severity |
+|------|---------|-----------------|
+| `time` | Decision elapsed time exceeded `deadlineMs` | yellow / red |
+| `freshness` | Context feature exceeded TTL at time of use (TOCTOU breach) | yellow / red |
+| `fallback` | Degrade ladder step was invoked | green / yellow |
+| `bypass` | Emergency bypass used (action dispatched without valid contract) | red |
+| `verify` | Verifier returned `fail` or `inconclusive` | yellow / red |
+| `outcome` | Post-action outcome differed from expected (anomaly) | yellow / red |
+| `fanout` | Agent exceeded `maxFanout` or `maxHops` from DTE limits | yellow |
+| `contention` | Resource lock or rate limit caused retry storm | yellow / red |
+
+The Exhaust Inbox refiner adds two additional drift types used during episode refinement:
+
+| Type | Trigger |
+|------|---------|
+| `contradiction` | Extracted claim contradicts existing canon |
+| `stale_reference` | Memory item references an episode ID no longer in the graph |
+
+---
+
+## Severity Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| `green` | Informational — within acceptable operating range | Log only |
+| `yellow` | Warning — approaching threshold or single-event anomaly | Review within SLO window |
+| `red` | Critical — threshold breached or safety violation | Immediate triage |
+
+---
+
+## Recommended Patch Types
+
+| Patch Type | Description |
+|-----------|-------------|
+| `dte_change` | Adjust deadline, stage budget, or limit in the DTE |
+| `ttl_change` | Increase or decrease TTL for a specific feature |
+| `cache_bundle_change` | Update the cached context bundle used during degrade |
+| `routing_change` | Redirect to a different model, tool, or data source |
+| `verification_change` | Change verifier method or timeout |
+| `action_scope_tighten` | Reduce blast radius or add preconditions to the action contract |
+| `manual_review` | No automated patch — escalate to human review |
+
+---
+
+## Fingerprint
+
+The `fingerprint.key` is a stable hash computed from `driftType + episodeId + evidence` that allows deduplication and trending across multiple episodes. Two drift events with the same fingerprint key are considered the same recurring pattern.
+
+`fingerprint.version` identifies the hashing algorithm version so that fingerprints can be migrated when the algorithm changes.
+
+---
+
+## Relationship to Other Schemas
+
+- **[DTE Schema](DTE-Schema)** — DTE parameters (deadlines, TTLs, limits) are the thresholds that drift measures against
+- **[Episode Schema](Episode-Schema)** — drift events reference `episodeId` to trace back to the full decision context
+- **[Action Contract Schema](Action-Contract-Schema)** — `bypass` drift fires when an action is dispatched without a valid contract
+- **[Policy Pack Schema](Policy-Pack-Schema)** — `missing_policy` signals relate to policy pack stamp absence
+
+---
+
+## Coherence Ops Integration
+
+Drift events feed the **DS (Drift Scan)** artifact in Coherence Ops. The `WHAT_DRIFTED` IRIS query aggregates drift events by fingerprint, severity, and resolution ratio. The patch workflow begins when a recurring fingerprint exceeds a configurable recurrence threshold.
+
+---
+
+## Related Pages
+
+- [Drift → Patch](Drift-to-Patch) — full lifecycle from detection to remediation
+- [Schemas](Schemas) — all JSON Schema specs
+- [IRIS](IRIS) — `WHAT_DRIFTED` query type
+- [Coherence Ops Mapping](Coherence-Ops-Mapping) — how drift feeds the DS artifact
+- [Exhaust Inbox](Exhaust-Inbox) — drift detection during episode refinement


### PR DESCRIPTION
## Summary

- Creates `Action-Contract-Schema.md` — blast radius tiers, authorization modes, rollback plan types, all fields from `specs/action_contract.schema.json`
- Creates `DTE-Schema.md` — stage budgets, freshness, limits, degrade ladder rungs, verification, safe action constraints from `specs/dte.schema.json`
- Creates `Drift-Schema.md` — all 8 drift types (+ 2 Exhaust Inbox types), severity levels, 7 patch types, fingerprint dedup model from `specs/drift.schema.json`
- All three pages were linked in `_Sidebar.md` under the Schemas section but did not exist — navigating to them produced a 404

## Test plan

- [ ] Click each sidebar link: Action Contract Schema, DTE Schema, Drift Schema — all resolve
- [ ] Verify field tables match `specs/action_contract.schema.json`, `specs/dte.schema.json`, `specs/drift.schema.json`
- [ ] Verify cross-links to related pages (Contracts, DTE-Schema, Action-Contract-Schema, Episode-Schema, etc.) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)