### PR TITLE
v0.6.0 Connector Contract v1.0 — standardized interface + canonical envelope

### DIFF
--- a/NAV.md
+++ b/NAV.md
@@ -60,7 +60,9 @@ last_updated: "2026-02-18"
 
 | Resource | Purpose |
 |----------|---------|
-| [`specs/`](specs/) | 11 JSON schemas (DLR, drift, episode, DTE, claim, canon, retcon, IRIS, PRIME) |
+| [`specs/`](specs/) | 12 JSON schemas (DLR, drift, episode, DTE, claim, canon, retcon, IRIS, PRIME, connector envelope) |
+| [`specs/connector_contract_v1.md`](specs/connector_contract_v1.md) | Connector Contract v1.0 — standard interface + canonical envelope |
+| [`connectors/`](connectors/) | Connector Contract module — `ConnectorV1` protocol + `RecordEnvelope` |
 | [`llm_data_model/`](llm_data_model/) | LLM-optimized canonical data model (10 sub-directories) |
 | [`rdf/`](rdf/) | RDF/SHACL ontology files |
 | [`primitives/`](primitives/) | Core primitive implementations |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ DeepSigma/
 
 ---
 
-## Connectors (v0.5.0)
+## Connectors (v0.6.0)
+
+All connectors conform to the [Connector Contract v1.0](specs/connector_contract_v1.md) — a standard interface with a canonical Record Envelope for provenance, hashing, and access control.
 
 | Connector | Transport | MCP Tools | Docs |
 |-----------|-----------|-----------|------|

--- a/adapters/asksage/connector.py
+++ b/adapters/asksage/connector.py
@@ -29,7 +29,11 @@ class AskSageConnector:
     - ``ASKSAGE_EMAIL``
     - ``ASKSAGE_API_KEY``
     - ``ASKSAGE_BASE_URL`` (default: ``https://api.asksage.ai``)
+
+    Implements ConnectorV1 contract (v0.6.0+).
     """
+
+    source_name = "asksage"
 
     def __init__(
         self,
@@ -123,6 +127,13 @@ class AskSageConnector:
         payload = {"content": content, "dataset": dataset}
         body = json.dumps(payload).encode()
         return self._post("/server/train", body)
+
+    # ── Envelope contract ──────────────────────────────────────────
+
+    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
+        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+        from connectors.contract import canonical_to_envelope
+        return [canonical_to_envelope(r, source_instance=self._base_url) for r in records]
 
     # ── HTTP helpers ─────────────────────────────────────────────
 

--- a/adapters/powerplatform/connector.py
+++ b/adapters/powerplatform/connector.py
@@ -63,7 +63,11 @@ class DataverseConnector:
     - ``DV_CLIENT_ID``
     - ``DV_CLIENT_SECRET``
     - ``DV_TENANT_ID``
+
+    Implements ConnectorV1 contract (v0.6.0+).
     """
+
+    source_name = "dataverse"
 
     def __init__(
         self,
@@ -106,6 +110,14 @@ class DataverseConnector:
         data = self._dv_get(url)
         rows = data.get("value", [])
         return [self._to_canonical(row, table_name) for row in rows]
+
+    # ── Envelope contract ──────────────────────────────────────────
+
+    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
+        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+        from connectors.contract import canonical_to_envelope
+        env_name = self._env_url.split("//")[-1].split(".")[0] if self._env_url else "unknown"
+        return [canonical_to_envelope(r, source_instance=env_name) for r in records]
 
     # ── Field mapping ────────────────────────────────────────────
 

--- a/adapters/sharepoint/connector.py
+++ b/adapters/sharepoint/connector.py
@@ -44,7 +44,11 @@ class SharePointConnector:
     - ``SP_CLIENT_ID``
     - ``SP_CLIENT_SECRET``
     - ``SP_SITE_ID``
+
+    Implements ConnectorV1 contract (v0.6.0+).
     """
+
+    source_name = "sharepoint"
 
     def __init__(
         self,
@@ -127,6 +131,14 @@ class SharePointConnector:
             "expirationDateTime": expiry,
         }
         return self._graph_post(f"{GRAPH_BASE}/subscriptions", body)
+
+    # ── Envelope contract ──────────────────────────────────────────
+
+    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
+        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+        from connectors.contract import canonical_to_envelope
+        instance = f"{self._site_id}" if self._site_id else "unknown"
+        return [canonical_to_envelope(r, source_instance=instance) for r in records]
 
     # ── Field mapping ────────────────────────────────────────────
 

--- a/adapters/snowflake/warehouse.py
+++ b/adapters/snowflake/warehouse.py
@@ -31,7 +31,11 @@ class SnowflakeWarehouseConnector:
     - ``SNOWFLAKE_DATABASE``
     - ``SNOWFLAKE_SCHEMA`` (default: ``PUBLIC``)
     - ``SNOWFLAKE_WAREHOUSE``
+
+    Implements ConnectorV1 contract (v0.6.0+).
     """
+
+    source_name = "snowflake"
 
     def __init__(self, auth: Optional[SnowflakeAuth] = None) -> None:
         self._auth = auth or SnowflakeAuth()
@@ -57,6 +61,12 @@ class SnowflakeWarehouseConnector:
         sql = f"DESCRIBE TABLE {self._database}.{self._schema}.{table}"
         result = self._execute_statement(sql)
         return self._parse_result(result)
+
+    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
+        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+        from connectors.contract import canonical_to_envelope
+        instance = self._auth.account if self._auth else "unknown"
+        return [canonical_to_envelope(r, source_instance=instance) for r in records]
 
     def to_canonical(self, rows: List[Dict[str, Any]], table_name: str) -> List[Dict[str, Any]]:
         """Transform SQL rows to canonical records."""

--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -1,0 +1,5 @@
+"""Connector Contract v1.0 — standardized interface and canonical envelope."""
+
+from connectors.contract import ConnectorV1, RecordEnvelope, validate_envelope
+
+__all__ = ["ConnectorV1", "RecordEnvelope", "validate_envelope"]

--- a/connectors/contract.py
+++ b/connectors/contract.py
@@ -1,0 +1,203 @@
+"""Connector Contract v1.0 — standard interface + canonical Record Envelope.
+
+Defines the protocol all connectors must satisfy and the RecordEnvelope
+dataclass used to wrap raw source data with provenance, hashes, and metadata.
+
+Usage::
+
+    from connectors.contract import ConnectorV1, RecordEnvelope, validate_envelope
+
+    # Validate an envelope dict against the schema
+    errors = validate_envelope(envelope_dict)
+
+    # Build an envelope programmatically
+    env = RecordEnvelope(
+        source="sharepoint",
+        source_instance="contoso.sharepoint.com",
+        record_id="rec-001",
+        record_type="Document",
+        raw={"title": "Policy v3"},
+    )
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+import jsonschema
+
+# ── Schema path ──────────────────────────────────────────────────────────────
+
+_SCHEMA_DIR = Path(__file__).resolve().parents[1] / "specs"
+_ENVELOPE_SCHEMA_PATH = _SCHEMA_DIR / "connector_envelope.schema.json"
+_ENVELOPE_SCHEMA: Optional[Dict[str, Any]] = None
+
+
+def _load_schema() -> Dict[str, Any]:
+    global _ENVELOPE_SCHEMA
+    if _ENVELOPE_SCHEMA is None:
+        _ENVELOPE_SCHEMA = json.loads(_ENVELOPE_SCHEMA_PATH.read_text())
+    return _ENVELOPE_SCHEMA
+
+
+# ── Protocol ─────────────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class ConnectorV1(Protocol):
+    """Standard connector interface (v1.0).
+
+    All source connectors should implement this protocol. Methods raise
+    ``NotImplementedError`` by default so connectors can opt into the
+    subset they support.
+    """
+
+    @property
+    def source_name(self) -> str:
+        """Canonical source identifier (e.g. ``"sharepoint"``)."""
+        ...
+
+    def list_records(self, **kwargs: Any) -> List[Dict[str, Any]]:
+        """List canonical records from the source."""
+        ...
+
+    def get_record(self, record_id: str, **kwargs: Any) -> Dict[str, Any]:
+        """Get a single canonical record by ID."""
+        ...
+
+    def to_envelopes(self, records: List[Dict[str, Any]]) -> List["RecordEnvelope"]:
+        """Convert canonical records to standardized envelopes."""
+        ...
+
+
+# ── RecordEnvelope ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class RecordEnvelope:
+    """Standardized record envelope for all connectors.
+
+    Wraps raw source data with provenance, hashes, and access control tags.
+    """
+
+    envelope_version: str = "1.0"
+    source: str = ""
+    source_instance: str = ""
+    collected_at: str = ""
+    record_id: str = ""
+    record_type: str = ""
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    hashes: Dict[str, str] = field(default_factory=dict)
+    acl_tags: List[str] = field(default_factory=list)
+    raw: Any = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.collected_at:
+            self.collected_at = datetime.now(timezone.utc).isoformat()
+        if self.raw is not None and "raw_sha256" not in self.hashes:
+            self.hashes["raw_sha256"] = compute_hash(self.raw)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict (JSON-safe)."""
+        return {
+            "envelope_version": self.envelope_version,
+            "source": self.source,
+            "source_instance": self.source_instance,
+            "collected_at": self.collected_at,
+            "record_id": self.record_id,
+            "record_type": self.record_type,
+            "provenance": self.provenance,
+            "hashes": self.hashes,
+            "acl_tags": self.acl_tags,
+            "raw": self.raw,
+            "metadata": self.metadata,
+        }
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def compute_hash(data: Any) -> str:
+    """Deterministic SHA-256 of *data*.
+
+    Strings are encoded directly. Everything else is JSON-serialized
+    with sorted keys before hashing.
+    """
+    if isinstance(data, str):
+        return hashlib.sha256(data.encode()).hexdigest()
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+def validate_envelope(envelope: Dict[str, Any]) -> List[str]:
+    """Validate an envelope dict against the JSON schema.
+
+    Returns a (possibly empty) list of human-readable error strings.
+    """
+    schema = _load_schema()
+    validator = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(validator.iter_errors(envelope), key=str)]
+
+
+def normalize_envelope_fields(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize envelope fields to canonical form (in-place + returned).
+
+    - Ensures ``envelope_version`` is present.
+    - Computes ``hashes.raw_sha256`` if missing and ``raw`` is present.
+    - Ensures ``collected_at`` is ISO-8601 UTC.
+    - Coerces ``acl_tags`` to list.
+    """
+    envelope.setdefault("envelope_version", "1.0")
+    envelope.setdefault("acl_tags", [])
+    envelope.setdefault("metadata", {})
+    envelope.setdefault("hashes", {})
+
+    if isinstance(envelope.get("acl_tags"), str):
+        envelope["acl_tags"] = [envelope["acl_tags"]]
+
+    raw = envelope.get("raw")
+    if raw is not None and "raw_sha256" not in envelope["hashes"]:
+        envelope["hashes"]["raw_sha256"] = compute_hash(raw)
+
+    if not envelope.get("collected_at"):
+        envelope["collected_at"] = datetime.now(timezone.utc).isoformat()
+
+    return envelope
+
+
+def canonical_to_envelope(
+    record: Dict[str, Any],
+    *,
+    source_instance: str = "",
+) -> RecordEnvelope:
+    """Convert an existing canonical record to a RecordEnvelope.
+
+    This is the compatibility bridge — connectors that already produce
+    canonical records can wrap them with a single call.
+    """
+    prov = record.get("provenance", [{}])
+    first_prov = prov[0] if prov else {}
+
+    return RecordEnvelope(
+        source=record.get("source", {}).get("system", ""),
+        source_instance=source_instance,
+        record_id=record.get("record_id", ""),
+        record_type=record.get("record_type", ""),
+        provenance={
+            "uri": first_prov.get("ref", ""),
+            "last_modified": record.get("observed_at", ""),
+            "author": record.get("source", {}).get("actor", {}).get("id", ""),
+        },
+        raw=record,
+        metadata={
+            "confidence": record.get("confidence", {}).get("score"),
+            "ttl": record.get("ttl"),
+            "labels": record.get("labels", {}),
+        },
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ include = [
     "verifiers*",
     "tools*",
     "adapters*",
+    "connectors*",
     "demos*",
 ]
 

--- a/specs/connector_contract_v1.md
+++ b/specs/connector_contract_v1.md
@@ -1,0 +1,198 @@
+# Connector Contract v1.0
+
+**Status:** Normative
+**Version:** 1.0.0
+**Since:** v0.6.0
+
+---
+
+## Overview
+
+Every external data source connector in Sigma OVERWATCH must conform to this contract.
+The contract defines:
+
+1. **A standard interface** (`ConnectorV1` protocol) — consistent method signatures
+2. **A canonical Record Envelope** — uniform wrapper around raw source data
+3. **Pagination, retry, and error expectations** — behavioral guarantees
+4. **Auth handling** — credentials via environment/config, never in fixtures
+
+---
+
+## Interface: ConnectorV1
+
+```python
+class ConnectorV1(Protocol):
+    @property
+    def source_name(self) -> str: ...
+
+    def list_records(self, **kwargs) -> List[Dict]: ...
+    def get_record(self, record_id: str, **kwargs) -> Dict: ...
+    def to_envelopes(self, records: List[Dict]) -> List[RecordEnvelope]: ...
+```
+
+### Methods
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `source_name` | Yes | Canonical source identifier (`"sharepoint"`, `"snowflake"`, etc.) |
+| `list_records(**kwargs)` | Yes | Fetch records from the source. Returns canonical record dicts. |
+| `get_record(record_id)` | Optional | Fetch a single record by ID. |
+| `to_envelopes(records)` | Yes | Wrap canonical records in `RecordEnvelope` instances. |
+
+Connectors that don't support `get_record` should raise `NotImplementedError`.
+
+---
+
+## Record Envelope
+
+Every record flowing through the system is wrapped in a `RecordEnvelope`:
+
+```json
+{
+  "envelope_version": "1.0",
+  "source": "sharepoint",
+  "source_instance": "contoso.sharepoint.com",
+  "collected_at": "2026-02-18T10:00:00+00:00",
+  "record_id": "5f3a7c28-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+  "record_type": "Document",
+  "provenance": {
+    "uri": "sharepoint://contoso.sharepoint.com/sites/ops/lists/Policies/1",
+    "last_modified": "2026-02-15T14:30:00.000Z",
+    "author": "jane.doe@contoso.com"
+  },
+  "hashes": {
+    "raw_sha256": "a1b2c3..."
+  },
+  "acl_tags": ["department:ops"],
+  "raw": { ... },
+  "metadata": { ... }
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `envelope_version` | `"1.0"` | Schema version |
+| `source` | string | Canonical source name |
+| `source_instance` | string | Instance identifier (site URL, account, etc.) |
+| `collected_at` | ISO-8601 | When the record was fetched |
+| `record_id` | string | Unique record identifier |
+| `record_type` | string | `"Document"`, `"Event"`, `"Entity"`, `"Claim"`, `"Metric"` |
+| `provenance.uri` | string | Source URI with scheme |
+| `hashes.raw_sha256` | hex string | SHA-256 of the `raw` field |
+| `raw` | object or string | The raw source data |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provenance.etag` | string | Source version identifier |
+| `provenance.last_modified` | string | Source last-modified timestamp |
+| `provenance.author` | string | Author or last modifier |
+| `hashes.normalized_sha256` | hex string | SHA-256 of normalized form |
+| `acl_tags` | string[] | Access control tags |
+| `metadata` | object | Connector-specific metadata |
+
+### JSON Schema
+
+See: [`specs/connector_envelope.schema.json`](connector_envelope.schema.json)
+
+---
+
+## Envelope Lifecycle
+
+```
+Source API Response (raw JSON)
+    │
+    ▼
+Connector._to_canonical(raw)          ← existing behavior (unchanged)
+    │
+    ▼
+Canonical Record (Dict)               ← what Golden Path/pipeline uses
+    │
+    ▼
+Connector.to_envelopes(records)       ← NEW: wraps in envelope
+    │
+    ▼
+RecordEnvelope                        ← standardized, hashable, auditable
+```
+
+Existing code that consumes canonical records continues to work unchanged.
+The envelope is an additive layer for audit, drift detection, and lineage tracking.
+
+---
+
+## Pagination Contract
+
+Connectors that support pagination must:
+
+1. Accept `cursor` or `offset`/`limit` kwargs in `list_records()`
+2. Return all results when no pagination args are provided (default behavior)
+3. Include `next_cursor` in response metadata when more pages exist
+
+Pagination is optional — connectors may return all results in a single call.
+
+---
+
+## Retry and Backoff
+
+Connectors should:
+
+1. Retry transient failures (HTTP 429, 503, network timeouts) up to 3 times
+2. Use exponential backoff: 1s, 2s, 4s (or honor `Retry-After` headers)
+3. Raise `ConnectorError` (or subclass) for non-retryable failures
+
+This is a behavioral expectation, not enforced in the protocol.
+
+---
+
+## Rate Limiting
+
+Connectors should:
+
+1. Respect source rate limits (HTTP 429 with `Retry-After`)
+2. Expose rate-limit state in metadata when available
+3. Never retry more than 3 times on rate-limit responses
+
+---
+
+## Error Model
+
+| Error Type | Retryable | Description |
+|-----------|-----------|-------------|
+| `ConnectorAuthError` | No | Authentication/authorization failure |
+| `ConnectorRateLimitError` | Yes | Rate limit exceeded |
+| `ConnectorTimeoutError` | Yes | Request timed out |
+| `ConnectorNotFoundError` | No | Resource not found |
+| `ConnectorError` | Depends | Base error class |
+
+---
+
+## Auth Handling
+
+- Credentials are provided via environment variables or constructor kwargs
+- Fixture mode bypasses authentication entirely
+- No secrets are ever stored in fixture files
+- Each connector documents its required env vars
+
+| Connector | Env Vars |
+|-----------|----------|
+| SharePoint | `SP_TENANT_ID`, `SP_CLIENT_ID`, `SP_CLIENT_SECRET`, `SP_SITE_ID` |
+| Dataverse | `DV_ENVIRONMENT_URL`, `DV_CLIENT_ID`, `DV_CLIENT_SECRET`, `DV_TENANT_ID` |
+| AskSage | `ASKSAGE_EMAIL`, `ASKSAGE_API_KEY` |
+| Snowflake | `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PRIVATE_KEY_PATH` |
+
+---
+
+## Validation
+
+```python
+from connectors.contract import validate_envelope
+
+errors = validate_envelope(envelope_dict)
+if errors:
+    print(f"Invalid envelope: {errors}")
+```
+
+Envelopes are validated against `specs/connector_envelope.schema.json`.

--- a/specs/connector_envelope.schema.json
+++ b/specs/connector_envelope.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deepsigma.dev/schemas/connector_envelope/v1.0",
+  "title": "Connector Record Envelope v1.0",
+  "description": "Standardized envelope wrapping raw source data with provenance, hashes, and metadata. All connectors must produce records conforming to this schema.",
+  "type": "object",
+  "required": [
+    "envelope_version",
+    "source",
+    "source_instance",
+    "collected_at",
+    "record_id",
+    "record_type",
+    "provenance",
+    "hashes",
+    "raw"
+  ],
+  "properties": {
+    "envelope_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Schema version. Must be '1.0' for this version of the contract."
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical source identifier (e.g. 'sharepoint', 'snowflake', 'dataverse', 'asksage')."
+    },
+    "source_instance": {
+      "type": "string",
+      "description": "Instance identifier (e.g. site URL, account name, environment URL). May be empty for singleton sources."
+    },
+    "collected_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp when the record was collected/fetched."
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the record within the source."
+    },
+    "record_type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical record type (e.g. 'Document', 'Event', 'Entity', 'Claim', 'Metric')."
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source URI (e.g. 'sharepoint://site/list/item', 'snowflake://account/db.schema.table/pk')."
+        },
+        "etag": {
+          "type": "string",
+          "description": "ETag or version identifier from the source system."
+        },
+        "last_modified": {
+          "type": "string",
+          "description": "Last modification timestamp from the source."
+        },
+        "author": {
+          "type": "string",
+          "description": "Author or last modifier identifier."
+        }
+      },
+      "additionalProperties": false
+    },
+    "hashes": {
+      "type": "object",
+      "required": ["raw_sha256"],
+      "properties": {
+        "raw_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "SHA-256 hex digest of the raw field content."
+        },
+        "normalized_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "SHA-256 hex digest of the normalized/canonical form."
+        }
+      },
+      "additionalProperties": false
+    },
+    "acl_tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Access control tags for RBAC filtering."
+    },
+    "raw": {
+      "description": "The raw source data. May be a JSON object or a string.",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "string" }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "default": {},
+      "description": "Arbitrary connector-specific metadata (confidence, TTL, labels, etc.)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_connector_contract_v1.py
+++ b/tests/test_connector_contract_v1.py
@@ -1,0 +1,316 @@
+"""Tests for the Connector Contract v1.0 — schema, envelope, and connector compliance."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from connectors.contract import (
+    RecordEnvelope,
+    canonical_to_envelope,
+    compute_hash,
+    normalize_envelope_fields,
+    validate_envelope,
+)
+
+FIXTURE_DIR = Path(__file__).parent.parent / "demos" / "golden_path" / "fixtures" / "sharepoint_small"
+
+
+# ── RecordEnvelope Tests ─────────────────────────────────────────────────────
+
+
+class TestRecordEnvelope:
+    def test_default_values(self):
+        env = RecordEnvelope(source="test", record_id="r1", record_type="Document")
+        assert env.envelope_version == "1.0"
+        assert env.source == "test"
+        assert env.collected_at  # auto-populated
+
+    def test_auto_hash(self):
+        env = RecordEnvelope(source="test", record_id="r1", record_type="Document", raw={"a": 1})
+        assert "raw_sha256" in env.hashes
+        assert len(env.hashes["raw_sha256"]) == 64
+
+    def test_deterministic_hash(self):
+        raw = {"key": "value", "nested": {"a": 1}}
+        e1 = RecordEnvelope(source="s", record_id="r", record_type="T", raw=raw, collected_at="2026-01-01T00:00:00Z")
+        e2 = RecordEnvelope(source="s", record_id="r", record_type="T", raw=raw, collected_at="2026-01-01T00:00:00Z")
+        assert e1.hashes["raw_sha256"] == e2.hashes["raw_sha256"]
+
+    def test_to_dict(self):
+        env = RecordEnvelope(source="test", record_id="r1", record_type="Doc", raw="hello")
+        d = env.to_dict()
+        assert isinstance(d, dict)
+        assert d["source"] == "test"
+        assert d["record_id"] == "r1"
+        assert d["raw"] == "hello"
+
+    def test_to_dict_all_fields(self):
+        env = RecordEnvelope(
+            source="test",
+            source_instance="inst",
+            record_id="r1",
+            record_type="Doc",
+            raw={"a": 1},
+            acl_tags=["admin"],
+            metadata={"key": "val"},
+        )
+        d = env.to_dict()
+        for key in ("envelope_version", "source", "source_instance", "collected_at",
+                     "record_id", "record_type", "provenance", "hashes", "acl_tags",
+                     "raw", "metadata"):
+            assert key in d, f"Missing key: {key}"
+
+
+# ── compute_hash Tests ───────────────────────────────────────────────────────
+
+
+class TestComputeHash:
+    def test_string_hash(self):
+        h = compute_hash("hello")
+        assert len(h) == 64
+        assert h == compute_hash("hello")
+
+    def test_dict_hash(self):
+        h = compute_hash({"b": 2, "a": 1})
+        assert h == compute_hash({"a": 1, "b": 2})  # sorted keys
+
+    def test_different_data(self):
+        assert compute_hash("a") != compute_hash("b")
+
+
+# ── validate_envelope Tests ──────────────────────────────────────────────────
+
+
+class TestValidateEnvelope:
+    def test_valid_envelope(self):
+        env = RecordEnvelope(
+            source="sharepoint",
+            source_instance="site-1",
+            record_id="r1",
+            record_type="Document",
+            provenance={"uri": "sharepoint://site/list/1"},
+            raw={"title": "Test"},
+        )
+        errors = validate_envelope(env.to_dict())
+        assert errors == [], f"Unexpected errors: {errors}"
+
+    def test_missing_required_fields(self):
+        errors = validate_envelope({})
+        assert len(errors) > 0
+
+    def test_missing_source(self):
+        env = RecordEnvelope(record_id="r1", record_type="Doc", raw={"a": 1})
+        env.source = ""
+        d = env.to_dict()
+        errors = validate_envelope(d)
+        assert len(errors) > 0  # empty source violates minLength
+
+    def test_missing_provenance_uri(self):
+        d = RecordEnvelope(
+            source="test",
+            source_instance="inst",
+            record_id="r1",
+            record_type="Doc",
+            provenance={},
+            raw={"a": 1},
+        ).to_dict()
+        errors = validate_envelope(d)
+        assert any("uri" in e.lower() for e in errors)
+
+    def test_invalid_hash_format(self):
+        d = RecordEnvelope(
+            source="test",
+            source_instance="inst",
+            record_id="r1",
+            record_type="Doc",
+            provenance={"uri": "test://a"},
+            raw={"a": 1},
+        ).to_dict()
+        d["hashes"]["raw_sha256"] = "not-a-sha256"
+        errors = validate_envelope(d)
+        assert len(errors) > 0
+
+
+# ── normalize_envelope_fields Tests ──────────────────────────────────────────
+
+
+class TestNormalizeEnvelopeFields:
+    def test_adds_defaults(self):
+        d = {"source": "test", "record_id": "r1", "record_type": "Doc", "raw": {"a": 1}}
+        result = normalize_envelope_fields(d)
+        assert result["envelope_version"] == "1.0"
+        assert result["acl_tags"] == []
+        assert result["metadata"] == {}
+        assert "raw_sha256" in result["hashes"]
+
+    def test_coerce_acl_tags_string(self):
+        d = {"acl_tags": "admin"}
+        normalize_envelope_fields(d)
+        assert d["acl_tags"] == ["admin"]
+
+    def test_preserves_existing(self):
+        d = {"envelope_version": "1.0", "acl_tags": ["x"], "hashes": {"raw_sha256": "abc" * 21 + "a"}, "metadata": {"k": "v"}}
+        normalize_envelope_fields(d)
+        assert d["acl_tags"] == ["x"]
+        assert d["metadata"] == {"k": "v"}
+
+
+# ── canonical_to_envelope Tests ──────────────────────────────────────────────
+
+
+class TestCanonicalToEnvelope:
+    def _load_records(self):
+        return json.loads((FIXTURE_DIR / "baseline.json").read_text())
+
+    def test_converts_sharepoint_record(self):
+        records = self._load_records()
+        env = canonical_to_envelope(records[0], source_instance="contoso")
+        assert env.source == "sharepoint"
+        assert env.source_instance == "contoso"
+        assert env.record_id == records[0]["record_id"]
+        assert env.record_type == "Document"
+        assert env.raw == records[0]
+        assert "raw_sha256" in env.hashes
+
+    def test_envelope_validates(self):
+        records = self._load_records()
+        for rec in records:
+            env = canonical_to_envelope(rec, source_instance="contoso")
+            errors = validate_envelope(env.to_dict())
+            assert errors == [], f"Validation errors for {rec['record_id']}: {errors}"
+
+    def test_all_fixture_records_valid(self):
+        records = self._load_records()
+        for rec in records:
+            env = canonical_to_envelope(rec, source_instance="contoso")
+            d = env.to_dict()
+            assert d["source"] == rec["source"]["system"]
+            assert d["record_id"] == rec["record_id"]
+            assert d["record_type"] == rec["record_type"]
+
+    def test_provenance_uri(self):
+        records = self._load_records()
+        env = canonical_to_envelope(records[0])
+        assert "sharepoint://" in env.provenance["uri"]
+
+    def test_metadata_includes_confidence(self):
+        records = self._load_records()
+        env = canonical_to_envelope(records[0])
+        assert env.metadata["confidence"] == 0.85
+
+    def test_hash_stability(self):
+        records = self._load_records()
+        e1 = canonical_to_envelope(records[0], source_instance="x")
+        e2 = canonical_to_envelope(records[0], source_instance="x")
+        assert e1.hashes["raw_sha256"] == e2.hashes["raw_sha256"]
+
+
+# ── Connector to_envelopes Tests ────────────────────────────────────────────
+
+
+class TestConnectorToEnvelopes:
+    def _load_fixture_records(self):
+        return json.loads((FIXTURE_DIR / "baseline.json").read_text())
+
+    def test_sharepoint_to_envelopes(self):
+        from unittest.mock import patch, MagicMock
+        from adapters.sharepoint.connector import SharePointConnector
+
+        with patch.object(SharePointConnector, "__init__", lambda self, **kw: None):
+            c = SharePointConnector.__new__(SharePointConnector)
+            c._site_id = "site-123"
+            c._delta_tokens = {}
+            c._auth = MagicMock()
+            c._tenant_id = "t"
+            c._client_id = "c"
+            c._client_secret = "s"
+
+        records = self._load_fixture_records()
+        envs = c.to_envelopes(records)
+        assert len(envs) == 5
+        for env in envs:
+            errors = validate_envelope(env.to_dict())
+            assert errors == [], f"Validation failed: {errors}"
+        assert envs[0].source == "sharepoint"
+        assert envs[0].source_instance == "site-123"
+
+    def test_dataverse_to_envelopes(self):
+        from unittest.mock import patch, MagicMock
+        from adapters.powerplatform.connector import DataverseConnector
+
+        with patch.object(DataverseConnector, "__init__", lambda self, **kw: None):
+            c = DataverseConnector.__new__(DataverseConnector)
+            c._env_url = "https://org.crm.dynamics.com"
+            c._auth = MagicMock()
+            c._client_id = "c"
+            c._client_secret = "s"
+            c._tenant_id = "t"
+
+        records = self._load_fixture_records()
+        envs = c.to_envelopes(records)
+        assert len(envs) == 5
+        for env in envs:
+            errors = validate_envelope(env.to_dict())
+            assert errors == [], f"Validation failed: {errors}"
+
+    def test_snowflake_to_envelopes(self):
+        from unittest.mock import patch, MagicMock
+        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
+
+        with patch.object(SnowflakeWarehouseConnector, "__init__", lambda self, **kw: None):
+            c = SnowflakeWarehouseConnector.__new__(SnowflakeWarehouseConnector)
+            c._auth = MagicMock()
+            c._auth.account = "acme-account"
+            c._database = "DB"
+            c._schema = "PUBLIC"
+            c._warehouse = "WH"
+
+        records = self._load_fixture_records()
+        envs = c.to_envelopes(records)
+        assert len(envs) == 5
+        for env in envs:
+            errors = validate_envelope(env.to_dict())
+            assert errors == [], f"Validation failed: {errors}"
+
+    def test_asksage_to_envelopes(self):
+        from unittest.mock import patch
+        from adapters.asksage.connector import AskSageConnector
+
+        with patch.object(AskSageConnector, "__init__", lambda self, **kw: None):
+            c = AskSageConnector.__new__(AskSageConnector)
+            c._base_url = "https://api.asksage.ai"
+            c._email = ""
+            c._api_key = ""
+            c._cached_token = None
+            c._token_expiry = 0.0
+
+        records = self._load_fixture_records()
+        envs = c.to_envelopes(records)
+        assert len(envs) == 5
+        for env in envs:
+            errors = validate_envelope(env.to_dict())
+            assert errors == [], f"Validation failed: {errors}"
+
+
+# ── Source name attribute Tests ──────────────────────────────────────────────
+
+
+class TestSourceNameAttribute:
+    def test_sharepoint(self):
+        from adapters.sharepoint.connector import SharePointConnector
+        assert SharePointConnector.source_name == "sharepoint"
+
+    def test_dataverse(self):
+        from adapters.powerplatform.connector import DataverseConnector
+        assert DataverseConnector.source_name == "dataverse"
+
+    def test_asksage(self):
+        from adapters.asksage.connector import AskSageConnector
+        assert AskSageConnector.source_name == "asksage"
+
+    def test_snowflake(self):
+        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
+        assert SnowflakeWarehouseConnector.source_name == "snowflake"


### PR DESCRIPTION
## Summary
- Introduces `ConnectorV1` protocol + `RecordEnvelope` dataclass as the standard interface all source connectors must satisfy
- Adds `specs/connector_envelope.schema.json` — JSON schema for the canonical record envelope (provenance, hashes, ACL tags, raw data)
- Adds `specs/connector_contract_v1.md` — normative spec covering interface, pagination, retry/backoff, rate limits, error model, auth handling
- All 4 connectors (SharePoint, Dataverse, AskSage, Snowflake) gain `source_name` attribute + `to_envelopes()` method — **additive, zero behavior change** to existing code
- 30 new tests validate schema compliance, hash stability, and envelope round-trips for all connectors

## File Tree
```
NEW:
  connectors/__init__.py
  connectors/contract.py          ← Protocol + RecordEnvelope + validate/normalize/bridge
  specs/connector_envelope.schema.json
  specs/connector_contract_v1.md
  tests/test_connector_contract_v1.py

MODIFIED (additive):
  adapters/sharepoint/connector.py      ← +source_name, +to_envelopes()
  adapters/powerplatform/connector.py   ← +source_name, +to_envelopes()
  adapters/asksage/connector.py         ← +source_name, +to_envelopes()
  adapters/snowflake/warehouse.py       ← +source_name, +to_envelopes()
  pyproject.toml                        ← +connectors* to package find
  NAV.md                                ← Connector Contract links
  README.md                             ← "Connectors are contract-driven" note
```

## Test plan
- [x] 30 new tests in `test_connector_contract_v1.py` pass
- [x] 33 existing golden path tests still pass
- [x] Lint clean (ruff)
- [ ] CI matrix (Python 3.10/3.11/3.12) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)