### PR TITLE
Container: deepsigma-coherence — CLI worker image for batch governance

### DIFF
--- a/.github/workflows/docker-coherence.yml
+++ b/.github/workflows/docker-coherence.yml
@@ -1,0 +1,69 @@
+name: Docker — Coherence CLI
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'coherence_ops/**'
+      - 'engine/**'
+      - 'verifiers/**'
+      - 'tools/**'
+      - 'specs/**'
+      - 'adapters/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.coherence'
+      - '.github/workflows/docker-coherence.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile.coherence'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deepsigma-coherence
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.coherence
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.coherence
+++ b/Dockerfile.coherence
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+# ── Coherence Ops CLI worker ─────────────────────────────────
+# Run-and-exit container for batch governance operations.
+#
+#   docker run --rm \
+#     -v ./data:/data \
+#     ghcr.io/8ryanwh1t3/deepsigma-coherence \
+#     score /data/episodes.json --json
+#
+# Available commands:
+#   coherence audit <path>
+#   coherence score <path> [--json]
+#   coherence mg export <path> [--format json]
+#   coherence iris query <path> --type STATUS|WHY|...
+# ─────────────────────────────────────────────────────────────
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/8ryanWh1t3/DeepSigma"
+LABEL org.opencontainers.image.description="Σ OVERWATCH Coherence Ops CLI — batch governance worker"
+LABEL org.opencontainers.image.licenses="MIT"
+
+RUN pip install --no-cache-dir \
+    "jsonschema" \
+    "referencing>=0.35.0" \
+    "pyyaml>=6.0"
+
+WORKDIR /app
+
+COPY pyproject.toml /app/
+COPY coherence_ops/ /app/coherence_ops/
+COPY engine/ /app/engine/
+COPY verifiers/ /app/verifiers/
+COPY tools/ /app/tools/
+COPY specs/ /app/specs/
+COPY adapters/ /app/adapters/
+
+RUN pip install --no-cache-dir -e /app
+
+# Mount episode/drift JSON files here
+RUN mkdir -p /data
+
+ENV PYTHONPATH=/app
+
+ENTRYPOINT ["coherence"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Adds `Dockerfile.coherence` and a matching CI workflow to publish `ghcr.io/8ryanwh1t3/deepsigma-coherence` — a minimal run-and-exit CLI worker for batch governance operations.

## Usage

```bash
# Score episodes
docker run --rm -v ./data:/data \
  ghcr.io/8ryanwh1t3/deepsigma-coherence \
  score /data/episodes.json --json

# Full audit
docker run --rm -v ./data:/data \
  ghcr.io/8ryanwh1t3/deepsigma-coherence \
  audit /data/

# IRIS query
docker run --rm -v ./data:/data \
  ghcr.io/8ryanwh1t3/deepsigma-coherence \
  iris query /data/ --type STATUS --json
```

## Files

| File | Purpose |
|------|---------|
| `Dockerfile.coherence` | `python:3.12-slim` — no nginx/supervisord; `ENTRYPOINT ["coherence"]` |
| `.github/workflows/docker-coherence.yml` | Publishes to GHCR on push to `coherence_ops/**`, `engine/**`, `Dockerfile.coherence` |

## Test plan

- [x] `docker build -f Dockerfile.coherence -t deepsigma-coherence:test .`
- [x] `docker run --rm deepsigma-coherence:test --help` → prints coherence CLI help
- [x] CI workflow YAML is valid
- [x] Image name, tag strategy, and cache config match existing `docker-publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)