### PR TITLE
CI: langchain-deepsigma PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-langchain.yml
+++ b/.github/workflows/publish-langchain.yml
@@ -1,0 +1,84 @@
+name: Publish — langchain-deepsigma
+
+# Publishes the langchain-deepsigma package to PyPI on version tags (vX.Y.Z)
+# or can be triggered manually for TestPyPI runs.
+#
+# Required GitHub secrets:
+#   LANGCHAIN_PYPI_TOKEN  — PyPI API token scoped to langchain-deepsigma
+#
+# To publish to TestPyPI first:
+#   1. Set LANGCHAIN_TEST_PYPI_TOKEN secret
+#   2. Run workflow manually with test_pypi=true input
+
+on:
+  push:
+    tags:
+      - 'langchain-v*'      # e.g. langchain-v0.2.0
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to TestPyPI instead of PyPI'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    defaults:
+      run:
+        working-directory: packages/langchain-deepsigma
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + dev deps
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short
+
+  build-and-publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC trusted publishing
+    defaults:
+      run:
+        working-directory: packages/langchain-deepsigma
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install --upgrade pip build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        if: github.event.inputs.test_pypi == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: packages/langchain-deepsigma/dist/
+
+      - name: Publish to PyPI
+        if: github.event.inputs.test_pypi != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/langchain-deepsigma/dist/


### PR DESCRIPTION
## Summary

Adds a publish workflow for the `langchain-deepsigma` package (`packages/langchain-deepsigma/`). Uses OIDC trusted publishing — no long-lived API token required.

## How to release

```bash
git tag langchain-v0.2.0
git push origin langchain-v0.2.0
# → triggers test (3.10/3.11/3.12) → build → publish to PyPI
```

**TestPyPI dry run:**
Run the workflow manually from Actions UI with `test_pypi = true`.

## Workflow

1. **test** — `pytest tests/` on Python 3.10, 3.11, 3.12 from `packages/langchain-deepsigma/`
2. **build-and-publish** — `python -m build` → `pypa/gh-action-pypi-publish` (OIDC)

**Tag pattern:** `langchain-v*` (e.g. `langchain-v0.1.0`, `langchain-v0.2.0`)

**Setup needed:** Add `langchain-deepsigma` as a trusted publisher in PyPI project settings pointing to this repo + `publish-langchain.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)