### PR TITLE
CI: auto-sync wiki/ to GitHub wiki on merge

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,37 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Clone wiki repo
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" /tmp/wiki
+
+      - name: Sync wiki/ files
+        run: |
+          cp wiki/*.md /tmp/wiki/
+
+      - name: Commit and push
+        run: |
+          cd /tmp/wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes to push."
+          else
+            git commit -m "Wiki sync from ${{ github.sha }}"
+            git push
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/wiki-sync.yml`
- Triggers on any push to `main` that touches `wiki/**`
- Clones `<repo>.wiki.git`, copies all `wiki/*.md` files, commits + pushes only when there's a diff
- Uses `GITHUB_TOKEN` — no additional secrets or PATs needed

## How it works

```
push to main (wiki/** changed)
  → checkout main repo
  → clone wiki repo via GITHUB_TOKEN
  → cp wiki/*.md → wiki repo
  → git diff --cached: if changes exist → commit + push
```

## Test plan

- [x] Workflow file is valid YAML
- [x] `paths: wiki/**` filter prevents triggering on unrelated commits
- [x] No-op if no diff (idempotent)
- [ ] Verify first run pushes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)