### PR TITLE
OpenClaw: implement OverwatchClient HTTP client

### DIFF
--- a/adapters/openclaw/overwatch_openclaw_adapter.py
+++ b/adapters/openclaw/overwatch_openclaw_adapter.py
@@ -1,23 +1,57 @@
 """
-Σ OVERWATCH × OpenClaw adapter (scaffold)
+Σ OVERWATCH × OpenClaw adapter
 
-This file is intentionally minimal: it defines the interface points needed to
-connect an OpenClaw "skill runner" to Overwatch contracts.
+Connects an OpenClaw skill runner to the Overwatch dashboard API.
+All calls go to the dashboard FastAPI server (default: http://localhost:8000).
 
-Planned:
-- map skill_run → decisionType
-- tool proxy: execute_tool(...) through Overwatch
-- action dispatch: dispatch_action(action_contract) through Overwatch
-- verification: run verifier(s)
-- sealing: emit episode + drift
+Configuration via environment variables:
+    OVERWATCH_BASE_URL   Base URL of the dashboard API (default: http://localhost:8000)
+    OVERWATCH_TIMEOUT    Request timeout in seconds (default: 30)
 
-NOTE: This repo intentionally avoids real credentialed system access in examples.
+Usage:
+    from adapters.openclaw.overwatch_openclaw_adapter import OverwatchClient, SkillRun, run_skill_with_overwatch
+
+    client = OverwatchClient()  # reads OVERWATCH_BASE_URL from env
+    result = run_skill_with_overwatch(
+        SkillRun(skill_name="AccountQuarantine", payload={...}, actor_id="agent-1"),
+        client,
+    )
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "http://localhost:8000"
+_DEFAULT_TIMEOUT = 30
+
+
+def _api(base_url: str, path: str, body: Dict[str, Any] | None = None, timeout: int = _DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    """Make a JSON API call (GET if body is None, POST otherwise)."""
+    url = base_url.rstrip("/") + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST" if data is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode(errors="replace")
+        raise RuntimeError(f"Overwatch API {exc.code} at {url}: {body_text}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Overwatch API unreachable at {url}: {exc.reason}") from exc
 
 
 @dataclass
@@ -28,36 +62,116 @@ class SkillRun:
 
 
 class OverwatchClient:
-    """Placeholder client; replace with real HTTP client in implementation."""
+    """HTTP client for the Σ OVERWATCH dashboard API.
+
+    All methods map directly to dashboard API endpoints.
+    Uses stdlib urllib only — no external dependencies required.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout: int | None = None,
+    ):
+        self.base_url = (base_url or os.environ.get("OVERWATCH_BASE_URL", _DEFAULT_BASE_URL)).rstrip("/")
+        self.timeout = timeout or int(os.environ.get("OVERWATCH_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+
+    def _call(self, path: str, body: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return _api(self.base_url, path, body, self.timeout)
+
+    # ── Episode lifecycle ────────────────────────────────────────
 
     def submit_task(self, decision_type: str, payload: Dict[str, Any], actor_id: str) -> str:
-        raise NotImplementedError
+        """Create a new episode and return its session/episode ID.
+
+        Maps to: POST /api/episodes
+        """
+        resp = self._call("/api/episodes", {
+            "decisionType": decision_type,
+            "payload": payload,
+            "actorId": actor_id,
+        })
+        episode_id: str = resp.get("episodeId") or resp.get("id") or resp["session_id"]
+        logger.debug("submit_task → episodeId=%s", episode_id)
+        return episode_id
 
     def execute_tool(self, session_id: str, tool_name: str, tool_input: Dict[str, Any]) -> Dict[str, Any]:
-        raise NotImplementedError
+        """Execute a tool call within an episode.
+
+        Maps to: POST /api/episodes/{session_id}/tool_calls
+        """
+        resp = self._call(f"/api/episodes/{session_id}/tool_calls", {
+            "toolName": tool_name,
+            "toolInput": tool_input,
+        })
+        logger.debug("execute_tool session=%s tool=%s → %s", session_id, tool_name, resp.get("status"))
+        return resp
 
     def dispatch_action(self, session_id: str, action_contract: Dict[str, Any]) -> Dict[str, Any]:
-        raise NotImplementedError
+        """Dispatch an action through the safe action contract enforcement layer.
+
+        Maps to: POST /api/episodes/{session_id}/actions
+        """
+        resp = self._call(f"/api/episodes/{session_id}/actions", action_contract)
+        logger.debug("dispatch_action session=%s → %s", session_id, resp.get("status"))
+        return resp
 
     def verify(self, session_id: str, method: str, details: Dict[str, Any]) -> Dict[str, Any]:
-        raise NotImplementedError
+        """Run a postcondition verifier on the episode.
+
+        Maps to: POST /api/episodes/{session_id}/verify
+        """
+        resp = self._call(f"/api/episodes/{session_id}/verify", {
+            "method": method,
+            "details": details,
+        })
+        logger.debug("verify session=%s method=%s → %s", session_id, method, resp.get("outcome"))
+        return resp
 
     def seal(self, session_id: str, episode: Dict[str, Any]) -> Dict[str, Any]:
-        raise NotImplementedError
+        """Seal and commit the episode to immutable storage.
+
+        Maps to: POST /api/episodes/{session_id}/seal
+        """
+        resp = self._call(f"/api/episodes/{session_id}/seal", episode)
+        logger.debug("seal session=%s → %s", session_id, resp.get("status"))
+        return resp
+
+    def health(self) -> Dict[str, Any]:
+        """Check dashboard API health.
+
+        Maps to: GET /api/health
+        """
+        return self._call("/api/health")
 
 
 def map_skill_to_decision_type(skill_name: str) -> str:
-    """Default mapping; override per project."""
+    """Default skill → decisionType mapping; override per project."""
     return f"OpenClaw::{skill_name}"
 
 
 def run_skill_with_overwatch(skill: SkillRun, ow: OverwatchClient) -> Dict[str, Any]:
+    """Run a full skill lifecycle through the Overwatch governance pipeline.
+
+    Steps: submit → (tool execution) → (action dispatch) → verify → seal
+    """
     decision_type = map_skill_to_decision_type(skill.skill_name)
-    session_id = ow.submit_task(decision_type=decision_type, payload=skill.payload, actor_id=skill.actor_id)
+    session_id = ow.submit_task(
+        decision_type=decision_type,
+        payload=skill.payload,
+        actor_id=skill.actor_id,
+    )
 
-    # TODO: tool execution through ow.execute_tool(...)
-    # TODO: action contract enforcement through ow.dispatch_action(...)
-    # TODO: verification through ow.verify(...)
-    # TODO: sealing through ow.seal(...)
+    # Callers can add tool execution and action dispatch here:
+    # ow.execute_tool(session_id, "my_tool", {...})
+    # ow.dispatch_action(session_id, action_contract)
 
-    return {"session_id": session_id, "status": "scaffold"}
+    verification = ow.verify(session_id, "read_after_write", {})
+    seal_result = ow.seal(session_id, {"verificationResult": verification})
+
+    return {
+        "session_id": session_id,
+        "verification": verification,
+        "seal": seal_result,
+        "status": seal_result.get("status", "sealed"),
+    }


### PR DESCRIPTION
## Summary

Replaces the `OverwatchClient` placeholder stub with a real HTTP client. Uses stdlib `urllib` only — no extra dependencies.

## Usage

```python
from adapters.openclaw.overwatch_openclaw_adapter import OverwatchClient, SkillRun, run_skill_with_overwatch

# Auto-reads OVERWATCH_BASE_URL from env (default: http://localhost:8000)
client = OverwatchClient()

# Check connectivity
client.health()

# Full skill lifecycle
result = run_skill_with_overwatch(
    SkillRun(skill_name="AccountQuarantine", payload={"accountId": "acct-123"}, actor_id="agent-1"),
    client,
)
# → {"session_id": "...", "verification": {...}, "seal": {...}, "status": "sealed"}
```

## API mapping

| Method | Endpoint |
|--------|---------|
| `submit_task()` | `POST /api/episodes` |
| `execute_tool()` | `POST /api/episodes/{id}/tool_calls` |
| `dispatch_action()` | `POST /api/episodes/{id}/actions` |
| `verify()` | `POST /api/episodes/{id}/verify` |
| `seal()` | `POST /api/episodes/{id}/seal` |
| `health()` | `GET /api/health` |

## Configuration

```bash
export OVERWATCH_BASE_URL=http://overwatch-dashboard:8000
export OVERWATCH_TIMEOUT=30
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)