### PR TITLE
Mermaid: Exhaust Inbox Build 29 coverage (4 files, 13 diagrams)

### DIFF
--- a/mermaid/29-exhaust-api-surface.md
+++ b/mermaid/29-exhaust-api-surface.md
@@ -1,0 +1,107 @@
+# Exhaust API Surface
+
+All ten REST endpoints exposed by `dashboard/server/exhaust_api.py`, grouped by resource.
+
+```mermaid
+graph TD
+    ROOT["/api/exhaust"] --> H
+    ROOT --> EV
+    ROOT --> EP
+    ROOT --> IT
+    ROOT --> MG2
+    ROOT --> DR
+
+    subgraph Health["Health"]
+        H["GET /health\n──────────────\nReturns: status, events_count,\nepisodes_count, refined_count\n200 OK"]
+    end
+
+    subgraph Events["Events"]
+        EV["POST /events\n──────────────\nBody: EpisodeEvent (JSON)\nReturns: {status: accepted}\n200 OK · 422 Unprocessable"]
+    end
+
+    subgraph Episodes["Episodes"]
+        EP --> LIST["GET /episodes\n──────────────\nReturns: {episodes: [DecisionEpisode]}\n200 OK"]
+        EP --> ASM["POST /episodes/assemble\n──────────────\nGroups buffered events by session_id\nReturns: {assembled: N, episode_ids: [...]}\n200 OK"]
+        EP --> GET1["GET /episodes/{episode_id}\n──────────────\nReturns: DecisionEpisode\n200 OK · 404 Not Found"]
+        EP --> REFINE["POST /episodes/{episode_id}/refine\n──────────────\nRuns rule-based (or LLM if EXHAUST_USE_LLM=1)\nReturns: RefinedEpisode\n{truth, reasoning, memory,\ndrift_signals, coherence_score, grade}\n200 OK · 404 Not Found"]
+        EP --> COMMIT["POST /episodes/{episode_id}/commit\n──────────────\nWrites to MG + Drift Log\nReturns: {status: committed, episode_id}\n200 OK · 404 Not Found · 400 Not Refined"]
+    end
+
+    subgraph Items["Item Actions"]
+        IT["PATCH /episodes/{episode_id}/items/{item_id}\n──────────────\nBody: ItemAction {action: accept|reject|edit,\n       item_type: truth|reasoning|memory,\n       updated_value: str?}\nReturns: {status: ok, item_id, action}\n200 OK · 404 Not Found"]
+    end
+
+    subgraph MG["Memory Graph"]
+        MG2["GET /mg\n──────────────\nReturns: {nodes: [MemoryItem]}\n200 OK"]
+    end
+
+    subgraph Drift["Drift Log"]
+        DR["GET /drift\n──────────────\nReturns: {signals: [DriftSignal]}\n200 OK"]
+    end
+
+    style Health fill:#1a1a2e,stroke:#e94560,color:#fff
+    style Events fill:#16213e,stroke:#0f3460,color:#fff
+    style Episodes fill:#162447,stroke:#e94560,color:#fff
+    style Items fill:#0f3460,stroke:#533483,color:#fff
+    style MG fill:#16213e,stroke:#533483,color:#fff
+    style Drift fill:#1a1a2e,stroke:#533483,color:#fff
+```
+
+## Request / Response Flow
+
+How a typical refine → item-action → commit sequence flows through the API.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as exhaust_api.py
+    participant Refiner as exhaust_refiner.py
+    participant LLM as LLMExtractor (optional)
+    participant Store as File Store (data/)
+
+    Client->>API: POST /events (×N)
+    API->>Store: append events.jsonl
+    API-->>Client: {status: accepted} ×N
+
+    Client->>API: POST /episodes/assemble
+    API->>Store: read events.jsonl, group by session_id
+    API->>Store: write episodes/{id}.json
+    API-->>Client: {assembled: 1, episode_ids: [...]}
+
+    Client->>API: POST /episodes/{id}/refine
+    API->>Refiner: refine_episode(episode, use_llm)
+    alt EXHAUST_USE_LLM=1
+        Refiner->>LLM: LLMExtractor().extract(episode)
+        LLM-->>Refiner: {truth, reasoning, memory}
+    else default
+        Refiner->>Refiner: rule-based extraction
+    end
+    Refiner-->>API: RefinedEpisode
+    API->>Store: write refined/{id}.json
+    API-->>Client: RefinedEpisode JSON
+
+    Client->>API: PATCH /episodes/{id}/items/{item_id}
+    API->>Store: load refined/{id}.json, mutate item
+    API->>Store: write refined/{id}.json
+    API-->>Client: {status: ok, item_id, action}
+
+    Client->>API: POST /episodes/{id}/commit
+    API->>Store: append mg/memory_graph.jsonl
+    API->>Store: append drift/drift.jsonl
+    API-->>Client: {status: committed, episode_id}
+```
+
+## Status Code Summary
+
+```mermaid
+graph LR
+    OK[200 OK] --> A[All successful responses]
+    UE[422 Unprocessable] --> B[POST /events — bad payload schema]
+    NF[404 Not Found] --> C[episode_id or item_id missing]
+    BR[400 Bad Request] --> D[POST /commit — episode not yet refined]
+
+    style OK fill:#0f3460,stroke:#533483,color:#fff
+    style UE fill:#e94560,stroke:#fff,color:#fff
+    style NF fill:#e94560,stroke:#fff,color:#fff
+    style BR fill:#e94560,stroke:#fff,color:#fff
+```

--- a/mermaid/29-exhaust-connector-map.md
+++ b/mermaid/29-exhaust-connector-map.md
@@ -1,0 +1,82 @@
+# Exhaust Connector Map
+
+How the three adapter types normalise raw AI interaction logs into EpisodeEvents and deliver them to the Exhaust Inbox.
+
+```mermaid
+graph LR
+    subgraph Sources["Source Systems"]
+        APP[LangChain App<br/>in-process callbacks]
+        AZL[Azure OpenAI<br/>JSONL log files]
+        ANL[Anthropic Messages API<br/>JSONL log files]
+        RAW[Any Agent<br/>raw REST calls]
+    end
+
+    subgraph Adapters["Adapters — adapters/"]
+        APP -->|inherits BaseCallbackHandler| LC["langchain_exhaust.py<br/>─────────────────<br/>on_llm_start → prompt event<br/>on_llm_end → completion + metric<br/>• latency_ms (monotonic delta)<br/>• model name from serialized<br/>on_tool_start/end → tool events"]
+        AZL -->|reads JSONL| AZA["azure_openai_exhaust.py<br/>─────────────────<br/>_normalise_entry()<br/>messages[] → prompt events<br/>choices[] → completion events<br/>usage{} → metric event"]
+        ANL -->|reads JSONL| ANA["anthropic_exhaust.py<br/>─────────────────<br/>_normalise_entry()<br/>input messages[] → prompt events<br/>content[] text → completion event<br/>content[] tool_use → tool event<br/>usage{} → metric event"]
+        RAW -->|POST JSON| MAN[Manual / SDK<br/>direct API calls]
+    end
+
+    subgraph Normalise["Normalised Shape — EpisodeEvent"]
+        LC --> EE["event_id, episode_id, event_type<br/>timestamp, source, user_hash<br/>session_id, project, team<br/>payload: Dict"]
+        AZA --> EE
+        ANA --> EE
+        MAN --> EE
+    end
+
+    subgraph Delivery["Delivery"]
+        EE -->|POST /api/exhaust/events| API["Exhaust Inbox API<br/>:8000"]
+        EE -->|--dry-run flag| DRY[Dry-run print<br/>no network call]
+    end
+
+    subgraph Grouping["Session Grouping — _group_events()"]
+        API --> GRP[Bucket by<br/>session_id + time window]
+        GRP --> EP[DecisionEpisode<br/>ready to assemble]
+    end
+
+    style Sources fill:#1a1a2e,stroke:#e94560,color:#fff
+    style Adapters fill:#16213e,stroke:#0f3460,color:#fff
+    style Normalise fill:#162447,stroke:#533483,color:#fff
+    style Delivery fill:#0f3460,stroke:#e94560,color:#fff
+    style Grouping fill:#1a1a2e,stroke:#533483,color:#fff
+```
+
+## Source Enum — Adapter Identity
+
+Each adapter stamps a `source` field so downstream analysis can distinguish origin.
+
+```mermaid
+graph TD
+    SRC[Source enum] --> LC2[langchain]
+    SRC --> OA[openai]
+    SRC --> AZ2[azure]
+    SRC --> AN2[anthropic]
+    SRC --> MN2[manual]
+
+    LC2 -.->|set by| LCA[langchain_exhaust.py]
+    AZ2 -.->|set by| AZB[azure_openai_exhaust.py]
+    AN2 -.->|set by| ANB[anthropic_exhaust.py]
+    MN2 -.->|set by| MNAPI[Direct REST callers<br/>cookbook / tests]
+
+    style SRC fill:#e94560,stroke:#fff,color:#fff
+```
+
+## Metric Enrichment — LangChain Adapter (Build 29)
+
+Targeted additions to `langchain_exhaust.py` that add observability fields to every LLM call.
+
+```mermaid
+flowchart LR
+    START["on_llm_start(serialized, run_id)"] --> ST["_run_start[run_id] = time.monotonic()"]
+    START --> MN3["_run_model[run_id] = serialized\n.kwargs.model_name"]
+
+    END["on_llm_end(response, run_id)"] --> LAT["latency_ms =\n(monotonic() − _run_start.pop()) × 1000"]
+    END --> MOD["model = _run_model.pop(run_id)"]
+    LAT --> EMIT["emit metric event\npayload = {latency_ms, model}"]
+    MOD --> EMIT
+
+    style START fill:#16213e,stroke:#0f3460,color:#fff
+    style END fill:#16213e,stroke:#0f3460,color:#fff
+    style EMIT fill:#0f3460,stroke:#533483,color:#fff
+```

--- a/mermaid/29-exhaust-inbox-pipeline.md
+++ b/mermaid/29-exhaust-inbox-pipeline.md
@@ -1,0 +1,111 @@
+# Exhaust Inbox Pipeline
+
+Full architecture of the Exhaust Inbox — from adapter emission through bucket extraction to Coherence Ops.
+
+```mermaid
+graph TB
+    subgraph Adapters["Adapters (Build 29)"]
+        LC[LangChain Callback<br/>on_llm_start / on_llm_end]
+        AZ[Azure OpenAI Adapter<br/>Batch JSONL]
+        AN[Anthropic Adapter<br/>Messages API JSONL]
+        MN[Manual / REST<br/>POST /api/exhaust/events]
+    end
+
+    subgraph Inbox["Exhaust Inbox API"]
+        EVT[Event Store<br/>events.jsonl]
+        LC -->|POST /events| EVT
+        AZ -->|POST /events| EVT
+        AN -->|POST /events| EVT
+        MN --> EVT
+        EVT --> ASM[Episode Assembler<br/>group by session_id]
+        ASM --> EP[Episode Store<br/>episodes/{id}.json]
+    end
+
+    subgraph Refiner["Refiner — POST /episodes/{id}/refine"]
+        EP --> RF{EXHAUST_USE_LLM?}
+        RF -->|"= 1 + ANTHROPIC_API_KEY set"| LLM[LLM Extraction<br/>claude-haiku-4-5-20251001]
+        RF -->|"= 0 (default)"| RB[Rule-Based Extraction<br/>keyword + pattern matching]
+        LLM -->|fallback on any error| RB
+        LLM --> BKT
+        RB --> BKT
+        BKT[Buckets<br/>TRUTH · REASONING · MEMORY]
+        BKT --> DRIFT[Drift Detector<br/>contradiction / stale_reference /<br/>missing_policy / low_coverage]
+        DRIFT --> SCORE[Coherence Scorer<br/>0–100 · Grade A–F]
+        SCORE --> REF[Refined Episode<br/>refined/{id}.json]
+    end
+
+    subgraph Commit["POST /episodes/{id}/commit"]
+        REF --> CMT[Commit Handler]
+        CMT --> MG[Memory Graph<br/>mg/memory_graph.jsonl]
+        CMT --> DRF[Drift Log<br/>drift/drift.jsonl]
+        CMT --> COH[Coherence Ops<br/>DLR · RS · DS · MG]
+    end
+
+    style Adapters fill:#1a1a2e,stroke:#e94560,color:#fff
+    style Inbox fill:#16213e,stroke:#0f3460,color:#fff
+    style Refiner fill:#162447,stroke:#e94560,color:#fff
+    style Commit fill:#0f3460,stroke:#533483,color:#fff
+```
+
+## Bucket Extraction Detail
+
+How events are mapped into TRUTH, REASONING, and MEMORY items.
+
+```mermaid
+flowchart TD
+    EV[Episode Events] --> ET{event_type}
+
+    ET -->|metric| TM["TRUTH item<br/>claim = '{name} is {value}{unit}'<br/>confidence = 0.80"]
+    ET -->|completion| TC["TRUTH items<br/>parse key sentences<br/>confidence = 0.70"]
+    ET -->|completion| RC["REASONING items<br/>keyword scan: recommend / should /<br/>because / decided / consider<br/>confidence = 0.75"]
+    ET -->|tool| MM["MEMORY item<br/>entity = tool name<br/>artifact_type = tool"]
+    ET -->|any| ME["MEMORY item<br/>entity = episode_id<br/>artifact_type = episode<br/>(always emitted)"]
+
+    TM --> CONF[Confidence<br/>clamped 0.0 – 1.0]
+    TC --> CONF
+    RC --> CONF
+    MM --> CONF
+    ME --> CONF
+
+    CONF --> OUT["RefinedEpisode<br/>{truth, reasoning, memory,<br/>drift_signals, coherence_score, grade}"]
+
+    style EV fill:#1a1a2e,stroke:#e94560,color:#fff
+    style OUT fill:#0f3460,stroke:#533483,color:#fff
+```
+
+## Episode State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Raw: POST /api/exhaust/events
+
+    state Raw {
+        [*] --> Buffered: appended to events.jsonl
+        Buffered --> [*]
+    }
+
+    Raw --> Assembled: POST /api/exhaust/episodes/assemble\ngroup by session_id + project + team
+
+    state Assembled {
+        [*] --> Stored: episodes/{id}.json written
+        Stored --> [*]
+    }
+
+    Assembled --> Refined: POST /api/exhaust/episodes/{id}/refine\nrule-based or LLM extraction
+
+    state Refined {
+        [*] --> Scored: coherence_score + grade computed
+        Scored --> ItemReview: items accept / edit / reject via\nPATCH /api/exhaust/episodes/{id}/items/{item_id}
+        ItemReview --> Scored: re-score on edit
+        Scored --> [*]
+    }
+
+    Refined --> Committed: POST /api/exhaust/episodes/{id}/commit\nMG + Drift Log updated
+
+    state Committed {
+        [*] --> Sealed: episode_id recorded in memory graph
+        Sealed --> [*]
+    }
+
+    Committed --> [*]
+```

--- a/mermaid/29-llm-extraction-flow.md
+++ b/mermaid/29-llm-extraction-flow.md
@@ -1,0 +1,105 @@
+# LLM Extraction Flow
+
+Internal mechanics of `LLMExtractor` — how an episode becomes structured TRUTH / REASONING / MEMORY buckets via the Anthropic Messages API, with full fallback handling.
+
+```mermaid
+flowchart LR
+    EP[DecisionEpisode] --> BUILD["_build_prompt(episode)\n──────────────\nSerialise each event:\n  [event_type] timestamp source=... payload=...\nTruncate transcript at 6 000 chars\nAppend 'Extract knowledge:'"]
+
+    BUILD --> CHK{len > 6000?}
+    CHK -->|yes| TRUNC["transcript[:6000]\n+ '...(truncated)'"]
+    CHK -->|no| CALL
+    TRUNC --> CALL
+
+    CALL["_call_api(prompt)\n──────────────\nanthropics.Anthropic(api_key=...)\n.messages.create(\n  model = claude-haiku-4-5-20251001\n  max_tokens = 2048\n  system = SYSTEM_PROMPT\n  messages = [{role:user, content:prompt}]\n)"]
+
+    CALL -->|"message.content[0].text"| PARSE["_parse_response(text)\n──────────────\nStrip markdown fences if present\njson.loads(stripped)\nBuild TruthItem / ReasoningItem / MemoryItem\nClamp all confidence to [0.0, 1.0]"]
+
+    PARSE --> MERGE["Merge with rule-based memory:\n• keep episode node from rule-based\n• add LLM memory items (non-episode)"]
+
+    MERGE --> OUT["Buckets\n{truth, reasoning, memory}"]
+
+    CALL -->|"any Exception"| FB["Fallback\nlogger.warning(...)\nreturn empty buckets"]
+    PARSE -->|"json.JSONDecodeError\nor KeyError"| FB
+    FB --> RB["Rule-based extraction\nruns transparently"]
+
+    style EP fill:#1a1a2e,stroke:#e94560,color:#fff
+    style OUT fill:#0f3460,stroke:#533483,color:#fff
+    style FB fill:#e94560,stroke:#fff,color:#fff
+    style RB fill:#16213e,stroke:#0f3460,color:#fff
+```
+
+## API Call Sequence
+
+End-to-end from `refine_episode()` caller through Anthropic and back.
+
+```mermaid
+sequenceDiagram
+    participant Caller as refine_episode()
+    participant Check as Env Check
+    participant LLM as LLMExtractor
+    participant Build as _build_prompt()
+    participant API as Anthropic Messages API
+    participant Parse as _parse_response()
+    participant Rule as Rule-Based Extractor
+
+    Caller->>Check: use_llm=True?
+    alt ANTHROPIC_API_KEY not set
+        Check-->>Caller: skip LLM path
+        Caller->>Rule: extract_truth/reasoning/memory()
+        Rule-->>Caller: buckets
+    else key is set
+        Check->>LLM: LLMExtractor().extract(episode)
+        LLM->>Build: episode events
+        Build-->>LLM: prompt string (≤6000 chars)
+        LLM->>API: messages.create(model, system, user=prompt)
+        alt API success
+            API-->>LLM: message.content[0].text (JSON)
+            LLM->>Parse: raw text
+            Parse-->>LLM: {truth[], reasoning[], memory[]}
+            LLM->>LLM: merge episode node from rule-based
+            LLM-->>Caller: merged buckets
+        else API error or bad JSON
+            API-->>LLM: Exception / non-JSON text
+            LLM-->>Caller: empty buckets {} + warning log
+            Caller->>Rule: extract_truth/reasoning/memory()
+            Rule-->>Caller: buckets
+        end
+    end
+
+    Caller->>Caller: detect_drift() + score_coherence()
+    Caller-->>Caller: RefinedEpisode
+```
+
+## Confidence Clamping
+
+Ensures LLM-returned confidence values are always valid regardless of model output.
+
+```mermaid
+flowchart TD
+    RAW["LLM returns confidence\ne.g. 1.5 / -0.2 / 'high' / null"] --> TRY{float(v)?}
+    TRY -->|success| CLAMP["max(0.0, min(1.0, v))"]
+    TRY -->|ValueError / TypeError| DEF["default = 0.5"]
+    CLAMP --> OUT2[Valid confidence 0.0–1.0]
+    DEF --> OUT2
+
+    style RAW fill:#1a1a2e,stroke:#e94560,color:#fff
+    style OUT2 fill:#0f3460,stroke:#533483,color:#fff
+```
+
+## System Prompt
+
+The instruction sent as the `system` parameter on every API call.
+
+```
+You are an institutional knowledge extractor for Σ OVERWATCH.
+Given an AI decision episode transcript, extract structured knowledge.
+Return ONLY valid JSON matching the schema below.
+No explanation, no markdown fences.
+
+{
+  "truth": [{"claim": str, "confidence": float, "evidence": str}],
+  "reasoning": [{"decision": str, "confidence": float, "rationale": str}],
+  "memory": [{"entity": str, "entity_type": str, "relations": [str], "confidence": float}]
+}
+```


### PR DESCRIPTION
## Summary

- 4 new diagram files covering the full Exhaust Inbox architecture shipped in Build 29 (PRs #44–46)
- 13 total diagrams: pipeline, connector map, API surface, and LLM extraction internals

## Files

| File | Diagrams | Coverage |
|------|----------|----------|
| `29-exhaust-inbox-pipeline.md` | 3 | Adapter → refine → coherence ops; bucket routing; episode state machine |
| `29-exhaust-connector-map.md` | 3 | LangChain / Anthropic / Azure normalisation paths; latency_ms + model enrichment |
| `29-exhaust-api-surface.md` | 3 | All 10 REST endpoints; refine→commit sequence; HTTP status codes |
| `29-llm-extraction-flow.md` | 4 | LLMExtractor internals; API call sequence; confidence clamping; system prompt |

## Test plan

- [x] All `.md` files contain valid mermaid fences
- [x] Diagram types used: `graph TB/LR/TD`, `flowchart TD/LR`, `stateDiagram-v2`, `sequenceDiagram`
- [x] Cross-referenced in `wiki/Exhaust-Inbox.md` (added in PR #48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)