### PR TITLE
OTel: add OTLP export + deepsigma-otel sidecar container

### DIFF
--- a/.github/workflows/docker-otel.yml
+++ b/.github/workflows/docker-otel.yml
@@ -1,0 +1,68 @@
+name: Docker — OTel Sidecar
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'adapters/otel/**'
+      - 'engine/**'
+      - 'coherence_ops/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.otel'
+      - '.github/workflows/docker-otel.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile.otel'
+      - 'adapters/otel/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deepsigma-otel
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push (gRPC variant)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.otel
+          build-args: INSTALL_OTLP=grpc
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.otel
+++ b/Dockerfile.otel
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+# ── Σ OVERWATCH OTel Sidecar ─────────────────────────────────
+# Watches /app/data/{episodes,drift}/ for new JSON files and
+# exports them to an OTLP collector as OTel spans.
+#
+# Usage:
+#   docker run \
+#     -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
+#     -v ./data:/app/data \
+#     ghcr.io/8ryanwh1t3/deepsigma-otel
+#
+# Build variants:
+#   default       — console exporter (no OTLP packages)
+#   --build-arg INSTALL_OTLP=grpc  — gRPC OTLP (port 4317)
+#   --build-arg INSTALL_OTLP=http  — HTTP OTLP (port 4318)
+#   --build-arg INSTALL_OTLP=both  — both transports
+# ─────────────────────────────────────────────────────────────
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/8ryanWh1t3/DeepSigma"
+LABEL org.opencontainers.image.description="Σ OVERWATCH OTel Sidecar — exports episodes and drift events to OTLP"
+LABEL org.opencontainers.image.licenses="MIT"
+
+RUN pip install --no-cache-dir \
+    "opentelemetry-api>=1.20.0" \
+    "opentelemetry-sdk>=1.20.0" \
+    "jsonschema" \
+    "referencing>=0.35.0" \
+    "pyyaml>=6.0"
+
+# Optional OTLP transport — install at build time via --build-arg INSTALL_OTLP=grpc|http|both
+ARG INSTALL_OTLP=none
+RUN if [ "$INSTALL_OTLP" = "grpc" ] || [ "$INSTALL_OTLP" = "both" ]; then \
+      pip install --no-cache-dir "opentelemetry-exporter-otlp-proto-grpc>=1.20.0"; \
+    fi && \
+    if [ "$INSTALL_OTLP" = "http" ] || [ "$INSTALL_OTLP" = "both" ]; then \
+      pip install --no-cache-dir "opentelemetry-exporter-otlp-proto-http>=1.20.0"; \
+    fi
+
+WORKDIR /app
+
+COPY pyproject.toml /app/
+COPY adapters/otel/ /app/adapters/otel/
+COPY adapters/__init__.py /app/adapters/__init__.py
+COPY engine/ /app/engine/
+COPY coherence_ops/ /app/coherence_ops/
+COPY specs/ /app/specs/
+
+RUN pip install --no-cache-dir -e /app
+
+# Watched directories (mount your data volume here)
+RUN mkdir -p /app/data/episodes /app/data/drift /app/data/exported
+
+ENV PYTHONPATH=/app
+# Set at runtime: -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=""
+ENV OTEL_SERVICE_NAME=sigma-overwatch
+ENV SIDECAR_POLL_INTERVAL=5
+
+CMD ["python", "-u", "adapters/otel/sidecar.py"]

--- a/adapters/otel/sidecar.py
+++ b/adapters/otel/sidecar.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Σ OVERWATCH OTel Sidecar — watch a data directory and export episodes/drift to OTLP.
+
+Watches /app/data/episodes/ and /app/data/drift/ for new JSON files,
+exports each to the configured OTLP endpoint, then moves them to
+/app/data/exported/ to avoid re-processing.
+
+Environment variables:
+    OTEL_EXPORTER_OTLP_ENDPOINT  OTLP gRPC (default) or HTTP endpoint
+                                  e.g. http://otel-collector:4317
+    OTEL_SERVICE_NAME            Service name tag (default: sigma-overwatch)
+    SIDECAR_POLL_INTERVAL        Seconds between directory polls (default: 5)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# Ensure the app root is importable
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from adapters.otel.exporter import OtelExporter  # noqa: E402
+
+DATA_ROOT = Path(os.environ.get("SIDECAR_DATA_DIR", "/app/data"))
+EPISODES_DIR = DATA_ROOT / "episodes"
+DRIFT_DIR = DATA_ROOT / "drift"
+EXPORTED_DIR = DATA_ROOT / "exported"
+POLL_INTERVAL = int(os.environ.get("SIDECAR_POLL_INTERVAL", "5"))
+
+
+def _ensure_dirs() -> None:
+    for d in (EPISODES_DIR, DRIFT_DIR, EXPORTED_DIR):
+        d.mkdir(parents=True, exist_ok=True)
+
+
+def _export_file(path: Path, exporter: OtelExporter, kind: str) -> None:
+    try:
+        data = json.loads(path.read_text())
+        items = data if isinstance(data, list) else [data]
+        for item in items:
+            if kind == "episode":
+                exporter.export_episode(item)
+            else:
+                exporter.export_drift(item)
+        dest = EXPORTED_DIR / path.name
+        path.rename(dest)
+        logger.info("Exported %s → %s", path.name, dest)
+    except Exception as exc:
+        logger.error("Failed to export %s: %s", path, exc)
+
+
+def run() -> None:
+    _ensure_dirs()
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    logger.info("Starting OTel sidecar | endpoint=%s | poll=%ss", endpoint or "console", POLL_INTERVAL)
+    exporter = OtelExporter()
+
+    while True:
+        for ep_file in sorted(EPISODES_DIR.glob("*.json")):
+            _export_file(ep_file, exporter, "episode")
+        for dr_file in sorted(DRIFT_DIR.glob("*.json")):
+            _export_file(dr_file, exporter, "drift")
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary

- Upgrades `adapters/otel/exporter.py` to support real OTLP export (gRPC and HTTP)
- Adds `adapters/otel/sidecar.py` — a standalone poll-loop that watches a data directory and ships episodes/drift to any OTLP collector
- Adds `Dockerfile.otel` and CI workflow for `ghcr.io/8ryanwh1t3/deepsigma-otel`

## Usage

```bash
# Point at a local Grafana/Tempo/Jaeger collector
docker run \
  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
  -v ./data:/app/data \
  ghcr.io/8ryanwh1t3/deepsigma-otel

# Console mode (no collector)
docker run -v ./data:/app/data ghcr.io/8ryanwh1t3/deepsigma-otel

# Build with HTTP transport instead of gRPC
docker build -f Dockerfile.otel --build-arg INSTALL_OTLP=http .
```

**Sidecar pattern:** drop JSON episode/drift files in `./data/episodes/` or `./data/drift/` → sidecar polls every 5s, exports spans, moves files to `./data/exported/`.

## Exporter selection

| Condition | Exporter |
|-----------|---------|
| `OTEL_EXPORTER_OTLP_ENDPOINT` set, `:4317` | OTLP gRPC (BatchSpanProcessor) |
| `OTEL_EXPORTER_OTLP_ENDPOINT` set, `:4318` or `/v1/traces` | OTLP HTTP (BatchSpanProcessor) |
| No endpoint | Console (SimpleSpanProcessor) |
| OTLP packages not installed | Console fallback with warning |

🤖 Generated with [Claude Code](https://claude.com/claude-code)