### PR TITLE
Wiki: fix markdown corruption + expand 3 stub pages

### DIFF
--- a/wiki/Canon.md
+++ b/wiki/Canon.md
@@ -78,7 +78,7 @@
 > ## Related Pages
 >
 > - [Unified Atomic Claims](Unified-Atomic-Claims) — the Claim Primitive that Canon promotes
-> - - [Retcon](Retcon) — retroactive correction of canon entries
->   - - [Sealing & Episodes](Sealing-and-Episodes) — immutability model
->     - - [Schemas](Schemas) — all JSON Schema specs
->       - - [IRIS](IRIS) — query resolution engine
+> - [Retcon](Retcon) — retroactive correction of canon entries
+> - [Sealing & Episodes](Sealing-and-Episodes) — immutability model
+> - [Schemas](Schemas) — all JSON Schema specs
+> - [IRIS](IRIS) — query resolution engine

--- a/wiki/Contracts.md
+++ b/wiki/Contracts.md
@@ -1,15 +1,100 @@
 # Contracts
 
-## DTE (Decision Timing Envelope)
-Defines time budgets (decision window + stage budgets) and limits (fanout/retries).
+RAL governance is expressed through four contract types. Each contract is a structured, versioned artifact that travels with the decision from planning through sealing.
+
+---
+
+## DTE — Decision Timing Envelope
+
+**Schema:** [`specs/dte.schema.json`](../specs/dte.schema.json) · [Full reference →](DTE-Schema)
+
+The DTE is the master budget and constraint contract for a `decisionType`. It defines:
+
+- **`deadlineMs`** — total wall-clock budget for the entire decision
+- **`stageBudgetsMs`** — per-stage budgets: `context`, `plan`, `act`, `verify`
+- **`freshness`** — TTL settings for context features (defaultTtlMs + per-feature overrides)
+- **`limits`** — structural guardrails: maxHops, maxFanout, maxToolCalls, maxChainDepth
+- **`degradeLadder`** — ordered fallback steps when budgets or freshness fail
+- **`verification`** — when verification is required and which methods are allowed
+- **`safeAction`** — blast radius ceiling and rollback requirements
+
+DTEs are loaded from a Policy Pack at decision start and stamped onto the sealed episode.
+
+---
 
 ## Safe Action Contract
-Defines blast radius tier + idempotency + rollback + auth mode.
+
+**Schema:** [`specs/action_contract.schema.json`](../specs/action_contract.schema.json) · [Full reference →](Action-Contract-Schema)
+
+The Safe Action Contract is the per-dispatch governance contract that must be satisfied before any tool action is executed. It encodes:
+
+- **`blastRadiusTier`** — potential impact scope: `tiny` / `small` / `medium` / `large`
+- **`idempotencyKey`** — ensures the action is safe to replay without side effects
+- **`rollbackPlan`** — how the action can be reversed: `none` / `compensate` / `restore` / `revert`
+- **`authorization.mode`** — `auto` (dispatch immediately), `hitl` (pause for human approval), or `blocked`
+- **`preconditions`** — declarative checks that must pass before dispatch
+- **`targetRefs`** — the specific resources this action will affect
+
+The supervisor validates the contract against the DTE's `safeAction` constraints before allowing dispatch. If the action's blast radius exceeds `blastRadiusMax` or authorization is blocked, the degrade ladder is consulted.
+
+---
 
 ## Verification Contract
-Defines how to prove the action succeeded (or fail safely).
+
+Verification is configured within the DTE (`verification` block) rather than as a separate JSON object. It specifies:
+
+- **`requiredAboveBlastRadius`** — blast radius tier above which verification becomes mandatory
+- **`methods`** — list of allowed verifier identifiers (e.g., `read_after_write`, `invariant_check`)
+- **`verifyTimeoutMs`** — hard timeout for the verify stage
+
+Verifiers run after action dispatch and return `pass`, `fail`, or `inconclusive`. Any non-pass outcome emits a `verify` DriftEvent.
+
+See: [Verifiers](Verifiers) — implementation details and scaffold reference.
+
+---
 
 ## DecisionEpisode
-Sealed record containing truth/reasoning/memory exhaust.
 
-See [Schemas](Schemas.md).
+**Schema:** [`specs/episode.schema.json`](../specs/episode.schema.json) · [Full reference →](Episode-Schema)
+
+The DecisionEpisode is not a pre-decision contract but the **sealed record** produced at the end of a decision cycle. It contains:
+
+- **`episodeId`** — stable unique identifier
+- **`decisionType`** — the type that governed this decision
+- **Context** — the feature snapshot used (with `capturedAt` and TTL metadata)
+- **Policy stamp** — `policyPackId`, `policyPackVersion`, `policyPackHash`
+- **Degrade step** — which rung (if any) was activated, and the rationale
+- **Verification** — method used, outcome, and details
+- **`sealHash` + `sealedAt`** — SHA-256 of the episode (excluding the seal field itself)
+
+Once sealed, an episode is immutable. All downstream analysis (DLR, Coherence Ops, IRIS) derives from sealed episodes.
+
+---
+
+## How the Contracts Interact
+
+```
+Policy Pack
+    └─ DTE (one per decisionType)
+            │
+            ├─ stageBudgetsMs → governs each runtime stage
+            ├─ freshness → gates context validity
+            ├─ degradeLadder → fallback when budgets or freshness fail
+            ├─ safeAction → constrains what the Action Contract may request
+            └─ verification → governs when/how Verifiers run
+                     │
+                     └─ Safe Action Contract (one per dispatched action)
+                              │
+                              └─ Verified → DecisionEpisode (sealed)
+```
+
+---
+
+## Related Pages
+
+- [DTE Schema](DTE-Schema) — full DTE field reference
+- [Action Contract Schema](Action-Contract-Schema) — full action contract field reference
+- [Verifiers](Verifiers) — verifier scaffolds and custom implementation guide
+- [Episode Schema](Episode-Schema) — sealed episode field reference
+- [Policy Packs](Policy-Packs) — how DTEs are packaged and versioned
+- [Schemas](Schemas) — all JSON Schema specs

--- a/wiki/Degrade-Ladder.md
+++ b/wiki/Degrade-Ladder.md
@@ -1,16 +1,71 @@
 # Degrade Ladder
 
-A degrade ladder is a controlled response to runtime physics.
+A **degrade ladder** is an ordered sequence of fallback steps the runtime walks when it cannot complete a decision within the nominal path. Each rung trades capability for safety: earlier rungs are gentler, later rungs are more conservative. The ladder is defined per `decisionType` in the DTE and stamped onto the sealed episode when a rung is activated.
 
-Example ladder:
-`cache_bundle → rules_only → hitl → abstain`
+The supervisor walks the ladder top-to-bottom, activating the lowest rung that brings the decision back within budget. If no rung resolves the issue, the decision emits a drift event and aborts.
 
-Triggers:
-- deadline pressure (remaining time)
-- tail latency/jitter
-- TTL/TOCTOU breaches
-- verifier fail/inconclusive
+---
 
-Implementation scaffold:
-- `engine/degrade_ladder.py`
-- `engine/supervisor_scaffold.py`
+## Rungs
+
+| Rung | Behaviour | When to Use |
+|------|-----------|-------------|
+| `cache_bundle` | Serve context from a pre-computed snapshot; skip live feature fetch entirely | Context fetch is slow or stale; cached bundle is fresh enough for this decision type |
+| `small_model` | Swap the plan stage to a smaller, lower-latency model | LLM response time is eating into the deadline; smaller model fits within remaining budget |
+| `rules_only` | Drop the LLM entirely; use a deterministic rule engine for the plan stage | Model unavailable, too slow, or decision type has a deterministic rule path |
+| `hitl` | Pause the decision and emit a human-in-the-loop approval request | Action blast radius is too high to proceed automatically; human sign-off required before continuing |
+| `abstain` | Refuse to act; return a safe no-op result and emit a `DriftEvent` | No safe path exists within constraints; better to do nothing than to act unsafely |
+| `bypass` | Emergency override — dispatch the action without completing the full governance chain | Production incident only; logged at elevated severity; full audit trail required |
+
+> **Note:** `bypass` should be treated as a last resort. Every bypass emits a `bypass` DriftEvent with severity `red`. Policies should be reviewed after any bypass usage.
+
+---
+
+## Triggers
+
+The supervisor evaluates ladder activation after each stage:
+
+| Trigger | Stage | Typical Rung Activated |
+|---------|-------|----------------------|
+| Remaining budget < next-stage budget | Context / Plan | `cache_bundle` or `small_model` |
+| P99 latency or jitter exceeds DTE threshold | Plan / Act | `small_model` or `rules_only` |
+| TTL / TOCTOU breach (context stale) | Context | `cache_bundle` or `abstain` |
+| Verifier returns `fail` or `inconclusive` | Verify | `hitl` or `abstain` |
+| Blast radius exceeds `blastRadiusMax` without approval | Act | `hitl` or `abstain` |
+| All rungs exhausted without resolution | Any | `abstain` (terminal) |
+
+---
+
+## Configuration
+
+The ladder is defined as an ordered array in the DTE under `degradeLadder`. Each step may carry an optional `maxExtraMs` — additional time that step may consume before the runtime advances to the next rung:
+
+```json
+"degradeLadder": [
+  { "step": "cache_bundle", "maxExtraMs": 200 },
+  { "step": "small_model",  "maxExtraMs": 800 },
+  { "step": "rules_only" },
+  { "step": "hitl" },
+  { "step": "abstain" }
+]
+```
+
+---
+
+## Episode Stamping
+
+When a degrade step is activated, the supervisor stamps the sealed episode with:
+- The activated `degrade_step` name
+- A `degrade_rationale` string explaining which trigger fired
+
+This makes every degrade visible in the DLR and queryable via IRIS `WHAT_CHANGED`.
+
+---
+
+## Related Pages
+
+- [DTE Schema](DTE-Schema) — where the ladder is configured per decision type
+- [Contracts](Contracts) — overview of all four contract types
+- [Drift Schema](Drift-Schema) — drift types emitted during degrade (`fallback`, `bypass`, `verify`)
+- [Verifiers](Verifiers) — verifier failure is a primary degrade trigger
+- [Operations](Operations) — tuning ladders for production SLOs

--- a/wiki/IRIS.md
+++ b/wiki/IRIS.md
@@ -59,127 +59,127 @@ Runs CoherenceScorer across all four artifacts. Returns overall score (0–100),
 Every response includes:
 
 - **query_id** — deterministic hash: `iris-{sha256[:12]}`
-- - **query_type** — WHY | WHAT_CHANGED | WHAT_DRIFTED | RECALL | STATUS
-  - - **status** — RESOLVED | PARTIAL | NOT_FOUND | ERROR
-    - - **summary** — human-readable explanation
-      - - **data** — query-type-specific structured data
-        - - **provenance_chain** — ordered list of `ProvenanceLink` objects
-          - - **confidence** — 0.0–1.0 (additive per artifact, capped at 1.0)
-            - - **resolved_at** — ISO-8601 timestamp
-              - - **elapsed_ms** — wall-clock time
-                - - **warnings** — performance or data quality alerts
-                 
-                  - ### Provenance Chain
-                 
-                  - Each link in the chain identifies:
-                 
-                  - - **artifact** — DLR, MG, DS, RS, or PRIME
-                    - - **ref_id** — specific record identifier
-                      - - **role** — `source` (primary), `evidence` (supporting), or `context` (enriching)
-                        - - **detail** — human-readable description
-                         
-                          - ### Resolution Status
-                         
-                          - | Status | Condition |
-                          - |--------|-----------|
-                          - | RESOLVED | confidence >= 0.5 |
-                          - | PARTIAL | 0 < confidence < 0.5 |
-                          - | NOT_FOUND | required data missing |
-                          - | ERROR | exception during resolution |
-                         
-                          - ---
+- **query_type** — WHY | WHAT_CHANGED | WHAT_DRIFTED | RECALL | STATUS
+- **status** — RESOLVED | PARTIAL | NOT_FOUND | ERROR
+- **summary** — human-readable explanation
+- **data** — query-type-specific structured data
+- **provenance_chain** — ordered list of `ProvenanceLink` objects
+- **confidence** — 0.0–1.0 (additive per artifact, capped at 1.0)
+- **resolved_at** — ISO-8601 timestamp
+- **elapsed_ms** — wall-clock time
+- **warnings** — performance or data quality alerts
 
-                          ## Interfaces
+### Provenance Chain
 
-                          ### Python
+Each link in the chain identifies:
 
-                          ```python
-                          from coherence_ops.iris import IRISEngine, IRISQuery, QueryType
+- **artifact** — DLR, MG, DS, RS, or PRIME
+- **ref_id** — specific record identifier
+- **role** — `source` (primary), `evidence` (supporting), or `context` (enriching)
+- **detail** — human-readable description
 
-                          engine = IRISEngine(dlr_builder=dlr, rs=rs, ds=ds, mg=mg)
-                          response = engine.resolve(IRISQuery(query_type=QueryType.WHY, episode_id="ep-001"))
-                          ```
+### Resolution Status
 
-                          ### CLI
+| Status | Condition |
+|--------|-----------|
+| RESOLVED | confidence >= 0.5 |
+| PARTIAL | 0 < confidence < 0.5 |
+| NOT_FOUND | required data missing |
+| ERROR | exception during resolution |
 
-                          ```bash
-                          coherence iris query --type WHY --target ep-001
-                          coherence iris query --type STATUS
-                          coherence iris query --type WHAT_DRIFTED --json
-                          ```
+---
 
-                          ### Dashboard
+## Interfaces
 
-                          View 4 (keyboard shortcut `4`) in the Σ OVERWATCH dashboard. Natural language input with query type selector, structured response with provenance chain visualization.
+### Python
 
-                          ### JSON Schema
+```python
+from coherence_ops.iris import IRISEngine, IRISQuery, QueryType
 
-                          `specs/iris_query.schema.json` — JSON Schema draft 2020-12, `$id: https://deepsigma.dev/schemas/iris_query.schema.json`.
+engine = IRISEngine(dlr_builder=dlr, rs=rs, ds=ds, mg=mg)
+response = engine.resolve(IRISQuery(query_type=QueryType.WHY, episode_id="ep-001"))
+```
 
-                          ---
+### CLI
 
-                          ## Usage Patterns
+```bash
+coherence iris query --type WHY --target ep-001
+coherence iris query --type STATUS
+coherence iris query --type WHAT_DRIFTED --json
+```
 
-                          | Pattern | Query Type | When |
-                          |---------|-----------|------|
-                          | Post-incident review | WHY | After an unexpected outcome — trace provenance + policy context |
-                          | Drift triage | WHAT_DRIFTED | Routine monitoring — severity breakdown + resolution ratio |
-                          | Health check | STATUS | Pre-deployment — coherence score + dimension breakdown |
-                          | Institutional memory | RECALL | Onboarding / knowledge transfer — full graph context for an episode |
-                          | Change audit | WHAT_CHANGED | Pre-policy-update — baseline outcome distribution + patch count |
+### Dashboard
 
-                          ---
+View 4 (keyboard shortcut `4`) in the Σ OVERWATCH dashboard. Natural language input with query type selector, structured response with provenance chain visualization.
 
-                          ## Configuration
+### JSON Schema
 
-                          | Parameter | Default | Description |
-                          |-----------|---------|-------------|
-                          | `response_time_target_ms` | 60,000 | Performance warning threshold |
-                          | `max_provenance_depth` | 50 | Max provenance links per response |
-                          | `default_time_window_seconds` | 3,600 | Time window for WHAT_CHANGED |
-                          | `default_limit` | 20 | Result count limit |
-                          | `include_raw_artifacts` | false | Include raw data in response |
+`specs/iris_query.schema.json` — JSON Schema draft 2020-12, `$id: https://deepsigma.dev/schemas/iris_query.schema.json`.
 
-                          ---
+---
 
-                          ## Design Principles
+## Usage Patterns
 
-                          - **Read-only** — queries but never writes. Mutation flows through PRIME.
-                          - - **Provenance-first** — no answer without lineage. Every response traces back to artifact records.
-                            - - **Sub-60-second** — matches MG's institutional memory promise.
-                              - - **Structured output** — machine-parseable (JSON) and human-readable.
-                                - - **Graceful degradation** — returns PARTIAL/NOT_FOUND instead of failing when artifacts are unavailable.
-                                 
-                                  - ---
+| Pattern | Query Type | When |
+|---------|-----------|------|
+| Post-incident review | WHY | After an unexpected outcome — trace provenance + policy context |
+| Drift triage | WHAT_DRIFTED | Routine monitoring — severity breakdown + resolution ratio |
+| Health check | STATUS | Pre-deployment — coherence score + dimension breakdown |
+| Institutional memory | RECALL | Onboarding / knowledge transfer — full graph context for an episode |
+| Change audit | WHAT_CHANGED | Pre-policy-update — baseline outcome distribution + patch count |
 
-                                  ## Files
+---
 
-                                  | File | Description |
-                                  |------|-------------|
-                                  | `coherence_ops/iris.py` | Engine implementation |
-                                  | `specs/iris_query.schema.json` | JSON Schema contract |
-                                  | `coherence_ops/cli.py` | CLI `coherence iris query` |
-                                  | `dashboard/src/IrisPanel.tsx` | Dashboard panel component |
-                                  | `dashboard/src/mockData.ts` | Mock resolver for dev mode |
+## Configuration
 
-                                  ---
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `response_time_target_ms` | 60,000 | Performance warning threshold |
+| `max_provenance_depth` | 50 | Max provenance links per response |
+| `default_time_window_seconds` | 3,600 | Time window for WHAT_CHANGED |
+| `default_limit` | 20 | Result count limit |
+| `include_raw_artifacts` | false | Include raw data in response |
 
-                                  ## Glossary Terms
+---
 
-                                  See [Glossary](Glossary) and [GLOSSARY.md](../GLOSSARY.md):
+## Design Principles
 
-                                  - **IRIS** — operator-facing interface layer; query resolution with sub-60s targets
-                                  - - **PRIME** — governance threshold gate; LLM output → decision-grade action
-                                    - - **DLR** — Decision Lineage Record; truth constitution for a decision class
-                                      - - **RS** — Reasoning Summary; outcome aggregation and learning
-                                        - - **DS** — Drift Scan; structured drift signals by type/severity/fingerprint
-                                          - - **MG** — Memory Graph; provenance + recall graph
-                                            - - **Claim–Evidence–Source** — the truth chain enforced by PRIME, reconstructed by IRIS
-                                              - - **Coherence Score** — 0–100 composite from all four artifacts
-                                                - - **Seal** — immutable, tamper-evident record
-                                                 
-                                                  - See also: [Language Map](../docs/01-language-map.md) for LinkedIn-to-Code mappings (IRIS = Phase 2).
-                                                 
-                                                  - ---
+- **Read-only** — queries but never writes. Mutation flows through PRIME.
+- **Provenance-first** — no answer without lineage. Every response traces back to artifact records.
+- **Sub-60-second** — matches MG's institutional memory promise.
+- **Structured output** — machine-parseable (JSON) and human-readable.
+- **Graceful degradation** — returns PARTIAL/NOT_FOUND instead of failing when artifacts are unavailable.
 
-                                                  Full documentation: `docs/18-iris.md`
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `coherence_ops/iris.py` | Engine implementation |
+| `specs/iris_query.schema.json` | JSON Schema contract |
+| `coherence_ops/cli.py` | CLI `coherence iris query` |
+| `dashboard/src/IrisPanel.tsx` | Dashboard panel component |
+| `dashboard/src/mockData.ts` | Mock resolver for dev mode |
+
+---
+
+## Glossary Terms
+
+See [Glossary](Glossary) and [GLOSSARY.md](../GLOSSARY.md):
+
+- **IRIS** — operator-facing interface layer; query resolution with sub-60s targets
+- **PRIME** — governance threshold gate; LLM output → decision-grade action
+- **DLR** — Decision Lineage Record; truth constitution for a decision class
+- **RS** — Reasoning Summary; outcome aggregation and learning
+- **DS** — Drift Scan; structured drift signals by type/severity/fingerprint
+- **MG** — Memory Graph; provenance + recall graph
+- **Claim–Evidence–Source** — the truth chain enforced by PRIME, reconstructed by IRIS
+- **Coherence Score** — 0–100 composite from all four artifacts
+- **Seal** — immutable, tamper-evident record
+
+See also: [Language Map](../docs/01-language-map.md) for LinkedIn-to-Code mappings (IRIS = Phase 2).
+
+---
+
+Full documentation: `docs/18-iris.md`

--- a/wiki/Retcon.md
+++ b/wiki/Retcon.md
@@ -106,17 +106,17 @@
 > Retcon preserves full provenance. After a retcon:
 >
 > 1. The original claim remains in the graph (it is never deleted)
-> 2. 2. The new claim has `graph.supersedes` pointing to the original
->    3. 3. The retcon record links both, with full audit trail
->       4. 4. Any claim with `graph.dependsOn` referencing the original is flagged for re-evaluation
->          5. 5. IRIS queries that walk the graph see the supersession chain
->            
->             6. This means you can always answer: "What did we believe then? What do we believe now? Why did it change?"
->            
->             7. ## Related Pages
->            
->             8. - [Unified Atomic Claims](Unified-Atomic-Claims) — the Claim Primitive that Retcon corrects
+> 2. The new claim has `graph.supersedes` pointing to the original
+> 3. The retcon record links both, with full audit trail
+> 4. Any claim with `graph.dependsOn` referencing the original is flagged for re-evaluation
+> 5. IRIS queries that walk the graph see the supersession chain
+>
+> This means you can always answer: "What did we believe then? What do we believe now? Why did it change?"
+>
+> ## Related Pages
+>
+> - [Unified Atomic Claims](Unified-Atomic-Claims) — the Claim Primitive that Retcon corrects
 > - [Canon](Canon) — blessed claim memory that may need retcon
-> - - [Sealing & Episodes](Sealing-and-Episodes) — immutability model
->   - - [Drift to Patch](Drift-to-Patch) — the drift lifecycle (patches vs retcons)
->     - - [Schemas](Schemas) — all JSON Schema specs
+> - [Sealing & Episodes](Sealing-and-Episodes) — immutability model
+> - [Drift to Patch](Drift-to-Patch) — the drift lifecycle (patches vs retcons)
+> - [Schemas](Schemas) — all JSON Schema specs

--- a/wiki/Verifiers.md
+++ b/wiki/Verifiers.md
@@ -1,10 +1,82 @@
 # Verifiers
 
-Verifiers implement: **success means verified**.
+A **Verifier** is a postcondition check that runs after an action is dispatched to confirm the action had the intended effect — or to detect and report failure safely. The governing principle is: **success means verified.**
 
-Included scaffolds:
-- `read_after_write`
-- `invariant_check`
+Verifiers are defined per `decisionType` in the DTE (`verification.methods`) and triggered by the supervisor scaffold after the action stage. A verifier returns one of three outcomes:
 
-Directory:
-- `verifiers/`
+| Outcome | Meaning |
+|---------|---------|
+| `pass` | Postcondition satisfied — episode proceeds to seal |
+| `fail` | Postcondition not satisfied — supervisor emits drift, may trigger degrade |
+| `inconclusive` | Could not determine outcome (timeout, missing data) — treated as `fail` for safety |
+
+---
+
+## Included Scaffolds
+
+### `read_after_write`
+
+Re-reads the target resource immediately after the action and asserts that the mutation is visible.
+
+**Use when:** the action writes a value that should be immediately readable back (e.g., update a flag, set a status, write a record).
+
+**Checks:** the value read back matches the expected post-action state within `verifyTimeoutMs`.
+
+**Emits drift:** `verify` signal with severity `yellow` if the read-back fails, `red` if it times out.
+
+### `invariant_check`
+
+Evaluates a boolean condition on system state without referencing the specific target resource.
+
+**Use when:** the action is expected to satisfy a global or cross-resource invariant (e.g., "no account with balance < 0 after transfer", "service health endpoint returns 200").
+
+**Checks:** the callable condition returns `True` within `verifyTimeoutMs`.
+
+**Emits drift:** `verify` signal with severity `yellow` if the condition is `False`, `red` on timeout.
+
+---
+
+## Implementing a Custom Verifier
+
+Place the verifier in the `verifiers/` directory. A verifier is any callable that accepts an episode context dict and returns a `VerificationResult`:
+
+```python
+# verifiers/my_verifier.py
+from engine.verifier_base import VerificationResult
+
+def verify(context: dict) -> VerificationResult:
+    target_id = context["action"]["targetRefs"][0]["id"]
+    # ... check the resource
+    ok = fetch_status(target_id) == "active"
+    return VerificationResult(
+        outcome="pass" if ok else "fail",
+        detail=f"Status check for {target_id}: {'ok' if ok else 'failed'}",
+    )
+```
+
+Register the verifier identifier in the DTE:
+
+```json
+"verification": {
+  "requiredAboveBlastRadius": "small",
+  "methods": ["my_verifier"],
+  "verifyTimeoutMs": 5000
+}
+```
+
+---
+
+## Relationship to Other Contracts
+
+- Verification requirements are set in the **[DTE Schema](DTE-Schema)** (`verification.requiredAboveBlastRadius`, `methods`, `verifyTimeoutMs`)
+- A verifier `fail` or `inconclusive` result causes the supervisor to emit a `verify` **[Drift Event](Drift-Schema)**
+- Verifier outcomes are recorded in the sealed **[Episode Schema](Episode-Schema)** under the `verification` field
+
+---
+
+## Related Pages
+
+- [Contracts](Contracts) — overview of all four contract types
+- [DTE Schema](DTE-Schema) — where verification requirements are configured
+- [Drift Schema](Drift-Schema) — `verify` drift type
+- [Degrade Ladder](Degrade-Ladder) — verifier failure can trigger degrade steps


### PR DESCRIPTION
## Summary

**Formatting fixes (3 files)**
- `IRIS.md` — ~120 lines of broken `- - - -` indentation chains repaired in Response Format, Provenance Chain, Design Principles, and Glossary Terms sections; all content preserved at correct depth
- `Canon.md` — Related Pages section: `- - [Page]` nested bullets → flat `- [Page]` list
- `Retcon.md` — Graph Integrity: duplicate numbering (`2. 2.`, `3. 3.` etc.) → clean `1.–5.` list; Related Pages: same nested-bullet fix

**Stub expansions (3 files)**
- `Verifiers.md` (151 → ~1.2KB) — defines what a verifier is, documents `pass`/`fail`/`inconclusive` outcomes, explains both included scaffolds (`read_after_write`, `invariant_check`) in detail, adds custom verifier implementation guide with code example
- `Degrade-Ladder.md` (358 → ~1.3KB) — documents all 6 rungs with behaviour and when-to-use guidance, trigger table per stage, configuration JSON example, episode stamping behaviour
- `Contracts.md` (411 → ~1.5KB) — expands all 4 contract types with key fields and schema links, adds ASCII interaction diagram, fixes Schemas.md link

## Test plan

- [ ] IRIS.md renders cleanly with no indentation artifacts in Response Format / Design Principles / Glossary Terms
- [ ] Canon.md Related Pages: 5 flat bullet links render correctly
- [ ] Retcon.md Graph Integrity: numbered list 1–5, no duplicates; Related Pages: 5 flat bullets
- [ ] Verifiers.md: code example renders correctly
- [ ] Degrade-Ladder.md: JSON example renders correctly
- [ ] Contracts.md: ASCII diagram and all 4 sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)