### PR TITLE
feat(v0.6.4): add stage 2 simulated credibility engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Demo Dashboard** (`dashboard/credibility-engine-demo/`): Static 7-panel cockpit surface — Credibility Index, Tier 0 claims, drift activity, correlation risk, TTL timeline, Sync Plane integrity, credibility packet generator. Vanilla HTML/CSS/JS, no frameworks. Mock JSON calibrated to 36,000-node production lattice
 - `README.md`: Added demo link to Progressive Escalation section
 
+### Added — Stage 2 Simulated Credibility Engine
+
+- **Simulation Harness** (`sim/credibility-engine/`): Tick-based engine (2-second intervals, 15 sim-min/tick) that overwrites dashboard JSON atomically. Models: claims, correlation clusters, sync regions, drift fingerprints
+- **4 Scenarios**: Day0 (stable baseline, CI 94–97), Day1 (entropy, CI 85–90), Day2 (coordinated darkness, CI 65–75), Day3 (external mismatch + recovery, CI 45–60)
+- **Credibility Packet Generator**: Live DLR/RS/DS/MG summaries with narrative reasoning and sealed hash chain
+- **Dashboard auto-refresh**: 2-second polling added to `app.js` for live simulation visualization
+- **Hot-swap scenarios**: Drop `scenario.json` in dashboard directory to switch scenarios at runtime
+
 ### Stats (Credibility Engine addition)
 
-- 11 new files + 11 demo files, 4 modified, 0 new tests (documentation-only), 2 new Mermaid diagrams
+- 11 new files + 11 demo files + 6 simulation files, 4 modified, 0 new tests (documentation-only), 2 new Mermaid diagrams
 
 ## [0.6.3] — 2026-02-19 — "Excel-first Hardening"
 

--- a/NAV.md
+++ b/NAV.md
@@ -94,6 +94,7 @@ last_updated: "2026-02-18"
 |----------|---------|
 | [`dashboard/`](dashboard/) | React dashboard UI + mock data + server API |
 | [`dashboard/src/TrustScorecardPanel.tsx`](dashboard/src/TrustScorecardPanel.tsx) | Trust Scorecard dashboard panel |
+| [`dashboard/credibility-engine-demo/`](dashboard/credibility-engine-demo/) | Credibility Engine Demo Cockpit — 7-panel static/live dashboard |
 
 ---
 
@@ -183,6 +184,7 @@ last_updated: "2026-02-18"
 | [`examples/03-credibility-engine-scale/`](examples/03-credibility-engine-scale/) | Credibility Engine at Scale — 30k–40k nodes, survivability |
 | [`mermaid/38-lattice-architecture.md`](mermaid/38-lattice-architecture.md) | Lattice architecture diagram |
 | [`mermaid/39-drift-loop.md`](mermaid/39-drift-loop.md) | Institutional drift loop diagram |
+| [`sim/credibility-engine/`](sim/credibility-engine/) | Stage 2 Simulation — tick-based engine driving live dashboard |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Same primitives. Same artifacts. Same loop. Different scale.
 > Examples: [Mini Lattice](examples/01-mini-lattice/) · [Enterprise Lattice](examples/02-enterprise-lattice/) · [Credibility Engine Scale](examples/03-credibility-engine-scale/) · [Full docs](docs/credibility-engine/)
 >
 > Demo: [Credibility Engine Cockpit](dashboard/credibility-engine-demo/) — static dashboard, 7 panels, 30 seconds to institutional state
+>
+> Stage 2: [Simulated Engine](sim/credibility-engine/) — live simulation driver, 4 scenarios (Day0–Day3), 2-second ticks
 
 ---
 
@@ -80,6 +82,26 @@ At 12 nodes, a human can trace every dependency. At 500, hidden correlations eme
 | **Seal authority matters** | No single region should control institutional truth. Authority distribution (no region >40%) prevents capture. |
 
 At every scale, the same question: **can the institution trust its own assertions right now?** The Credibility Index answers it with a number. The Drift→Patch→Seal loop keeps that number honest.
+
+---
+
+## Stage 2 — Simulated Credibility Engine
+
+Run the simulation driver to power the dashboard with live synthetic data:
+
+```bash
+# Terminal 1: Start simulation (Day0 = stable baseline)
+python sim/credibility-engine/runner.py --scenario day0
+
+# Terminal 2: Serve dashboard
+python -m http.server 8000
+```
+
+Visit: [http://localhost:8000/dashboard/credibility-engine-demo/](http://localhost:8000/dashboard/credibility-engine-demo/)
+
+Four scenarios model progressive institutional entropy: Day0 (stable), Day1 (entropy emerges), Day2 (coordinated darkness), Day3 (external mismatch + recovery). The dashboard updates every 2 seconds.
+
+> [Simulation docs](sim/credibility-engine/) · [Dashboard](dashboard/credibility-engine-demo/)
 
 ---
 

--- a/dashboard/credibility-engine-demo/app.js
+++ b/dashboard/credibility-engine-demo/app.js
@@ -423,4 +423,9 @@
 
   /* ── Boot ── */
   loadAll();
+
+  /* ── Auto-refresh for simulation mode ── */
+  setInterval(function () {
+    loadAll().catch(function () { /* ignore refresh errors */ });
+  }, 2000);
 })();

--- a/sim/credibility-engine/README.md
+++ b/sim/credibility-engine/README.md
@@ -1,0 +1,145 @@
+---
+title: "Credibility Engine Simulation"
+version: "1.0.0"
+status: "Stage 2"
+last_updated: "2026-02-19"
+---
+
+# Credibility Engine — Stage 2 Simulation
+
+A time-driven simulation harness that powers the [Credibility Engine Demo Cockpit](../../dashboard/credibility-engine-demo/) with live synthetic data.
+
+---
+
+## What This Is
+
+Stage 2 converts the static demo dashboard into a live simulation. The runner advances the engine every 2 seconds, producing drift events, compressing quorum margins, increasing correlation coefficients, decaying TTL windows, and degrading sync plane integrity. The dashboard auto-refreshes to reflect the changing state.
+
+This is **not** a production engine. It is a simulation of institutional-scale truth maintenance dynamics.
+
+---
+
+## How to Run
+
+**Terminal 1 — Start the simulation:**
+
+```bash
+python sim/credibility-engine/runner.py --scenario day0
+```
+
+**Terminal 2 — Serve the dashboard:**
+
+```bash
+python -m http.server 8000
+```
+
+Then visit: [http://localhost:8000/dashboard/credibility-engine-demo/](http://localhost:8000/dashboard/credibility-engine-demo/)
+
+The dashboard will update every 2 seconds as the simulation writes new JSON snapshots.
+
+---
+
+## Scenarios
+
+| Scenario | Description | Index Range | Key Events |
+|----------|-------------|-------------|------------|
+| `day0` | Baseline — stable lattice | 94–97 | Minimal drift, healthy quorum, low correlation |
+| `day1` | Entropy emerges | 85–90 | Drift increases, CG-002 crosses REVIEW, quorum compresses |
+| `day2` | Coordinated darkness | 65–75 | Silent nodes, Tier 0 flips UNKNOWN, sync watermark lag |
+| `day3` | External mismatch + recovery | 45–60 then partial recovery | CRITICAL correlation, replay flags, patch-driven recovery |
+
+### Switch scenarios:
+
+```bash
+# Run with a specific scenario
+python sim/credibility-engine/runner.py --scenario day2
+
+# Or hot-swap during runtime by creating scenario.json in the dashboard dir:
+echo '{"scenario": "day3"}' > dashboard/credibility-engine-demo/scenario.json
+```
+
+---
+
+## Arguments
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--scenario` | `day0` | Scenario to run: `day0`, `day1`, `day2`, `day3` |
+| `--interval` | `2` | Seconds between ticks |
+| `--output-dir` | `dashboard/credibility-engine-demo/` | Where to write JSON snapshots |
+
+---
+
+## Architecture
+
+```
+sim/credibility-engine/
+├── runner.py      — CLI entrypoint, tick loop, atomic file writes
+├── engine.py      — Simulation engine: state management, tick logic, JSON export
+├── models.py      — Data models: Claim, CorrelationCluster, SyncRegion, DriftFingerprint
+├── scenarios.py   — Day0–Day3 scenario phase definitions
+├── packet.py      — Credibility Packet generator (DLR/RS/DS/MG + seal)
+└── README.md      — This file
+```
+
+### Tick Lifecycle
+
+Each tick (2 real seconds = 15 simulated minutes):
+
+1. Decrement TTL remaining on all claims
+2. Inject drift events (rate + severity from scenario phase)
+3. Adjust correlation coefficients toward phase targets
+4. Apply claim effects (margin compression, status changes)
+5. Update sync plane metrics (skew, lag, replays)
+6. Recalculate Credibility Index (6 components)
+7. Generate Credibility Packet (DLR + RS + DS + MG + seal)
+8. Write all 7 JSON files atomically
+
+### Index Calculation
+
+```
+Index = base(60) + integrity + drift_penalty + correlation_penalty
+        + quorum_penalty + ttl_penalty + confirmation_bonus
+```
+
+Clamped to 0–100.
+
+### Atomic Writes
+
+All JSON files are written atomically: write to temp file, then `os.replace()` to target. This prevents the dashboard from reading partial files.
+
+---
+
+## Output Files
+
+Written to `dashboard/credibility-engine-demo/` each tick:
+
+| File | Content |
+|------|---------|
+| `credibility_snapshot.json` | Index score, band, trend, 6 components |
+| `claims_tier0.json` | 5 Tier 0 claims with quorum and TTL |
+| `drift_events_24h.json` | Accumulated events, severity, categories, fingerprints |
+| `correlation_map.json` | 6 clusters with live coefficients |
+| `ttl_timeline.json` | 4-hour expiration forecast |
+| `sync_integrity.json` | 3 regions + federation health |
+| `credibility_packet_example.json` | Sealed DLR/RS/DS/MG assessment |
+
+---
+
+## Guardrails
+
+- Abstract institutional credibility architecture only
+- No real-world weapon modeling
+- No operational defense content
+- No external API dependencies
+- Fully local simulation
+- All data is synthetic
+
+---
+
+## Related
+
+- [Credibility Engine Docs](../../docs/credibility-engine/)
+- [Demo Cockpit](../../dashboard/credibility-engine-demo/)
+- [Credibility Index Specification](../../docs/credibility-engine/credibility_index.md)
+- [Lattice Architecture Diagram](../../mermaid/38-lattice-architecture.md)

--- a/sim/credibility-engine/engine.py
+++ b/sim/credibility-engine/engine.py
@@ -1,0 +1,621 @@
+"""Credibility Engine Simulation - Tick-based Engine.
+
+Maintains simulation state and advances it each tick based on
+scenario phase parameters.  Produces JSON-compatible snapshots
+for all 7 dashboard data files.
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta, timezone
+
+from models import (
+    Claim,
+    CorrelationCluster,
+    DriftFingerprint,
+    SyncRegion,
+    make_baseline_claims,
+    make_baseline_clusters,
+    make_baseline_fingerprints,
+    make_baseline_sync,
+)
+from scenarios import SCENARIOS
+
+# Each tick advances sim time by 15 minutes.
+SIM_STEP = timedelta(minutes=15)
+
+
+class CredibilityEngine:
+    """Tick-based credibility engine simulation."""
+
+    def __init__(self, scenario_name: str = "day0") -> None:
+        self.scenario_name = scenario_name
+        self.scenario = SCENARIOS[scenario_name]
+        self.tick_num = 0
+        self.sim_time = datetime.now(timezone.utc)
+
+        # State
+        self.claims: list[Claim] = make_baseline_claims()
+        self.clusters: list[CorrelationCluster] = make_baseline_clusters()
+        self.sync_regions: list[SyncRegion] = make_baseline_sync()
+        self.fingerprints: list[DriftFingerprint] = make_baseline_fingerprints()
+
+        # Index components
+        self.integrity = 42
+        self.drift_penalty = 0
+        self.correlation_penalty = 0
+        self.quorum_penalty = 0
+        self.ttl_penalty = 0
+        self.confirmation_bonus = 5
+
+        # Drift accumulation
+        self.drift_total = 0
+        self.drift_by_severity = {"low": 0, "medium": 0, "high": 0, "critical": 0}
+        self.drift_by_category = {
+            "timing_entropy": 0, "correlation_drift": 0,
+            "confidence_volatility": 0, "ttl_compression": 0,
+            "external_mismatch": 0,
+        }
+        self.drift_by_region = {"East": 0, "Central": 0, "West": 0}
+        self.drift_auto_resolved = 0
+        self.drift_pending = 0
+        self.drift_escalated = 0
+        self.drift_hourly: list[int] = [0] * 24
+
+        # Trend history (last 5 index values)
+        self.trend_history: list[int] = []
+
+        # Seal chain tracking
+        self.seal_chain_length = 157
+        self.patches_applied = 0
+        self.seals_created = 0
+        self.nodes_added = 0
+        self.edges_added = 0
+        self.nodes_modified = 0
+
+    # -- Phase resolution ------------------------------------------------------
+
+    def _current_phase(self) -> dict:
+        """Find the active phase for the current tick."""
+        for phase in self.scenario["phases"]:
+            if phase["start"] <= self.tick_num <= phase["end"]:
+                return phase
+        return self.scenario["phases"][-1]
+
+    # -- Tick -------------------------------------------------------------------
+
+    def tick(self) -> None:
+        """Advance the simulation by one tick."""
+        phase = self._current_phase()
+        self.tick_num += 1
+        self.sim_time += SIM_STEP
+
+        self._decay_ttl(phase)
+        self._inject_drift(phase)
+        self._adjust_correlations(phase)
+        self._apply_claim_effects(phase)
+        self._update_sync(phase)
+        self._recalculate_index(phase)
+        self._update_trend()
+        self._track_operations(phase)
+
+    # -- Subsystem updates -----------------------------------------------------
+
+    def _decay_ttl(self, phase: dict) -> None:
+        """Decrement TTL remaining on all claims."""
+        decay = int(15 * phase.get("ttl_decay_multiplier", 1.0))
+        for claim in self.claims:
+            claim.ttl_remaining_minutes = max(0, claim.ttl_remaining_minutes - decay)
+            # Refresh TTL if still verified and TTL gets low
+            if (claim.status == "VERIFIED"
+                    and claim.ttl_remaining_minutes < 30
+                    and claim.claim_id not in phase.get("claim_effects", {})):
+                claim.ttl_remaining_minutes = claim.ttl_minutes
+                claim.last_verified = self.sim_time.isoformat().replace("+00:00", "Z")
+
+    def _inject_drift(self, phase: dict) -> None:
+        """Add drift events for this tick."""
+        rate = phase["drift_rate"]
+        count = max(0, rate + random.randint(-2, 2))
+
+        sev_weights = phase["severity_weights"]
+        cat_weights = phase["category_weights"]
+        sevs = ["low", "medium", "high", "critical"]
+        cats = list(self.drift_by_category.keys())
+        regions = ["East", "Central", "West"]
+
+        auto_resolve_rate = 0.92 if phase.get("patch_active", True) else 0.40
+
+        for _ in range(count):
+            sev = random.choices(sevs, weights=sev_weights, k=1)[0]
+            cat = random.choices(cats, weights=cat_weights, k=1)[0]
+            reg = random.choice(regions)
+
+            self.drift_total += 1
+            self.drift_by_severity[sev] += 1
+            self.drift_by_category[cat] += 1
+            self.drift_by_region[reg] += 1
+
+            if random.random() < auto_resolve_rate:
+                self.drift_auto_resolved += 1
+            elif random.random() < 0.7:
+                self.drift_pending += 1
+            else:
+                self.drift_escalated += 1
+
+        # Update hourly distribution (slot = sim hour mod 24)
+        hour_slot = int((self.sim_time.hour + self.sim_time.minute / 60)) % 24
+        self.drift_hourly[hour_slot] += count
+
+        # Update fingerprint recurrence
+        fp_escalation = phase.get("fingerprint_escalation", {})
+        for fp in self.fingerprints:
+            if random.random() < 0.3:
+                fp.recurrence_count += random.randint(0, 2)
+            if fp.fingerprint in fp_escalation:
+                esc = fp_escalation[fp.fingerprint]
+                fp.severity = esc["severity"]
+                fp.auto_resolved = esc["auto_resolved"]
+
+    def _adjust_correlations(self, phase: dict) -> None:
+        """Move correlation coefficients toward scenario targets."""
+        targets = phase["correlation_targets"]
+        speed = phase.get("correlation_drift_speed", 0.01)
+
+        for cluster in self.clusters:
+            target = targets.get(cluster.cluster_id, cluster.coefficient)
+            diff = target - cluster.coefficient
+            if abs(diff) < 0.005:
+                cluster.coefficient = target
+            else:
+                jitter = random.uniform(-0.005, 0.005)
+                cluster.coefficient += diff * speed / max(abs(diff), speed) + jitter
+                cluster.coefficient = max(0.0, min(1.0, cluster.coefficient))
+
+    def _apply_claim_effects(self, phase: dict) -> None:
+        """Apply scenario-driven claim state changes."""
+        effects = phase.get("claim_effects", {})
+        for claim in self.claims:
+            if claim.claim_id in effects:
+                eff = effects[claim.claim_id]
+                # Status
+                claim.status = eff.get("status", claim.status)
+                # Confidence
+                if "confidence_target" in eff:
+                    target = eff["confidence_target"]
+                    if target is None:
+                        claim.confidence = None
+                    elif claim.confidence is not None:
+                        diff = target - claim.confidence
+                        claim.confidence += diff * 0.15
+                        claim.confidence = round(claim.confidence, 2)
+                    else:
+                        claim.confidence = target
+                # Margin
+                if "margin_target" in eff:
+                    target = eff["margin_target"]
+                    if claim.margin > target:
+                        claim.margin = max(target, claim.margin - 1)
+                    elif claim.margin < target:
+                        claim.margin = min(target, claim.margin + 1)
+                # Correlation groups
+                if "correlation_groups_actual" in eff:
+                    claim.correlation_groups_actual = eff["correlation_groups_actual"]
+                # Out of band
+                if "out_of_band_present" in eff:
+                    claim.out_of_band_present = eff["out_of_band_present"]
+                # Degradation reason
+                if "degradation_reason" in eff:
+                    claim.degradation_reason = eff["degradation_reason"]
+                # Update last_verified for active claims
+                if claim.status == "VERIFIED":
+                    claim.last_verified = (
+                        self.sim_time.isoformat().replace("+00:00", "Z")
+                    )
+            else:
+                # Claims not under pressure stay healthy
+                if claim.status == "DEGRADED" and claim.claim_id not in effects:
+                    pass  # Keep current state unless scenario says otherwise
+
+        # Auto-evaluate quorum: if margin <= 0 and status isn't already UNKNOWN
+        for claim in self.claims:
+            if claim.margin <= 0 and claim.status != "UNKNOWN":
+                if claim.claim_id in effects and effects[claim.claim_id].get("status") == "UNKNOWN":
+                    claim.status = "UNKNOWN"
+                    claim.confidence = None
+            # TTL expiry forces UNKNOWN
+            if claim.ttl_remaining_minutes <= 0 and claim.status == "VERIFIED":
+                if claim.claim_id not in effects:
+                    claim.ttl_remaining_minutes = claim.ttl_minutes
+                    claim.last_verified = (
+                        self.sim_time.isoformat().replace("+00:00", "Z")
+                    )
+
+    def _update_sync(self, phase: dict) -> None:
+        """Move sync plane metrics toward scenario targets."""
+        targets = phase.get("sync_targets", {})
+        speed = phase.get("sync_drift_speed", 1.0)
+
+        for sr in self.sync_regions:
+            if sr.region not in targets:
+                continue
+            t = targets[sr.region]
+
+            # Time skew
+            diff = t["skew"] - sr.time_skew_ms
+            sr.time_skew_ms += int(diff * min(speed * 0.1, 1.0))
+            sr.time_skew_ms = max(0, sr.time_skew_ms + random.randint(-2, 2))
+
+            # Watermark lag
+            diff_lag = t["lag"] - sr.watermark_lag_s
+            sr.watermark_lag_s += diff_lag * min(speed * 0.1, 1.0)
+            sr.watermark_lag_s = max(0.1, sr.watermark_lag_s + random.uniform(-0.1, 0.1))
+
+            # Replay flags
+            target_replays = t["replays"]
+            if sr.replay_flags_count < target_replays:
+                if random.random() < 0.3:
+                    sr.replay_flags_count += 1
+            elif sr.replay_flags_count > target_replays:
+                if random.random() < 0.2:
+                    sr.replay_flags_count = max(0, sr.replay_flags_count - 1)
+
+            # Nodes down
+            target_down = t.get("nodes_down", 0)
+            sr.sync_nodes_healthy = sr.sync_nodes - target_down
+
+            # Watermark advancing if lag < critical
+            sr.watermark_advancing = sr.watermark_lag_s < 30
+
+            # Update timestamp
+            sr.last_watermark = self.sim_time.isoformat().replace("+00:00", "Z")
+
+            # Warning detail
+            if sr.status == "WARN":
+                issues = []
+                if sr.time_skew_ms > 100:
+                    issues.append(f"time skew {sr.time_skew_ms}ms")
+                if sr.replay_flags_count > 0:
+                    issues.append(
+                        f"{sr.replay_flags_count} replay flag(s)")
+                if sr.sync_nodes_healthy < sr.sync_nodes:
+                    issues.append(
+                        f"{sr.sync_nodes - sr.sync_nodes_healthy} sync node(s) degraded")
+                sr.warning_detail = " — ".join(issues) if issues else None
+            elif sr.status == "CRITICAL":
+                issues = []
+                if sr.time_skew_ms > 500:
+                    issues.append(f"CRITICAL time skew {sr.time_skew_ms}ms")
+                if sr.replay_flags_count >= 5:
+                    issues.append(
+                        f"{sr.replay_flags_count} replay flags — backfill suspected")
+                if sr.watermark_lag_s > 30:
+                    issues.append(f"watermark stalled ({sr.watermark_lag_s:.1f}s lag)")
+                sr.warning_detail = " — ".join(issues) if issues else None
+            else:
+                sr.warning_detail = None
+
+    def _recalculate_index(self, phase: dict) -> None:
+        """Recalculate all Credibility Index components.
+
+        Uses rate-based drift penalty (current phase severity, not
+        accumulated totals) to prevent runaway penalty growth.
+        """
+        # Integrity — moves toward phase target
+        target_int = phase.get("integrity_target", 37)
+        diff = target_int - self.integrity
+        self.integrity += int(diff * 0.15) + (1 if diff > 0 else -1 if diff < 0 else 0)
+        self.integrity = max(0, min(50, self.integrity))
+
+        # Drift penalty — rate-based (current phase severity profile)
+        rate = phase["drift_rate"]
+        sev = phase["severity_weights"]
+        self.drift_penalty = -int(
+            rate * (sev[3] * 6 + sev[2] * 2 + sev[1] * 0.3)
+        )
+        self.drift_penalty = max(-15, self.drift_penalty)
+
+        # Correlation penalty — based on current cluster coefficients
+        max_coeff = max(c.coefficient for c in self.clusters)
+        review_count = sum(1 for c in self.clusters if c.coefficient > 0.7)
+        critical_count_corr = sum(1 for c in self.clusters if c.coefficient > 0.9)
+        self.correlation_penalty = -(
+            critical_count_corr * 3 + review_count * 1
+            + int(max(0, max_coeff - 0.6) * 5)
+        )
+        self.correlation_penalty = max(-12, self.correlation_penalty)
+
+        # Quorum penalty — based on current claim margins
+        unknown_count = sum(1 for c in self.claims if c.status == "UNKNOWN")
+        margin_1_count = sum(
+            1 for c in self.claims
+            if c.margin == 1 and c.status != "UNKNOWN"
+        )
+        self.quorum_penalty = -(unknown_count * 2 + margin_1_count * 1)
+        self.quorum_penalty = max(-10, self.quorum_penalty)
+
+        # TTL penalty — based on expired or near-expired claims
+        expired_count = sum(
+            1 for c in self.claims if c.ttl_remaining_minutes <= 0
+        )
+        near_expired = sum(
+            1 for c in self.claims if 0 < c.ttl_remaining_minutes <= 30
+        )
+        self.ttl_penalty = -(expired_count * 2 + near_expired * 1)
+        self.ttl_penalty = max(-6, self.ttl_penalty)
+
+        # Confirmation bonus
+        self.confirmation_bonus = phase.get("confirmation_bonus", 3)
+
+    def _update_trend(self) -> None:
+        """Track rolling index history."""
+        score = self.credibility_index
+        self.trend_history.append(score)
+        if len(self.trend_history) > 5:
+            self.trend_history = self.trend_history[-5:]
+
+    def _track_operations(self, phase: dict) -> None:
+        """Track operational metrics for packet generation."""
+        if phase.get("patch_active", True):
+            new_patches = random.randint(1, 4)
+            self.patches_applied += new_patches
+            self.seals_created += random.randint(0, new_patches)
+        self.nodes_added += random.randint(1, 5)
+        self.edges_added += random.randint(2, 8)
+        self.nodes_modified += random.randint(0, 3)
+        self.seal_chain_length += 1
+
+    # -- Computed properties ---------------------------------------------------
+
+    @property
+    def credibility_index(self) -> int:
+        base = 60
+        score = (
+            base + self.integrity + self.drift_penalty
+            + self.correlation_penalty + self.quorum_penalty
+            + self.ttl_penalty + self.confirmation_bonus
+        )
+        return max(0, min(100, score))
+
+    @property
+    def index_band(self) -> str:
+        s = self.credibility_index
+        if s >= 95:
+            return "Stable"
+        if s >= 85:
+            return "Minor Drift"
+        if s >= 70:
+            return "Elevated Risk"
+        if s >= 50:
+            return "Structural Degradation"
+        return "Compromised"
+
+    @property
+    def index_band_color(self) -> str:
+        s = self.credibility_index
+        if s >= 95:
+            return "green"
+        if s >= 85:
+            return "yellow"
+        return "red"
+
+    @property
+    def auto_patch_rate(self) -> float:
+        if self.drift_total == 0:
+            return 1.0
+        return round(self.drift_auto_resolved / max(self.drift_total, 1), 2)
+
+    @property
+    def active_drift_signals(self) -> int:
+        return sum(
+            1 for fp in self.fingerprints if not fp.auto_resolved
+        )
+
+    # -- Scenario switching ----------------------------------------------------
+
+    def set_scenario(self, scenario_name: str) -> None:
+        """Switch to a different scenario without resetting state."""
+        if scenario_name in SCENARIOS:
+            self.scenario_name = scenario_name
+            self.scenario = SCENARIOS[scenario_name]
+            self.tick_num = 0
+
+    # -- JSON snapshot export --------------------------------------------------
+
+    def snapshot_credibility(self) -> dict:
+        """Produce credibility_snapshot.json."""
+        labels = ["T-4", "T-3", "T-2", "T-1", "Now"]
+        history = self.trend_history[-5:]
+        while len(history) < 5:
+            history.insert(0, history[0] if history else self.credibility_index)
+
+        return {
+            "index_score": self.credibility_index,
+            "index_band": self.index_band,
+            "index_band_color": self.index_band_color,
+            "trend_points": list(history),
+            "trend_labels": labels,
+            "last_updated": self.sim_time.isoformat().replace("+00:00", "Z"),
+            "total_nodes": 36000,
+            "regions": 3,
+            "active_drift_signals": self.active_drift_signals,
+            "auto_patch_rate": self.auto_patch_rate,
+            "bands": [
+                {"range": "95\u2013100", "label": "Stable", "action": "Monitor"},
+                {"range": "85\u201394", "label": "Minor Drift",
+                 "action": "Review flagged claims"},
+                {"range": "70\u201384", "label": "Elevated Risk",
+                 "action": "Patch required"},
+                {"range": "50\u201369", "label": "Structural Degradation",
+                 "action": "Immediate remediation"},
+                {"range": "<50", "label": "Compromised",
+                 "action": "Halt dependent decisions"},
+            ],
+            "components": {
+                "tier_weighted_integrity": self.integrity,
+                "drift_penalty": self.drift_penalty,
+                "correlation_risk": self.correlation_penalty,
+                "quorum_margin": self.quorum_penalty,
+                "ttl_expiration": self.ttl_penalty,
+                "confirmation_bonus": self.confirmation_bonus,
+                "base": 60,
+            },
+        }
+
+    def snapshot_claims(self) -> dict:
+        """Produce claims_tier0.json."""
+        return {
+            "tier": 0,
+            "total_count": 200,
+            "claims": [c.to_dict() for c in self.claims],
+        }
+
+    def snapshot_drift(self) -> dict:
+        """Produce drift_events_24h.json."""
+        window_end = self.sim_time
+        window_start = window_end - timedelta(hours=24)
+
+        # Derive top fingerprints sorted by recurrence
+        sorted_fps = sorted(
+            self.fingerprints,
+            key=lambda f: f.recurrence_count,
+            reverse=True,
+        )
+
+        return {
+            "window": "24h",
+            "window_start": window_start.isoformat().replace("+00:00", "Z"),
+            "window_end": window_end.isoformat().replace("+00:00", "Z"),
+            "total_count": self.drift_total,
+            "by_severity": dict(self.drift_by_severity),
+            "by_category": dict(self.drift_by_category),
+            "by_region": dict(self.drift_by_region),
+            "auto_resolved": self.drift_auto_resolved,
+            "pending_review": self.drift_pending,
+            "escalated": self.drift_escalated,
+            "top_fingerprints": [fp.to_dict() for fp in sorted_fps[:5]],
+            "hourly_distribution": list(self.drift_hourly),
+        }
+
+    def snapshot_correlation(self) -> dict:
+        """Produce correlation_map.json."""
+        return {
+            "clusters": [c.to_dict() for c in self.clusters],
+            "thresholds": {
+                "ok_max": 0.7,
+                "review_max": 0.9,
+                "critical_min": 0.9,
+            },
+        }
+
+    def snapshot_ttl(self) -> dict:
+        """Produce ttl_timeline.json."""
+        # Generate TTL buckets based on current state
+        base_expiring = max(100, 342 + self.tick_num * 3)
+        phase = self._current_phase()
+        multiplier = phase.get("ttl_decay_multiplier", 1.0)
+
+        buckets = []
+        bucket_defs = [
+            ("0\u201330min", 0.13),
+            ("30\u201360min", 0.21),
+            ("1\u20132h", 0.35),
+            ("2\u20134h", 0.31),
+        ]
+        total_expiring = 0
+        for label, frac in bucket_defs:
+            count = int(base_expiring * frac * min(multiplier, 3.0))
+            count = max(1, count + random.randint(-3, 3))
+            total_expiring += count
+
+            # Distribute by tier
+            t0 = max(0, int(count * 0.04) + random.randint(0, 2))
+            t1 = int(count * 0.35)
+            t2 = int(count * 0.38)
+            t3 = count - t0 - t1 - t2
+
+            # Distribute by region
+            east = int(count * 0.32)
+            central = int(count * 0.38)
+            west = count - east - central
+
+            buckets.append({
+                "bucket": label,
+                "count": count,
+                "by_tier": {"0": t0, "1": t1, "2": t2, "3": t3},
+                "by_region": {"East": east, "Central": central, "West": west},
+            })
+
+        # Tier 0 expirations from actual claim state
+        tier0_exp = []
+        for claim in self.claims:
+            if claim.ttl_remaining_minutes <= 60:
+                tier0_exp.append({
+                    "evidence_id": f"EV-{claim.domain}-{random.randint(100, 9999):04d}",
+                    "claim_id": claim.claim_id,
+                    "ttl_remaining_minutes": max(0, claim.ttl_remaining_minutes),
+                    "source": f"S-{claim.domain}-{random.randint(1, 20):03d}",
+                    "region": claim.region,
+                })
+
+        clustering = multiplier > 1.5 or len(tier0_exp) > 1
+        clustering_desc = ""
+        if clustering:
+            clustering_desc = (
+                f"{random.randint(40, 120)} Tier 1 evidence nodes expire "
+                f"within a 15-minute window at T+{random.randint(1, 3)}h"
+                f"{random.randint(0, 59):02d}m"
+            )
+
+        return {
+            "window": "next_4h",
+            "total_evidence_nodes": 9500,
+            "expiring_within_window": total_expiring,
+            "clustering_warning": clustering,
+            "clustering_description": clustering_desc,
+            "upcoming_expirations": buckets,
+            "tier_0_expirations": tier0_exp,
+        }
+
+    def snapshot_sync(self) -> dict:
+        """Produce sync_integrity.json."""
+        # Compute federation skew
+        max_skew = max(sr.time_skew_ms for sr in self.sync_regions)
+        min_skew = min(sr.time_skew_ms for sr in self.sync_regions)
+        cross_skew = max_skew - min_skew + random.randint(0, 10)
+
+        fed_status = "OK" if cross_skew < 200 else "WARN"
+        if cross_skew > 500:
+            fed_status = "CRITICAL"
+
+        return {
+            "regions": [sr.to_dict() for sr in self.sync_regions],
+            "federation": {
+                "cross_region_skew_ms": cross_skew,
+                "max_acceptable_skew_ms": 200,
+                "status": fed_status,
+            },
+            "thresholds": {
+                "time_skew_warn_ms": 100,
+                "time_skew_critical_ms": 500,
+                "watermark_lag_warn_s": 5,
+                "watermark_lag_critical_s": 30,
+                "replay_warn_count": 1,
+                "replay_critical_count": 5,
+            },
+        }
+
+    def all_snapshots(self) -> dict[str, dict]:
+        """Return all 7 JSON snapshots keyed by filename (no extension)."""
+        return {
+            "credibility_snapshot": self.snapshot_credibility(),
+            "claims_tier0": self.snapshot_claims(),
+            "drift_events_24h": self.snapshot_drift(),
+            "correlation_map": self.snapshot_correlation(),
+            "ttl_timeline": self.snapshot_ttl(),
+            "sync_integrity": self.snapshot_sync(),
+        }

--- a/sim/credibility-engine/models.py
+++ b/sim/credibility-engine/models.py
@@ -1,0 +1,330 @@
+"""Credibility Engine Simulation - Data Models.
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Claim:
+    """Tier 0 claim in the credibility lattice."""
+
+    claim_id: str
+    title: str
+    status: str  # VERIFIED | DEGRADED | UNKNOWN
+    confidence: float | None
+    k_required: int
+    n_total: int
+    margin: int
+    ttl_minutes: int
+    ttl_remaining_minutes: int
+    correlation_groups_required: int
+    correlation_groups_actual: int
+    out_of_band_required: bool
+    out_of_band_present: bool
+    region: str
+    domain: str
+    last_verified: str
+    degradation_reason: str | None = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "claim_id": self.claim_id,
+            "title": self.title,
+            "status": self.status,
+            "confidence": self.confidence,
+            "k_required": self.k_required,
+            "n_total": self.n_total,
+            "margin": self.margin,
+            "ttl_minutes": self.ttl_minutes,
+            "ttl_remaining_minutes": max(0, self.ttl_remaining_minutes),
+            "correlation_groups_required": self.correlation_groups_required,
+            "correlation_groups_actual": self.correlation_groups_actual,
+            "out_of_band_required": self.out_of_band_required,
+            "out_of_band_present": self.out_of_band_present,
+            "region": self.region,
+            "domain": self.domain,
+            "last_verified": self.last_verified,
+        }
+        if self.degradation_reason:
+            d["degradation_reason"] = self.degradation_reason
+        return d
+
+
+@dataclass
+class CorrelationCluster:
+    """Correlation cluster tracking shared-source risk."""
+
+    cluster_id: str
+    label: str
+    sources: list[str]
+    coefficient: float
+    claims_affected: int
+    domains: list[str]
+    regions: list[str]
+
+    @property
+    def status(self) -> str:
+        if self.coefficient > 0.9:
+            return "CRITICAL"
+        if self.coefficient > 0.7:
+            return "REVIEW"
+        return "OK"
+
+    @property
+    def risk_level(self) -> str:
+        if self.coefficient > 0.9:
+            return "high"
+        if self.coefficient > 0.7:
+            return "medium"
+        return "low"
+
+    def to_dict(self) -> dict:
+        return {
+            "cluster_id": self.cluster_id,
+            "label": self.label,
+            "sources": list(self.sources),
+            "coefficient": round(self.coefficient, 2),
+            "status": self.status,
+            "claims_affected": self.claims_affected,
+            "domains": list(self.domains),
+            "regions": list(self.regions),
+            "risk_level": self.risk_level,
+        }
+
+
+@dataclass
+class SyncRegion:
+    """Sync plane region health."""
+
+    region: str
+    sync_nodes: int
+    sync_nodes_healthy: int
+    beacons: int
+    beacons_healthy: int
+    time_skew_ms: int
+    watermark_lag_s: float
+    watermark_advancing: bool
+    replay_flags_count: int
+    last_watermark: str
+    warning_detail: str | None = None
+
+    @property
+    def status(self) -> str:
+        if (self.time_skew_ms > 500 or self.watermark_lag_s > 30
+                or self.replay_flags_count >= 5):
+            return "CRITICAL"
+        if (self.time_skew_ms > 100 or self.watermark_lag_s > 5
+                or self.replay_flags_count >= 1):
+            return "WARN"
+        return "OK"
+
+    def to_dict(self) -> dict:
+        d = {
+            "region": self.region,
+            "sync_nodes": self.sync_nodes,
+            "sync_nodes_healthy": self.sync_nodes_healthy,
+            "beacons": self.beacons,
+            "beacons_healthy": self.beacons_healthy,
+            "time_skew_ms": self.time_skew_ms,
+            "watermark_lag_s": round(self.watermark_lag_s, 1),
+            "watermark_advancing": self.watermark_advancing,
+            "replay_flags_count": self.replay_flags_count,
+            "last_watermark": self.last_watermark,
+            "status": self.status,
+        }
+        if self.warning_detail:
+            d["warning_detail"] = self.warning_detail
+        return d
+
+
+@dataclass
+class DriftFingerprint:
+    """Recurring drift pattern fingerprint."""
+
+    fingerprint: str
+    description: str
+    recurrence_count: int
+    tier_impact: int
+    severity: str
+    auto_resolved: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "fingerprint": self.fingerprint,
+            "description": self.description,
+            "recurrence_count": self.recurrence_count,
+            "tier_impact": self.tier_impact,
+            "severity": self.severity,
+            "auto_resolved": self.auto_resolved,
+        }
+
+
+# -- Baseline factories -------------------------------------------------------
+
+def make_baseline_claims() -> list[Claim]:
+    """Create the 5 Tier 0 claims matching the dashboard schema."""
+    return [
+        Claim(
+            claim_id="CLM-T0-001",
+            title="Primary institutional readiness assertion",
+            status="VERIFIED", confidence=0.94,
+            k_required=3, n_total=5, margin=2,
+            ttl_minutes=240, ttl_remaining_minutes=185,
+            correlation_groups_required=2, correlation_groups_actual=3,
+            out_of_band_required=True, out_of_band_present=True,
+            region="East", domain="E1",
+            last_verified="2026-02-19T17:30:00Z",
+        ),
+        Claim(
+            claim_id="CLM-T0-002",
+            title="Cross-regional coordination integrity",
+            status="VERIFIED", confidence=0.88,
+            k_required=4, n_total=6, margin=2,
+            ttl_minutes=120, ttl_remaining_minutes=95,
+            correlation_groups_required=2, correlation_groups_actual=2,
+            out_of_band_required=True, out_of_band_present=True,
+            region="Central", domain="C2",
+            last_verified="2026-02-19T17:45:00Z",
+        ),
+        Claim(
+            claim_id="CLM-T0-003",
+            title="External compliance attestation",
+            status="VERIFIED", confidence=0.90,
+            k_required=3, n_total=4, margin=2,
+            ttl_minutes=60, ttl_remaining_minutes=45,
+            correlation_groups_required=2, correlation_groups_actual=2,
+            out_of_band_required=True, out_of_band_present=True,
+            region="West", domain="W2",
+            last_verified="2026-02-19T17:50:00Z",
+        ),
+        Claim(
+            claim_id="CLM-T0-004",
+            title="Infrastructure continuity baseline",
+            status="VERIFIED", confidence=0.96,
+            k_required=3, n_total=7, margin=4,
+            ttl_minutes=480, ttl_remaining_minutes=410,
+            correlation_groups_required=2, correlation_groups_actual=4,
+            out_of_band_required=True, out_of_band_present=True,
+            region="East", domain="E3",
+            last_verified="2026-02-19T18:20:00Z",
+        ),
+        Claim(
+            claim_id="CLM-T0-005",
+            title="Decision authority chain validation",
+            status="VERIFIED", confidence=0.91,
+            k_required=3, n_total=5, margin=2,
+            ttl_minutes=360, ttl_remaining_minutes=220,
+            correlation_groups_required=2, correlation_groups_actual=3,
+            out_of_band_required=True, out_of_band_present=True,
+            region="Central", domain="C1",
+            last_verified="2026-02-19T17:55:00Z",
+        ),
+    ]
+
+
+def make_baseline_clusters() -> list[CorrelationCluster]:
+    """Create the 6 correlation clusters matching the dashboard schema."""
+    return [
+        CorrelationCluster(
+            cluster_id="CG-001", label="Internal Sensors (East)",
+            sources=["S-001", "S-004", "S-008"], coefficient=0.42,
+            claims_affected=15, domains=["E1", "E2"], regions=["East"],
+        ),
+        CorrelationCluster(
+            cluster_id="CG-002", label="Shared Infrastructure (East + Central)",
+            sources=["S-003", "S-007", "S-012"], coefficient=0.55,
+            claims_affected=28, domains=["E2", "C1", "C2"],
+            regions=["East", "Central"],
+        ),
+        CorrelationCluster(
+            cluster_id="CG-003", label="Cross-Region API Feed",
+            sources=["S-CR-017", "S-CR-022"], coefficient=0.48,
+            claims_affected=18, domains=["E3", "C2", "W1"],
+            regions=["East", "Central", "West"],
+        ),
+        CorrelationCluster(
+            cluster_id="CG-004", label="Compliance Feeds (West)",
+            sources=["S-006", "S-010"], coefficient=0.34,
+            claims_affected=10, domains=["W2"], regions=["West"],
+        ),
+        CorrelationCluster(
+            cluster_id="CG-005", label="Central Primary (Central)",
+            sources=["S-011", "S-013", "S-014", "S-019"], coefficient=0.45,
+            claims_affected=22, domains=["C1", "C3", "C4"],
+            regions=["Central"],
+        ),
+        CorrelationCluster(
+            cluster_id="CG-006", label="Reference Data (All Regions)",
+            sources=["S-015", "S-016"], coefficient=0.38,
+            claims_affected=8, domains=["E1", "C1", "W1"],
+            regions=["East", "Central", "West"],
+        ),
+    ]
+
+
+def make_baseline_sync() -> list[SyncRegion]:
+    """Create 3 sync plane regions matching the dashboard schema."""
+    return [
+        SyncRegion(
+            region="East", sync_nodes=5, sync_nodes_healthy=5,
+            beacons=2, beacons_healthy=2, time_skew_ms=12,
+            watermark_lag_s=0.8, watermark_advancing=True,
+            replay_flags_count=0,
+            last_watermark="2026-02-19T18:44:30Z",
+        ),
+        SyncRegion(
+            region="Central", sync_nodes=5, sync_nodes_healthy=5,
+            beacons=2, beacons_healthy=2, time_skew_ms=18,
+            watermark_lag_s=1.2, watermark_advancing=True,
+            replay_flags_count=0,
+            last_watermark="2026-02-19T18:44:12Z",
+        ),
+        SyncRegion(
+            region="West", sync_nodes=4, sync_nodes_healthy=4,
+            beacons=2, beacons_healthy=2, time_skew_ms=8,
+            watermark_lag_s=0.5, watermark_advancing=True,
+            replay_flags_count=0,
+            last_watermark="2026-02-19T18:44:45Z",
+        ),
+    ]
+
+
+def make_baseline_fingerprints() -> list[DriftFingerprint]:
+    """Create baseline drift fingerprints."""
+    return [
+        DriftFingerprint(
+            fingerprint="TTL-BATCH-EXPIRE-T1",
+            description="Tier 1 evidence batch TTL expiration",
+            recurrence_count=0, tier_impact=1,
+            severity="low", auto_resolved=True,
+        ),
+        DriftFingerprint(
+            fingerprint="CONF-VOLATILITY-C2",
+            description="Confidence oscillation in Central Domain C2",
+            recurrence_count=0, tier_impact=0,
+            severity="medium", auto_resolved=True,
+        ),
+        DriftFingerprint(
+            fingerprint="CORR-DRIFT-S003",
+            description="Cross-region correlation drift from Source-S003",
+            recurrence_count=0, tier_impact=0,
+            severity="medium", auto_resolved=True,
+        ),
+        DriftFingerprint(
+            fingerprint="TIMING-LAG-WEST",
+            description="Ingestion lag variance in West region feeds",
+            recurrence_count=0, tier_impact=2,
+            severity="low", auto_resolved=True,
+        ),
+        DriftFingerprint(
+            fingerprint="SYNC-BEACON-SKEW",
+            description="Beacon-W2 time skew exceeding 200ms",
+            recurrence_count=0, tier_impact=1,
+            severity="low", auto_resolved=True,
+        ),
+    ]

--- a/sim/credibility-engine/packet.py
+++ b/sim/credibility-engine/packet.py
@@ -1,0 +1,320 @@
+"""Credibility Engine Simulation - Credibility Packet Generator.
+
+Produces credibility_packet_example.json matching the dashboard schema.
+Each packet includes DLR, RS, DS, MG summaries and a seal.
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine import CredibilityEngine
+
+
+def generate_packet(engine: CredibilityEngine) -> dict:
+    """Generate a complete credibility packet from current engine state."""
+    now = engine.sim_time
+    ts = now.isoformat().replace("+00:00", "Z")
+    packet_id = f"CP-{now.strftime('%Y-%m-%d-%H%M')}"
+
+    # -- DLR summary -----------------------------------------------------------
+    findings = _build_findings(engine)
+
+    dlr = {
+        "dlr_id": f"DLR-{packet_id}",
+        "title": "Credibility Packet \u2014 Institutional State Assessment",
+        "decided_by": "credibility-engine (automated)",
+        "decision_type": "assessment",
+        "key_findings": findings,
+    }
+
+    # -- RS summary ------------------------------------------------------------
+    rs = {
+        "rs_id": f"RS-{packet_id}",
+        "reasoning": _build_reasoning(engine),
+    }
+
+    # -- DS summary ------------------------------------------------------------
+    ds = _build_ds(engine, packet_id)
+
+    # -- MG summary ------------------------------------------------------------
+    mg = {
+        "mg_id": f"MG-{packet_id}",
+        "changes_last_24h": {
+            "nodes_added": engine.nodes_added,
+            "edges_added": engine.edges_added,
+            "nodes_modified": engine.nodes_modified,
+            "drift_signals_created": engine.drift_total,
+            "patches_applied": engine.patches_applied,
+            "seals_created": engine.seals_created,
+        },
+    }
+
+    # -- Seal ------------------------------------------------------------------
+    seal_input = f"{packet_id}:{ts}:{engine.credibility_index}"
+    seal_hash = hashlib.sha256(seal_input.encode()).hexdigest()[:40]
+
+    seal = {
+        "sealed": True,
+        "seal_hash": f"sha256:{seal_hash}",
+        "sealed_at": ts,
+        "sealed_by": "credibility-engine-sim",
+        "role": "Coherence Steward",
+        "hash_chain_length": engine.seal_chain_length,
+    }
+
+    return {
+        "packet_id": packet_id,
+        "generated_at": ts,
+        "generated_by": "credibility-engine-sim",
+        "credibility_index": {
+            "score": engine.credibility_index,
+            "band": engine.index_band,
+            "components": {
+                "tier_weighted_integrity": engine.integrity,
+                "drift_penalty": engine.drift_penalty,
+                "correlation_risk": engine.correlation_penalty,
+                "quorum_margin": engine.quorum_penalty,
+                "ttl_expiration": engine.ttl_penalty,
+                "confirmation_bonus": engine.confirmation_bonus,
+            },
+        },
+        "dlr_summary": dlr,
+        "rs_summary": rs,
+        "ds_summary": ds,
+        "mg_summary": mg,
+        "seal": seal,
+        "guardrails": {
+            "abstract_model": True,
+            "domain_specific": False,
+            "description": (
+                "Simulation-generated credibility packet. "
+                "Abstract institutional architecture. "
+                "No real-world system modeled."
+            ),
+        },
+    }
+
+
+# -- Internal helpers ----------------------------------------------------------
+
+def _build_findings(engine: CredibilityEngine) -> list[str]:
+    """Generate DLR key findings from engine state."""
+    findings = [
+        f"Credibility Index at {engine.credibility_index} "
+        f"({engine.index_band}) \u2014 "
+        f"{'within healthy production band' if engine.credibility_index >= 85 else 'below healthy production band'}"
+    ]
+
+    unknown_claims = [c for c in engine.claims if c.status == "UNKNOWN"]
+    if unknown_claims:
+        ids = ", ".join(c.claim_id for c in unknown_claims)
+        findings.append(
+            f"{len(unknown_claims)} Tier 0 claim(s) in UNKNOWN state: {ids}"
+        )
+
+    degraded_claims = [c for c in engine.claims if c.status == "DEGRADED"]
+    if degraded_claims:
+        ids = ", ".join(c.claim_id for c in degraded_claims)
+        findings.append(
+            f"{len(degraded_claims)} Tier 0 claim(s) DEGRADED: {ids}"
+        )
+
+    critical_clusters = [
+        c for c in engine.clusters if c.coefficient > 0.9
+    ]
+    if critical_clusters:
+        for cc in critical_clusters:
+            findings.append(
+                f"Correlation cluster {cc.cluster_id} ({cc.label}) "
+                f"at {cc.coefficient:.2f} \u2014 CRITICAL"
+            )
+
+    findings.append(
+        f"{engine.drift_total} drift events accumulated \u2014 "
+        f"{engine.auto_patch_rate:.0%} auto-resolved, "
+        f"{engine.drift_escalated} escalated"
+    )
+
+    return findings
+
+
+def _build_reasoning(engine: CredibilityEngine) -> dict:
+    """Generate RS reasoning narrative from engine state."""
+    idx = engine.credibility_index
+    band = engine.index_band
+
+    if idx >= 85:
+        assessment = (
+            "Lattice is operationally healthy with "
+            f"Credibility Index at {idx} ({band}). "
+            "Localized drift signals are within expected bounds."
+        )
+    elif idx >= 70:
+        assessment = (
+            f"Lattice is under elevated stress. "
+            f"Credibility Index at {idx} ({band}). "
+            "Multiple subsystems showing degradation. "
+            "Coordinated response required."
+        )
+    elif idx >= 50:
+        assessment = (
+            f"Lattice is in structural degradation. "
+            f"Credibility Index at {idx} ({band}). "
+            "Multiple Tier 0 claims compromised. "
+            "Dependent decisions should be suspended pending recovery."
+        )
+    else:
+        assessment = (
+            f"Lattice integrity compromised. "
+            f"Credibility Index at {idx} ({band}). "
+            "Institutional truth maintenance has failed. "
+            "All dependent decisions must halt. "
+            "Full recovery protocol required."
+        )
+
+    # Primary risk
+    worst_cluster = max(engine.clusters, key=lambda c: c.coefficient)
+    if worst_cluster.coefficient > 0.9:
+        primary = (
+            f"{worst_cluster.cluster_id} ({worst_cluster.label}) "
+            f"correlation at {worst_cluster.coefficient:.2f} \u2014 "
+            f"affects {worst_cluster.claims_affected} claims across "
+            f"{', '.join(worst_cluster.regions)}. "
+            "Structural redundancy illusion."
+        )
+    elif worst_cluster.coefficient > 0.7:
+        primary = (
+            f"{worst_cluster.cluster_id} ({worst_cluster.label}) "
+            f"correlation at {worst_cluster.coefficient:.2f} approaching "
+            "critical threshold. Monitor closely."
+        )
+    else:
+        primary = "No immediate correlation risk. All clusters below review threshold."
+
+    # Secondary risk
+    unknown_claims = [c for c in engine.claims if c.status == "UNKNOWN"]
+    if unknown_claims:
+        c = unknown_claims[0]
+        secondary = (
+            f"{c.claim_id} in UNKNOWN state \u2014 "
+            f"{c.degradation_reason or 'quorum broken'}"
+        )
+    else:
+        degraded = [c for c in engine.claims if c.status == "DEGRADED"]
+        if degraded:
+            c = degraded[0]
+            secondary = (
+                f"{c.claim_id} DEGRADED with margin {c.margin} \u2014 "
+                f"{c.degradation_reason or 'confidence below threshold'}"
+            )
+        else:
+            secondary = "No claim-level risks identified."
+
+    # Recommendation
+    if idx >= 85:
+        recommendation = (
+            "Continue monitoring. "
+            "Review flagged drift fingerprints on next rotation."
+        )
+    elif idx >= 70:
+        recommendation = (
+            "Prioritize correlation mitigation for clusters in REVIEW state. "
+            "Restore quorum margin on compressed claims. "
+            "Investigate sync plane anomalies."
+        )
+    elif idx >= 50:
+        recommendation = (
+            "Activate remediation protocol. "
+            "Restore Tier 0 quorum before allowing dependent decisions. "
+            "Isolate correlated failure domains. "
+            "Engage sync plane recovery."
+        )
+    else:
+        recommendation = (
+            "HALT all dependent decisions. "
+            "Activate full recovery protocol. "
+            "Restore sync plane integrity before quorum. "
+            "Independent verification required before index can be trusted."
+        )
+
+    return {
+        "overall_assessment": assessment,
+        "primary_risk": primary,
+        "secondary_risk": secondary,
+        "recommendation": recommendation,
+    }
+
+
+def _build_ds(engine: CredibilityEngine, packet_id: str) -> dict:
+    """Generate DS summary from engine state."""
+    by_sev = {
+        "low": 0, "medium": 0, "high": 0, "critical": 0,
+    }
+    for fp in engine.fingerprints:
+        if not fp.auto_resolved and fp.recurrence_count > 0:
+            by_sev[fp.severity] += 1
+
+    active = sum(by_sev.values())
+
+    # Find the most critical signal
+    critical_fps = [
+        fp for fp in engine.fingerprints
+        if fp.severity == "critical" and not fp.auto_resolved
+    ]
+    if not critical_fps:
+        critical_fps = [
+            fp for fp in engine.fingerprints
+            if fp.severity == "high" and not fp.auto_resolved
+        ]
+    if not critical_fps:
+        critical_fps = sorted(
+            engine.fingerprints,
+            key=lambda f: f.recurrence_count,
+            reverse=True,
+        )
+
+    top = critical_fps[0] if critical_fps else engine.fingerprints[0]
+
+    # Map fingerprint to cluster/region
+    regions = ["East", "Central", "West"]
+    if "WEST" in top.fingerprint:
+        regions = ["West"]
+    elif "C2" in top.fingerprint or "CENTRAL" in top.fingerprint.upper():
+        regions = ["Central"]
+    elif "S003" in top.fingerprint:
+        regions = ["East", "Central", "West"]
+
+    return {
+        "ds_id": f"DS-{packet_id}",
+        "active_signals": max(active, engine.active_drift_signals),
+        "by_severity": by_sev,
+        "critical_signal": {
+            "category": _fp_to_category(top.fingerprint),
+            "source": top.fingerprint,
+            "claims_affected": max(1, top.tier_impact * 5 + top.recurrence_count // 3),
+            "regions": regions,
+            "description": top.description,
+        },
+    }
+
+
+def _fp_to_category(fingerprint: str) -> str:
+    """Map fingerprint ID to drift category."""
+    fp = fingerprint.upper()
+    if "TTL" in fp:
+        return "ttl_compression"
+    if "CONF" in fp:
+        return "confidence_volatility"
+    if "CORR" in fp:
+        return "correlation_drift"
+    if "TIMING" in fp or "LAG" in fp:
+        return "timing_entropy"
+    if "SYNC" in fp or "BEACON" in fp:
+        return "external_mismatch"
+    return "timing_entropy"

--- a/sim/credibility-engine/runner.py
+++ b/sim/credibility-engine/runner.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Credibility Engine Simulation - Runner.
+
+Drives the simulation engine in a tick loop, writing JSON snapshots
+to the dashboard directory for live visualization.
+
+Usage:
+    python runner.py --scenario day0
+    python runner.py --scenario day2 --interval 2 --output-dir ../../dashboard/credibility-engine-demo
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Ensure sim package is importable
+sys.path.insert(0, str(Path(__file__).parent))
+
+from engine import CredibilityEngine
+from packet import generate_packet
+from scenarios import SCENARIOS
+
+# Default output directory (relative to this file)
+DEFAULT_OUTPUT = str(
+    Path(__file__).parent.parent.parent / "dashboard" / "credibility-engine-demo"
+)
+
+# Scenario hot-reload file (optional)
+SCENARIO_FILE = "scenario.json"
+
+
+def write_atomic(filepath: str, data: dict) -> None:
+    """Write JSON atomically: write temp file, then rename."""
+    dir_path = os.path.dirname(filepath)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, filepath)
+    except Exception:
+        # Clean up temp file on error
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def check_scenario_switch(engine: CredibilityEngine, output_dir: str) -> None:
+    """Check for scenario.json hot-reload file."""
+    scenario_path = os.path.join(output_dir, SCENARIO_FILE)
+    if os.path.exists(scenario_path):
+        try:
+            with open(scenario_path) as f:
+                data = json.load(f)
+            new_scenario = data.get("scenario", "").strip()
+            if new_scenario and new_scenario in SCENARIOS:
+                if new_scenario != engine.scenario_name:
+                    print(f"\n  Switching scenario: {engine.scenario_name} -> {new_scenario}")
+                    engine.set_scenario(new_scenario)
+            os.unlink(scenario_path)
+        except (json.JSONDecodeError, KeyError, OSError):
+            pass
+
+
+def print_status(engine: CredibilityEngine, tick: int) -> None:
+    """Print a compact status line."""
+    idx = engine.credibility_index
+    band = engine.index_band
+
+    # Color codes
+    if idx >= 95:
+        color = "\033[92m"  # green
+    elif idx >= 85:
+        color = "\033[93m"  # yellow
+    elif idx >= 70:
+        color = "\033[91m"  # red
+    elif idx >= 50:
+        color = "\033[91m"  # red
+    else:
+        color = "\033[91;1m"  # bold red
+    reset = "\033[0m"
+
+    unknown = sum(1 for c in engine.claims if c.status == "UNKNOWN")
+    degraded = sum(1 for c in engine.claims if c.status == "DEGRADED")
+    max_corr = max(c.coefficient for c in engine.clusters)
+    drift = engine.drift_total
+
+    claims_str = ""
+    if unknown:
+        claims_str += f" UNK:{unknown}"
+    if degraded:
+        claims_str += f" DEG:{degraded}"
+    if not claims_str:
+        claims_str = " ALL OK"
+
+    print(
+        f"  [{tick:4d}] "
+        f"CI: {color}{idx:3d}{reset} ({band:<24s}) "
+        f"| Drift: {drift:5d} "
+        f"| Corr: {max_corr:.2f} "
+        f"| Claims:{claims_str} "
+        f"| Sim: {engine.sim_time.strftime('%H:%M')}",
+        flush=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Credibility Engine Simulation Runner",
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=list(SCENARIOS.keys()),
+        default="day0",
+        help="Scenario to run (default: day0)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=2.0,
+        help="Seconds between ticks (default: 2)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT,
+        help="Directory to write JSON snapshots",
+    )
+    args = parser.parse_args()
+
+    output_dir = os.path.abspath(args.output_dir)
+    if not os.path.isdir(output_dir):
+        print(f"Error: output directory does not exist: {output_dir}")
+        sys.exit(1)
+
+    engine = CredibilityEngine(args.scenario)
+    scenario_desc = engine.scenario["description"]
+
+    print()
+    print("  ╔══════════════════════════════════════════════════════╗")
+    print("  ║   Σ OVERWATCH — Credibility Engine Simulation       ║")
+    print("  ╚══════════════════════════════════════════════════════╝")
+    print()
+    print(f"  Scenario:  {args.scenario} — {scenario_desc}")
+    print(f"  Interval:  {args.interval}s per tick (15 min sim time)")
+    print(f"  Output:    {output_dir}")
+    print("  Dashboard: http://localhost:8000/dashboard/credibility-engine-demo/")
+    print()
+    print("  Press Ctrl+C to stop.")
+    print()
+    print(
+        f"  {'Tick':>6s}  {'CI':>3s}  {'Band':<24s}  "
+        f"{'Drift':>5s}  {'Corr':>5s}  {'Claims':<12s}  {'SimTime':<6s}"
+    )
+    print("  " + "-" * 80)
+
+    try:
+        while True:
+            # Check for hot-reload scenario switch
+            check_scenario_switch(engine, output_dir)
+
+            # Advance simulation
+            engine.tick()
+
+            # Generate all snapshots
+            snapshots = engine.all_snapshots()
+            packet = generate_packet(engine)
+
+            # Write all files atomically
+            for name, data in snapshots.items():
+                filepath = os.path.join(output_dir, f"{name}.json")
+                write_atomic(filepath, data)
+            write_atomic(
+                os.path.join(output_dir, "credibility_packet_example.json"),
+                packet,
+            )
+
+            # Print status
+            print_status(engine, engine.tick_num)
+
+            # Sleep
+            time.sleep(args.interval)
+
+    except KeyboardInterrupt:
+        print("\n")
+        print("  Simulation stopped.")
+        print(f"  Final CI: {engine.credibility_index} ({engine.index_band})")
+        print(f"  Total ticks: {engine.tick_num}")
+        print(f"  Total drift: {engine.drift_total}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/credibility-engine/scenarios.py
+++ b/sim/credibility-engine/scenarios.py
@@ -1,0 +1,726 @@
+"""Credibility Engine Simulation - Scenario Definitions.
+
+Four scenarios that progress from baseline stability through
+institutional entropy, coordinated darkness, and external mismatch.
+
+Each scenario is a list of phases. Each phase specifies:
+- tick range (start, end)
+- drift injection rate and severity distribution
+- correlation coefficient targets per cluster
+- claim pressure (margin compression, TTL decay multipliers)
+- sync plane degradation parameters
+- index component adjustments
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+# Severity distribution weights: (low, medium, high, critical)
+# Category distribution weights: (timing_entropy, correlation_drift,
+#   confidence_volatility, ttl_compression, external_mismatch)
+
+SCENARIOS = {
+    "day0": {
+        "description": "Baseline — stable lattice, healthy quorum, minimal drift",
+        "phases": [
+            {
+                "start": 0, "end": 999,
+                "drift_rate": 3,
+                "severity_weights": (0.70, 0.22, 0.07, 0.01),
+                "category_weights": (0.30, 0.15, 0.25, 0.20, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.42, "CG-002": 0.55, "CG-003": 0.48,
+                    "CG-004": 0.34, "CG-005": 0.45, "CG-006": 0.38,
+                },
+                "correlation_drift_speed": 0.01,
+                "claim_effects": {},
+                "sync_targets": {
+                    "East":    {"skew": 12, "lag": 0.8, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 18, "lag": 1.2, "replays": 0, "nodes_down": 0},
+                    "West":    {"skew": 8,  "lag": 0.5, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 0.5,
+                "integrity_target": 32,
+                "confirmation_bonus": 5,
+                "ttl_decay_multiplier": 1.0,
+                "patch_active": True,
+                "fingerprint_escalation": {},
+            },
+        ],
+    },
+
+    "day1": {
+        "description": "Entropy emerges — drift increases, correlation crosses REVIEW, quorum compresses",
+        "phases": [
+            # Phase 1: Stable opening (ticks 0-20)
+            {
+                "start": 0, "end": 20,
+                "drift_rate": 3,
+                "severity_weights": (0.70, 0.22, 0.07, 0.01),
+                "category_weights": (0.30, 0.15, 0.25, 0.20, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.42, "CG-002": 0.58, "CG-003": 0.50,
+                    "CG-004": 0.34, "CG-005": 0.45, "CG-006": 0.38,
+                },
+                "correlation_drift_speed": 0.01,
+                "claim_effects": {},
+                "sync_targets": {
+                    "East":    {"skew": 12, "lag": 0.8, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 20, "lag": 1.5, "replays": 0, "nodes_down": 0},
+                    "West":    {"skew": 10, "lag": 0.6, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 0.5,
+                "integrity_target": 32,
+                "confirmation_bonus": 5,
+                "ttl_decay_multiplier": 1.0,
+                "patch_active": True,
+                "fingerprint_escalation": {},
+            },
+            # Phase 2: Drift accelerates, correlation rises (ticks 21-50)
+            {
+                "start": 21, "end": 50,
+                "drift_rate": 6,
+                "severity_weights": (0.55, 0.30, 0.12, 0.03),
+                "category_weights": (0.35, 0.20, 0.20, 0.15, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.48, "CG-002": 0.74, "CG-003": 0.58,
+                    "CG-004": 0.36, "CG-005": 0.50, "CG-006": 0.40,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {},
+                "sync_targets": {
+                    "East":    {"skew": 18, "lag": 1.2, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 35, "lag": 2.0, "replays": 0, "nodes_down": 0},
+                    "West":    {"skew": 14, "lag": 0.8, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 1.0,
+                "integrity_target": 32,
+                "confirmation_bonus": 4,
+                "ttl_decay_multiplier": 1.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 3: Quorum compression (ticks 51-70)
+            {
+                "start": 51, "end": 70,
+                "drift_rate": 8,
+                "severity_weights": (0.45, 0.35, 0.15, 0.05),
+                "category_weights": (0.30, 0.25, 0.20, 0.15, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.52, "CG-002": 0.78, "CG-003": 0.62,
+                    "CG-004": 0.38, "CG-005": 0.52, "CG-006": 0.42,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.78,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 22, "lag": 1.5, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 45, "lag": 2.3, "replays": 1, "nodes_down": 1},
+                    "West":    {"skew": 16, "lag": 1.0, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 1.5,
+                "integrity_target": 32,
+                "confirmation_bonus": 3,
+                "ttl_decay_multiplier": 2.0,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 4: Holds at Minor Drift (ticks 71+)
+            {
+                "start": 71, "end": 999,
+                "drift_rate": 7,
+                "severity_weights": (0.50, 0.30, 0.15, 0.05),
+                "category_weights": (0.30, 0.22, 0.22, 0.16, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.54, "CG-002": 0.78, "CG-003": 0.64,
+                    "CG-004": 0.38, "CG-005": 0.54, "CG-006": 0.42,
+                },
+                "correlation_drift_speed": 0.01,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.78,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 22, "lag": 1.5, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 45, "lag": 2.3, "replays": 1, "nodes_down": 1},
+                    "West":    {"skew": 16, "lag": 1.0, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 0.5,
+                "integrity_target": 31,
+                "confirmation_bonus": 3,
+                "ttl_decay_multiplier": 1.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                },
+            },
+        ],
+    },
+
+    "day2": {
+        "description": "Coordinated darkness — silent nodes, UNKNOWN claim, sync degradation",
+        "phases": [
+            # Phase 1: Starting from Day1 end state (ticks 0-10)
+            {
+                "start": 0, "end": 10,
+                "drift_rate": 7,
+                "severity_weights": (0.50, 0.30, 0.15, 0.05),
+                "category_weights": (0.30, 0.22, 0.22, 0.16, 0.10),
+                "correlation_targets": {
+                    "CG-001": 0.54, "CG-002": 0.78, "CG-003": 0.64,
+                    "CG-004": 0.38, "CG-005": 0.54, "CG-006": 0.42,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.78,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 22, "lag": 1.5, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 50, "lag": 2.5, "replays": 1, "nodes_down": 1},
+                    "West":    {"skew": 16, "lag": 1.0, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 1.0,
+                "integrity_target": 31,
+                "confirmation_bonus": 3,
+                "ttl_decay_multiplier": 1.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 2: Silent nodes increase, correlation climbs (ticks 11-30)
+            {
+                "start": 11, "end": 30,
+                "drift_rate": 10,
+                "severity_weights": (0.40, 0.30, 0.22, 0.08),
+                "category_weights": (0.25, 0.28, 0.18, 0.14, 0.15),
+                "correlation_targets": {
+                    "CG-001": 0.58, "CG-002": 0.82, "CG-003": 0.76,
+                    "CG-004": 0.42, "CG-005": 0.60, "CG-006": 0.45,
+                },
+                "correlation_drift_speed": 0.03,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.72,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 35, "lag": 2.0, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 80, "lag": 4.5, "replays": 2, "nodes_down": 1},
+                    "West":    {"skew": 28, "lag": 1.8, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 2.0,
+                "integrity_target": 31,
+                "confirmation_bonus": 2,
+                "ttl_decay_multiplier": 2.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 3: Tier0 flips to UNKNOWN (ticks 31-50)
+            {
+                "start": 31, "end": 50,
+                "drift_rate": 12,
+                "severity_weights": (0.35, 0.30, 0.25, 0.10),
+                "category_weights": (0.22, 0.30, 0.18, 0.15, 0.15),
+                "correlation_targets": {
+                    "CG-001": 0.60, "CG-002": 0.85, "CG-003": 0.82,
+                    "CG-004": 0.44, "CG-005": 0.62, "CG-006": 0.48,
+                },
+                "correlation_drift_speed": 0.03,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.68,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 45, "lag": 3.0, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 120, "lag": 8.0, "replays": 3, "nodes_down": 1},
+                    "West":    {"skew": 40, "lag": 2.5, "replays": 1, "nodes_down": 0},
+                },
+                "sync_drift_speed": 3.0,
+                "integrity_target": 29,
+                "confirmation_bonus": 1,
+                "ttl_decay_multiplier": 3.0,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "medium", "auto_resolved": False},
+                },
+            },
+            # Phase 4: Sync watermark lag peaks (ticks 51-70)
+            {
+                "start": 51, "end": 70,
+                "drift_rate": 14,
+                "severity_weights": (0.30, 0.30, 0.28, 0.12),
+                "category_weights": (0.20, 0.28, 0.18, 0.16, 0.18),
+                "correlation_targets": {
+                    "CG-001": 0.62, "CG-002": 0.86, "CG-003": 0.85,
+                    "CG-004": 0.46, "CG-005": 0.64, "CG-006": 0.50,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.65,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 55, "lag": 4.0, "replays": 1, "nodes_down": 0},
+                    "Central": {"skew": 180, "lag": 14.0, "replays": 4, "nodes_down": 2},
+                    "West":    {"skew": 55, "lag": 4.5, "replays": 2, "nodes_down": 0},
+                },
+                "sync_drift_speed": 3.0,
+                "integrity_target": 30,
+                "confirmation_bonus": 1,
+                "ttl_decay_multiplier": 3.0,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "medium", "auto_resolved": False},
+                },
+            },
+            # Phase 5: Holds at Elevated Risk (ticks 71+)
+            {
+                "start": 71, "end": 999,
+                "drift_rate": 12,
+                "severity_weights": (0.30, 0.30, 0.28, 0.12),
+                "category_weights": (0.22, 0.28, 0.18, 0.16, 0.16),
+                "correlation_targets": {
+                    "CG-001": 0.62, "CG-002": 0.86, "CG-003": 0.85,
+                    "CG-004": 0.46, "CG-005": 0.64, "CG-006": 0.50,
+                },
+                "correlation_drift_speed": 0.01,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.65,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 55, "lag": 4.0, "replays": 1, "nodes_down": 0},
+                    "Central": {"skew": 180, "lag": 14.0, "replays": 4, "nodes_down": 2},
+                    "West":    {"skew": 55, "lag": 4.5, "replays": 2, "nodes_down": 0},
+                },
+                "sync_drift_speed": 0.5,
+                "integrity_target": 30,
+                "confirmation_bonus": 1,
+                "ttl_decay_multiplier": 2.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "medium", "auto_resolved": False},
+                },
+            },
+        ],
+    },
+
+    "day3": {
+        "description": "External mismatch — critical drift, INVALID correlation, replay flags, potential recovery",
+        "phases": [
+            # Phase 1: Starting from Day2 end state (ticks 0-10)
+            {
+                "start": 0, "end": 10,
+                "drift_rate": 12,
+                "severity_weights": (0.30, 0.30, 0.28, 0.12),
+                "category_weights": (0.22, 0.28, 0.18, 0.16, 0.16),
+                "correlation_targets": {
+                    "CG-001": 0.62, "CG-002": 0.86, "CG-003": 0.85,
+                    "CG-004": 0.46, "CG-005": 0.64, "CG-006": 0.50,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.65,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Evidence-C2-014 confidence dropped below 0.80 threshold",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 60, "lag": 5.0, "replays": 1, "nodes_down": 0},
+                    "Central": {"skew": 200, "lag": 16.0, "replays": 4, "nodes_down": 2},
+                    "West":    {"skew": 60, "lag": 5.0, "replays": 2, "nodes_down": 0},
+                },
+                "sync_drift_speed": 2.0,
+                "integrity_target": 30,
+                "confirmation_bonus": 1,
+                "ttl_decay_multiplier": 3.0,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "medium", "auto_resolved": False},
+                },
+            },
+            # Phase 2: Critical drift injection (ticks 11-30)
+            {
+                "start": 11, "end": 30,
+                "drift_rate": 16,
+                "severity_weights": (0.25, 0.28, 0.30, 0.17),
+                "category_weights": (0.18, 0.30, 0.15, 0.12, 0.25),
+                "correlation_targets": {
+                    "CG-001": 0.65, "CG-002": 0.88, "CG-003": 0.92,
+                    "CG-004": 0.50, "CG-005": 0.68, "CG-006": 0.55,
+                },
+                "correlation_drift_speed": 0.04,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 0,
+                        "confidence_target": 0.55,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Multiple evidence nodes below confidence threshold — "
+                            "quorum margin exhausted",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                    "CLM-T0-005": {
+                        "margin_target": 1,
+                        "confidence_target": 0.76,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Cross-region correlation from CG-003 "
+                            "degrading Central domain evidence",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 90, "lag": 8.0, "replays": 2, "nodes_down": 1},
+                    "Central": {"skew": 350, "lag": 22.0, "replays": 6, "nodes_down": 2},
+                    "West":    {"skew": 85, "lag": 7.0, "replays": 3, "nodes_down": 1},
+                },
+                "sync_drift_speed": 5.0,
+                "integrity_target": 22,
+                "confirmation_bonus": 0,
+                "ttl_decay_multiplier": 4.0,
+                "patch_active": False,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "critical", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "critical", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "critical", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "high", "auto_resolved": False},
+                    "TIMING-LAG-WEST": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 3: Correlation crosses INVALID, replay flags peak (ticks 31-50)
+            {
+                "start": 31, "end": 50,
+                "drift_rate": 18,
+                "severity_weights": (0.20, 0.25, 0.32, 0.23),
+                "category_weights": (0.15, 0.32, 0.13, 0.12, 0.28),
+                "correlation_targets": {
+                    "CG-001": 0.68, "CG-002": 0.92, "CG-003": 0.96,
+                    "CG-004": 0.55, "CG-005": 0.72, "CG-006": 0.60,
+                },
+                "correlation_drift_speed": 0.04,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 0,
+                        "confidence_target": 0.45,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — multiple evidence nodes offline "
+                            "across Central domain",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                    "CLM-T0-005": {
+                        "margin_target": 0,
+                        "confidence_target": 0.60,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": True,
+                        "degradation_reason":
+                            "Quorum broken — CG-003 correlation invalidated "
+                            "3 evidence streams",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 150, "lag": 12.0, "replays": 4, "nodes_down": 1},
+                    "Central": {"skew": 500, "lag": 35.0, "replays": 8, "nodes_down": 3},
+                    "West":    {"skew": 140, "lag": 10.0, "replays": 5, "nodes_down": 1},
+                },
+                "sync_drift_speed": 8.0,
+                "integrity_target": 24,
+                "confirmation_bonus": 0,
+                "ttl_decay_multiplier": 5.0,
+                "patch_active": False,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "critical", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "critical", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "critical", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "high", "auto_resolved": False},
+                    "TIMING-LAG-WEST": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 4: Bottom — index at lowest (ticks 51-70)
+            {
+                "start": 51, "end": 70,
+                "drift_rate": 20,
+                "severity_weights": (0.15, 0.22, 0.35, 0.28),
+                "category_weights": (0.12, 0.35, 0.13, 0.10, 0.30),
+                "correlation_targets": {
+                    "CG-001": 0.70, "CG-002": 0.94, "CG-003": 0.97,
+                    "CG-004": 0.58, "CG-005": 0.75, "CG-006": 0.62,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — multiple evidence nodes offline "
+                            "across Central domain",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 offline, "
+                            "TTL expired on 2 evidence nodes",
+                    },
+                    "CLM-T0-005": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": True,
+                        "degradation_reason":
+                            "Quorum broken — CG-003 correlation invalidated "
+                            "3 evidence streams",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 200, "lag": 16.0, "replays": 5, "nodes_down": 2},
+                    "Central": {"skew": 600, "lag": 40.0, "replays": 10, "nodes_down": 3},
+                    "West":    {"skew": 180, "lag": 14.0, "replays": 6, "nodes_down": 1},
+                },
+                "sync_drift_speed": 5.0,
+                "integrity_target": 22,
+                "confirmation_bonus": 0,
+                "ttl_decay_multiplier": 5.0,
+                "patch_active": False,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "critical", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "critical", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "critical", "auto_resolved": False},
+                    "TTL-BATCH-EXPIRE-T1": {"severity": "high", "auto_resolved": False},
+                    "TIMING-LAG-WEST": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 5: Patch begins — partial recovery (ticks 71-90)
+            {
+                "start": 71, "end": 90,
+                "drift_rate": 12,
+                "severity_weights": (0.35, 0.30, 0.25, 0.10),
+                "category_weights": (0.22, 0.25, 0.18, 0.18, 0.17),
+                "correlation_targets": {
+                    "CG-001": 0.62, "CG-002": 0.88, "CG-003": 0.88,
+                    "CG-004": 0.50, "CG-005": 0.65, "CG-006": 0.52,
+                },
+                "correlation_drift_speed": 0.03,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.72,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Recovering — evidence nodes coming back online",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 0,
+                        "confidence_target": None,
+                        "status": "UNKNOWN",
+                        "correlation_groups_actual": 1,
+                        "out_of_band_present": False,
+                        "degradation_reason":
+                            "Quorum broken — Source-W2-007 recovery pending",
+                    },
+                    "CLM-T0-005": {
+                        "margin_target": 1,
+                        "confidence_target": 0.78,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Recovering — independent backup sources activated",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 80, "lag": 6.0, "replays": 2, "nodes_down": 0},
+                    "Central": {"skew": 250, "lag": 18.0, "replays": 4, "nodes_down": 1},
+                    "West":    {"skew": 70, "lag": 5.0, "replays": 2, "nodes_down": 0},
+                },
+                "sync_drift_speed": 4.0,
+                "integrity_target": 16,
+                "confirmation_bonus": 1,
+                "ttl_decay_multiplier": 2.0,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CONF-VOLATILITY-C2": {"severity": "high", "auto_resolved": False},
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "high", "auto_resolved": False},
+                },
+            },
+            # Phase 6: Partial stabilization (ticks 91+)
+            {
+                "start": 91, "end": 999,
+                "drift_rate": 8,
+                "severity_weights": (0.45, 0.30, 0.18, 0.07),
+                "category_weights": (0.28, 0.22, 0.20, 0.18, 0.12),
+                "correlation_targets": {
+                    "CG-001": 0.58, "CG-002": 0.82, "CG-003": 0.80,
+                    "CG-004": 0.44, "CG-005": 0.58, "CG-006": 0.46,
+                },
+                "correlation_drift_speed": 0.02,
+                "claim_effects": {
+                    "CLM-T0-002": {
+                        "margin_target": 1,
+                        "confidence_target": 0.78,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Partially recovered — monitoring for stability",
+                    },
+                    "CLM-T0-003": {
+                        "margin_target": 1,
+                        "confidence_target": 0.70,
+                        "status": "DEGRADED",
+                        "degradation_reason":
+                            "Source-W2-007 backup activated — re-establishing quorum",
+                    },
+                    "CLM-T0-005": {
+                        "margin_target": 2,
+                        "confidence_target": 0.84,
+                        "status": "VERIFIED",
+                    },
+                },
+                "sync_targets": {
+                    "East":    {"skew": 40, "lag": 2.5, "replays": 0, "nodes_down": 0},
+                    "Central": {"skew": 120, "lag": 8.0, "replays": 2, "nodes_down": 1},
+                    "West":    {"skew": 35, "lag": 2.0, "replays": 0, "nodes_down": 0},
+                },
+                "sync_drift_speed": 3.0,
+                "integrity_target": 20,
+                "confirmation_bonus": 2,
+                "ttl_decay_multiplier": 1.5,
+                "patch_active": True,
+                "fingerprint_escalation": {
+                    "CORR-DRIFT-S003": {"severity": "high", "auto_resolved": False},
+                    "SYNC-BEACON-SKEW": {"severity": "medium", "auto_resolved": True},
+                },
+            },
+        ],
+    },
+}


### PR DESCRIPTION
## Summary

- Added simulation harness under `sim/credibility-engine/` with tick-based engine (2-second intervals, 15 sim-min/tick)
- Implemented 4 scenarios: Day0 (stable, CI 94–97), Day1 (entropy, CI 85–90), Day2 (coordinated darkness, CI 65–75), Day3 (external mismatch + recovery, CI 45–60)
- Dashboard auto-refreshes every 2 seconds for live visualization
- Generates dynamic credibility packets with DLR/RS/DS/MG narratives and sealed hash chain
- Supports hot-swap scenario switching via `scenario.json`

## Files

**New (6):** `sim/credibility-engine/` — runner.py, engine.py, models.py, scenarios.py, packet.py, README.md

**Modified (4):** `app.js` (auto-refresh), `README.md` (Stage 2 section), `NAV.md` (sim links), `CHANGELOG.md` (Stage 2 entry)

## Run instructions

```bash
# Terminal 1: Start simulation
python sim/credibility-engine/runner.py --scenario day0

# Terminal 2: Serve dashboard
python -m http.server 8000
# Visit http://localhost:8000/dashboard/credibility-engine-demo/
```

## Test plan

- [x] Day0 produces CI 94–97 (Stable)
- [x] Day1 shows correlation REVIEW, CI drops to 85–90
- [x] Day2 produces UNKNOWN claim, CI drops to 65–75
- [x] Day3 produces CRITICAL correlation + replay flags, CI 45–60, then recovers
- [x] All JSON schemas match dashboard expectations
- [x] 735 tests pass, lint clean
- [x] No domain modeling present

🤖 Generated with [Claude Code](https://claude.com/claude-code)