### PR TITLE
RDF/SPARQL: Fuseki container pre-loaded with DeepSigma ontology

### DIFF
--- a/.github/workflows/docker-rdf.yml
+++ b/.github/workflows/docker-rdf.yml
@@ -1,0 +1,64 @@
+name: Docker — RDF/SPARQL
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'rdf/**'
+      - 'Dockerfile.rdf'
+      - '.github/workflows/docker-rdf.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile.rdf'
+      - 'rdf/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deepsigma-rdf
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.rdf
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.rdf
+++ b/Dockerfile.rdf
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1
+# ── Σ OVERWATCH RDF/SPARQL endpoint ──────────────────────────
+# Apache Jena Fuseki pre-loaded with the DeepSigma ontology.
+# Exposes a SPARQL 1.1 endpoint at http://localhost:3030/deepsigma
+#
+# Usage:
+#   docker run -p 3030:3030 ghcr.io/8ryanwh1t3/deepsigma-rdf
+#
+# SPARQL query endpoint: http://localhost:3030/deepsigma/sparql
+# SPARQL update:         http://localhost:3030/deepsigma/update
+# Graph store:           http://localhost:3030/deepsigma/data
+# Fuseki admin UI:       http://localhost:3030
+#
+# Example query:
+#   curl -X POST http://localhost:3030/deepsigma/sparql \
+#     -H "Content-Type: application/sparql-query" \
+#     -H "Accept: application/json" \
+#     -d "SELECT * WHERE { ?s ?p ?o } LIMIT 10"
+# ─────────────────────────────────────────────────────────────
+FROM stain/jena-fuseki:5.0.0
+
+LABEL org.opencontainers.image.source="https://github.com/8ryanWh1t3/DeepSigma"
+LABEL org.opencontainers.image.description="Σ OVERWATCH RDF — Jena Fuseki SPARQL endpoint with DeepSigma ontology"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Copy all ontology TTL files
+COPY rdf/coherence-ops-ontology.ttl /staging/
+COPY rdf/namespaces.ttl             /staging/
+COPY rdf/ontology/claim_primitive.ttl       /staging/
+COPY rdf/ontology/coherence_ops_core.ttl   /staging/
+COPY rdf/ontology/coherence_ops_extended.ttl /staging/
+
+# Copy sample data and SHACL shapes
+COPY rdf/sample_data/ /staging/sample_data/
+COPY rdf/shapes/      /staging/shapes/
+
+# Create Fuseki dataset config
+COPY <<'FUSEKI_CONF' /fuseki/configuration/deepsigma.ttl
+@prefix :      <#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:  <http://jena.apache.org/2016/tdb#> .
+@prefix ja:    <http://jena.hpl.hp.com/2005/11/Assembler#> .
+
+:service_deepsigma  a fuseki:Service ;
+    fuseki:name          "deepsigma" ;
+    fuseki:endpoint      [ fuseki:operation fuseki:query ;    fuseki:name "sparql" ] ;
+    fuseki:endpoint      [ fuseki:operation fuseki:update ;   fuseki:name "update" ] ;
+    fuseki:endpoint      [ fuseki:operation fuseki:gsp-rw ;   fuseki:name "data" ] ;
+    fuseki:dataset       :dataset_deepsigma .
+
+:dataset_deepsigma  a  tdb2:DatasetTDB2 ;
+    tdb2:location "/fuseki/databases/deepsigma" .
+FUSEKI_CONF
+
+# Load ontology TTL files into the dataset at build time
+USER root
+RUN mkdir -p /fuseki/databases/deepsigma && \
+    /jena/bin/tdb2.tdbloader \
+        --loc /fuseki/databases/deepsigma \
+        /staging/namespaces.ttl \
+        /staging/coherence-ops-ontology.ttl \
+        /staging/claim_primitive.ttl \
+        /staging/coherence_ops_core.ttl \
+        /staging/coherence_ops_extended.ttl && \
+    chown -R 9008:9008 /fuseki/databases/deepsigma
+
+USER 9008
+
+EXPOSE 3030
+
+# Fuseki reads datasets from /fuseki/configuration/
+ENV FUSEKI_DATASET_1=deepsigma


### PR DESCRIPTION
## Summary

Adds `Dockerfile.rdf` — an Apache Jena Fuseki container with all DeepSigma ontology TTL files pre-loaded into a TDB2 dataset at build time.

## Usage

```bash
docker run -p 3030:3030 ghcr.io/8ryanwh1t3/deepsigma-rdf
```

**Endpoints:**
- SPARQL query: `http://localhost:3030/deepsigma/sparql`
- SPARQL update: `http://localhost:3030/deepsigma/update`
- Graph store: `http://localhost:3030/deepsigma/data`
- Admin UI: `http://localhost:3030`

**Example query:**
```bash
curl -X POST http://localhost:3030/deepsigma/sparql \
  -H "Content-Type: application/sparql-query" \
  -H "Accept: application/json" \
  -d "PREFIX co: <https://deepsigma.ai/coherence-ops#>
      SELECT ?class WHERE { ?class a owl:Class } LIMIT 20"
```

## TTL files loaded

- `rdf/coherence-ops-ontology.ttl` — main ontology
- `rdf/namespaces.ttl` — namespace declarations
- `rdf/ontology/claim_primitive.ttl` — claim primitive ontology
- `rdf/ontology/coherence_ops_core.ttl` — core types
- `rdf/ontology/coherence_ops_extended.ttl` — extended vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)