### PR TITLE
Container: deepsigma-exhaust — standalone Exhaust Inbox API service

### DIFF
--- a/.github/workflows/docker-exhaust.yml
+++ b/.github/workflows/docker-exhaust.yml
@@ -1,0 +1,73 @@
+name: Docker — Exhaust Inbox
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'dashboard/server/exhaust_api.py'
+      - 'dashboard/server/exhaust_main.py'
+      - 'dashboard/server/models_exhaust.py'
+      - 'engine/exhaust_refiner.py'
+      - 'engine/exhaust_llm_extractor.py'
+      - 'coherence_ops/**'
+      - 'engine/**'
+      - 'specs/**'
+      - 'adapters/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.exhaust'
+      - '.github/workflows/docker-exhaust.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile.exhaust'
+      - 'dashboard/server/exhaust_main.py'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deepsigma-exhaust
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.exhaust
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.exhaust
+++ b/Dockerfile.exhaust
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+# ── Exhaust Inbox standalone service ─────────────────────────
+# FastAPI service for AI interaction exhaust ingestion.
+# Runs independently of the dashboard — no UI, no nginx.
+#
+#   docker run -p 8001:8001 \
+#     -e EXHAUST_USE_LLM=1 \
+#     -e ANTHROPIC_API_KEY=sk-ant-... \
+#     -v ./data:/app/data \
+#     ghcr.io/8ryanwh1t3/deepsigma-exhaust
+#
+# Build with LLM extraction support (opt-in):
+#   docker build -f Dockerfile.exhaust --build-arg INSTALL_LLM=1 .
+# ─────────────────────────────────────────────────────────────
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/8ryanWh1t3/DeepSigma"
+LABEL org.opencontainers.image.description="Σ OVERWATCH Exhaust Inbox — standalone ingestion service"
+LABEL org.opencontainers.image.licenses="MIT"
+
+RUN pip install --no-cache-dir \
+    "fastapi>=0.104.0" \
+    "uvicorn[standard]>=0.24.0" \
+    "jsonschema" \
+    "referencing>=0.35.0" \
+    "pyyaml>=6.0"
+
+WORKDIR /app
+
+COPY pyproject.toml /app/
+COPY dashboard/server/ /app/dashboard/server/
+RUN touch /app/dashboard/__init__.py /app/dashboard/server/__init__.py
+COPY engine/ /app/engine/
+COPY coherence_ops/ /app/coherence_ops/
+COPY verifiers/ /app/verifiers/
+COPY tools/ /app/tools/
+COPY specs/ /app/specs/
+COPY adapters/ /app/adapters/
+
+RUN pip install --no-cache-dir -e /app
+
+# Optional: install Anthropic client for LLM-backed extraction
+# Build with --build-arg INSTALL_LLM=1 to include it
+ARG INSTALL_LLM=0
+RUN if [ "$INSTALL_LLM" = "1" ]; then \
+    pip install --no-cache-dir "anthropic>=0.40.0"; \
+    fi
+
+# Data directory for episode/drift storage (mount volume here)
+RUN mkdir -p /app/data
+
+ENV PYTHONPATH=/app
+# Set EXHAUST_USE_LLM=1 at runtime to enable LLM extraction
+ENV EXHAUST_USE_LLM=0
+
+EXPOSE 8001
+
+# Use urllib (stdlib) — no curl needed in slim image
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/healthz')"
+
+CMD ["uvicorn", "dashboard.server.exhaust_main:app", \
+     "--host", "0.0.0.0", "--port", "8001", "--workers", "1"]

--- a/dashboard/server/exhaust_main.py
+++ b/dashboard/server/exhaust_main.py
@@ -1,0 +1,35 @@
+"""Standalone Exhaust Inbox service entrypoint.
+
+Runs the Exhaust Inbox API as an independent FastAPI service,
+decoupled from the main dashboard server.
+
+Usage:
+    uvicorn dashboard.server.exhaust_main:app --host 0.0.0.0 --port 8001
+
+Environment variables:
+    EXHAUST_USE_LLM     Set to "1" to enable Anthropic-backed extraction (default: "0")
+    ANTHROPIC_API_KEY   Required when EXHAUST_USE_LLM=1
+"""
+from __future__ import annotations
+
+try:
+    from fastapi import FastAPI
+    from dashboard.server.exhaust_api import router as exhaust_router
+
+    app = FastAPI(
+        title="Σ OVERWATCH Exhaust Inbox",
+        version="0.3.0",
+        description="Standalone ingestion service for AI interaction exhaust",
+    )
+
+    app.include_router(exhaust_router, prefix="/api/exhaust")
+
+    @app.get("/healthz", tags=["health"])
+    def health() -> dict:
+        return {"status": "ok", "service": "exhaust"}
+
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError(
+        "FastAPI is required for exhaust_main. "
+        "Install with: pip install 'fastapi>=0.104.0' 'uvicorn[standard]>=0.24.0'"
+    ) from exc


### PR DESCRIPTION
## Summary

Adds a standalone FastAPI container for the Exhaust Inbox — runs independently of the dashboard with full LLM extraction support.

## Usage

```bash
# Base image (rule-based extraction)
docker run -p 8001:8001 \
  -v ./data:/app/data \
  ghcr.io/8ryanwh1t3/deepsigma-exhaust

# With LLM extraction (runtime opt-in)
docker run -p 8001:8001 \
  -e EXHAUST_USE_LLM=1 \
  -e ANTHROPIC_API_KEY=sk-ant-... \
  -v ./data:/app/data \
  ghcr.io/8ryanwh1t3/deepsigma-exhaust

# Build with Anthropic baked in
docker build -f Dockerfile.exhaust --build-arg INSTALL_LLM=1 -t deepsigma-exhaust:llm .
```

## Files

| File | Purpose |
|------|---------|
| `dashboard/server/exhaust_main.py` | Thin FastAPI app mounting existing `exhaust_api` router at `/api/exhaust` |
| `Dockerfile.exhaust` | `python:3.12-slim` — port 8001, `ARG INSTALL_LLM`, stdlib healthcheck |
| `.github/workflows/docker-exhaust.yml` | Publishes `ghcr.io/8ryanwh1t3/deepsigma-exhaust` on exhaust file changes |

## Test plan

- [x] `docker build -f Dockerfile.exhaust -t deepsigma-exhaust:test .`
- [x] `curl http://localhost:8001/healthz` → `{"status":"ok","service":"exhaust"}`
- [x] `curl http://localhost:8001/api/exhaust/health` → exhaust router responds
- [x] `docker build --build-arg INSTALL_LLM=1` → anthropic present in image
- [x] No changes to `exhaust_api.py` or `dashboard/server/api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)