### PR TITLE
Container: deepsigma-mcp — JSON-RPC stdio MCP server

### DIFF
--- a/.github/workflows/docker-mcp.yml
+++ b/.github/workflows/docker-mcp.yml
@@ -1,0 +1,67 @@
+name: Docker — MCP Server
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'adapters/mcp/**'
+      - 'engine/**'
+      - 'coherence_ops/**'
+      - 'specs/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.mcp'
+      - '.github/workflows/docker-mcp.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile.mcp'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deepsigma-mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.mcp
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+# ── Σ OVERWATCH MCP Server ───────────────────────────────────
+# JSON-RPC stdio server implementing the Model Context Protocol.
+# MCP clients launch this as a subprocess and pipe stdin/stdout.
+#
+# Claude Desktop config (~/.claude/claude_desktop_config.json):
+#   {
+#     "mcpServers": {
+#       "deepsigma": {
+#         "command": "docker",
+#         "args": ["run", "--rm", "-i",
+#                  "-v", "/path/to/data:/app/data",
+#                  "ghcr.io/8ryanwh1t3/deepsigma-mcp"]
+#       }
+#     }
+#   }
+#
+# Direct usage (pipe JSON-RPC over stdin):
+#   echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | \
+#     docker run --rm -i ghcr.io/8ryanwh1t3/deepsigma-mcp
+# ─────────────────────────────────────────────────────────────
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/8ryanWh1t3/DeepSigma"
+LABEL org.opencontainers.image.description="Σ OVERWATCH MCP Server — JSON-RPC stdio server for Model Context Protocol clients"
+LABEL org.opencontainers.image.licenses="MIT"
+
+RUN pip install --no-cache-dir \
+    "jsonschema" \
+    "referencing>=0.35.0" \
+    "pyyaml>=6.0"
+
+WORKDIR /app
+
+COPY pyproject.toml /app/
+COPY adapters/mcp/ /app/adapters/mcp/
+COPY adapters/__init__.py /app/adapters/__init__.py
+COPY engine/ /app/engine/
+COPY coherence_ops/ /app/coherence_ops/
+COPY verifiers/ /app/verifiers/
+COPY tools/ /app/tools/
+COPY specs/ /app/specs/
+
+RUN pip install --no-cache-dir -e /app
+
+# Episode/drift data accessible to MCP tools
+RUN mkdir -p /app/data
+
+ENV PYTHONPATH=/app
+
+# stdin/stdout for JSON-RPC — run with: docker run -i
+CMD ["python", "-u", "adapters/mcp/mcp_server_scaffold.py"]


### PR DESCRIPTION
## Summary

Adds `Dockerfile.mcp` and CI workflow for `ghcr.io/8ryanwh1t3/deepsigma-mcp` — a containerized MCP server that speaks JSON-RPC over stdin/stdout, matching the standard MCP subprocess pattern.

## Usage

**Claude Desktop** (`~/.claude/claude_desktop_config.json`):
```json
{
  "mcpServers": {
    "deepsigma": {
      "command": "docker",
      "args": ["run", "--rm", "-i",
               "-v", "/path/to/data:/app/data",
               "ghcr.io/8ryanwh1t3/deepsigma-mcp"]
    }
  }
}
```

**Direct pipe:**
```bash
echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | \
  docker run --rm -i ghcr.io/8ryanwh1t3/deepsigma-mcp
```

**Available MCP tools:** `submit_task`, `tool_execute`, `action_dispatch`, `verify_run`, `episode_seal`, `drift_emit`

## Files

| File | Purpose |
|------|---------|
| `Dockerfile.mcp` | `python:3.12-slim`, runs `mcp_server_scaffold.py` via stdin/stdout |
| `.github/workflows/docker-mcp.yml` | Publishes `ghcr.io/8ryanwh1t3/deepsigma-mcp` on MCP adapter changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)