### PR TITLE
Fix CI: ruff E402 in otel sidecar

### DIFF
--- a/adapters/otel/sidecar.py
+++ b/adapters/otel/sidecar.py
@@ -16,17 +16,17 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import time
 from pathlib import Path
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-logger = logging.getLogger(__name__)
-
 # Ensure the app root is importable
-import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from adapters.otel.exporter import OtelExporter  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
 
 DATA_ROOT = Path(os.environ.get("SIDECAR_DATA_DIR", "/app/data"))
 EPISODES_DIR = DATA_ROOT / "episodes"


### PR DESCRIPTION
## Summary
- Moved `import sys` to the top of `adapters/otel/sidecar.py` with other stdlib imports
- Placed `logging.basicConfig()` after the `sys.path` manipulation block
- Fixes the E402 (module-level import not at top of file) that is failing the lint job on main

## Test plan
- [x] `ruff check . --select E,F,W --ignore E501` passes clean locally
- [x] All 287 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)