### PR TITLE
feat: multi-region sync plane prototype (#102)

### DIFF
--- a/mesh/envelopes.py
+++ b/mesh/envelopes.py
@@ -42,6 +42,8 @@ class EvidenceEnvelope:
     payload_hash: str = ""
     signature: str = ""
     public_key: str = ""
+    event_time: str = ""  # source-reported observation time
+    sequence_number: int = 0  # monotonic per-source sequence
 
     def compute_payload_hash(self) -> str:
         raw = canonical_bytes(self.payload)
@@ -217,6 +219,8 @@ def create_envelope(
     private_key: str,
     public_key: str,
     signal_type: str = "evidence",
+    event_time: str = "",
+    sequence_number: int = 0,
 ) -> EvidenceEnvelope:
     """Factory: create and sign an evidence envelope."""
     env = EvidenceEnvelope(
@@ -226,6 +230,8 @@ def create_envelope(
         correlation_group=correlation_group,
         signal_type=signal_type,
         payload=payload,
+        event_time=event_time,
+        sequence_number=sequence_number,
     )
     env.sign_envelope(private_key, public_key)
     return env

--- a/mesh/sync_plane.py
+++ b/mesh/sync_plane.py
@@ -1,0 +1,475 @@
+"""Mesh Sync Plane — Evidence timing verification across regions.
+
+Enforces monotonic source sequences, watermark-based window closure,
+independent time beacon validation, and replay detection.
+
+Abstract institutional credibility architecture.
+No real-world system modeled.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso_to_ms(iso: str) -> float:
+    """Convert ISO timestamp to milliseconds since epoch."""
+    if not iso:
+        return 0.0
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.timestamp() * 1000.0
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _ms_delta(t1: str, t2: str) -> float:
+    """Absolute difference in ms between two ISO timestamps."""
+    return abs(_iso_to_ms(t1) - _iso_to_ms(t2))
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SourceState:
+    """Per-source tracking state within a sync node."""
+
+    source_id: str
+    last_sequence: int = 0
+    last_event_time: str = ""
+    envelope_count: int = 0
+    quarantined: bool = False
+    quarantine_reason: str = ""
+    violations: int = 0
+
+
+@dataclass
+class TimeBeacon:
+    """External independent time reference."""
+
+    beacon_id: str
+    region_id: str = ""
+    reference_time: str = ""
+    tolerance_ms: float = 500.0
+    healthy: bool = True
+
+
+@dataclass
+class IngestResult:
+    """Result of ingesting an envelope through the sync plane."""
+
+    accepted: bool = True
+    quarantined: bool = False
+    drift_signals: list[dict] = field(default_factory=list)
+    watermark_advanced: bool = False
+    ingestion_lag_ms: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# SyncNode — per-region sync tracking
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SyncNode:
+    """Sync node tracking sources and watermark for a region."""
+
+    node_id: str
+    region_id: str
+    sources: dict[str, SourceState] = field(default_factory=dict)
+    watermark: str = ""
+    beacon_refs: list[str] = field(default_factory=list)
+    drift_signals: list[dict] = field(default_factory=list)
+    envelope_count: int = 0
+    # seq_key → payload_hash
+    _hashes: dict[str, str] = field(default_factory=dict)
+
+    def _source(self, source_id: str) -> SourceState:
+        if source_id not in self.sources:
+            self.sources[source_id] = SourceState(source_id=source_id)
+        return self.sources[source_id]
+
+
+# ---------------------------------------------------------------------------
+# SyncPlane — multi-region coordinator
+# ---------------------------------------------------------------------------
+
+class SyncPlane:
+    """Multi-region sync plane for evidence timing verification.
+
+    Parameters
+    ----------
+    regions : list[str]
+        Region IDs (e.g. ["East", "West", "Central"]).
+    nodes_per_region : int
+        Number of sync nodes per region.
+    max_authority_pct : float
+        Maximum fraction of total envelopes from any single region.
+    watermark_stall_threshold_ms : float
+        If a source's watermark hasn't advanced in this many ms,
+        fire SIGNAL_LOSS.
+    """
+
+    def __init__(
+        self,
+        regions: list[str],
+        nodes_per_region: int = 3,
+        max_authority_pct: float = 0.40,
+        watermark_stall_threshold_ms: float = 30_000.0,
+    ) -> None:
+        self._regions = list(regions)
+        self._nodes_per_region = nodes_per_region
+        self._max_authority_pct = max_authority_pct
+        self._stall_threshold_ms = watermark_stall_threshold_ms
+        self._beacons: dict[str, TimeBeacon] = {}
+        self._total_envelopes = 0
+        self._region_envelope_counts: dict[str, int] = {r: 0 for r in regions}
+
+        # Create sync nodes
+        self._nodes: dict[str, list[SyncNode]] = {}
+        for region in regions:
+            self._nodes[region] = [
+                SyncNode(
+                    node_id=f"sync-{region}-{i}",
+                    region_id=region,
+                )
+                for i in range(nodes_per_region)
+            ]
+
+    @property
+    def regions(self) -> list[str]:
+        return list(self._regions)
+
+    @property
+    def total_envelopes(self) -> int:
+        return self._total_envelopes
+
+    def add_beacon(self, beacon: TimeBeacon) -> None:
+        """Register an external time beacon."""
+        self._beacons[beacon.beacon_id] = beacon
+        # Assign to region nodes if region matches
+        if beacon.region_id:
+            for node in self._nodes.get(beacon.region_id, []):
+                if beacon.beacon_id not in node.beacon_refs:
+                    node.beacon_refs.append(beacon.beacon_id)
+
+    def ingest(self, envelope: dict) -> IngestResult:
+        """Ingest an evidence envelope through the sync plane.
+
+        Checks monotonic sequence, watermark, beacon divergence,
+        and replay detection.
+        """
+        result = IngestResult()
+
+        source_id = envelope.get("producer_id", "")
+        region_id = envelope.get("region_id", "")
+        event_time = (
+            envelope.get("event_time", "")
+            or envelope.get("timestamp", "")
+        )
+        ingest_time = envelope.get("timestamp", "")
+        seq = envelope.get("sequence_number", 0)
+        payload_hash = envelope.get("payload_hash", "")
+
+        if not source_id or not region_id:
+            result.accepted = False
+            return result
+
+        # Track region authority
+        self._total_envelopes += 1
+        if region_id in self._region_envelope_counts:
+            self._region_envelope_counts[region_id] += 1
+
+        # Compute ingestion lag
+        if event_time and ingest_time:
+            result.ingestion_lag_ms = _ms_delta(event_time, ingest_time)
+
+        # Route to region's primary sync node
+        nodes = self._nodes.get(region_id, [])
+        if not nodes:
+            result.accepted = False
+            return result
+
+        node = nodes[0]  # primary
+        node.envelope_count += 1
+        src = node._source(source_id)
+        src.envelope_count += 1
+
+        # --- Monotonic sequence check ---
+        if seq > 0 and src.last_sequence > 0:
+            if seq <= src.last_sequence:
+                # Check for replay (same seq + same hash)
+                seq_key = f"{source_id}:{seq}"
+                stored = node._hashes.get(seq_key)
+                if stored and stored == payload_hash:
+                    sig = self._signal(
+                        "REPLAY_DETECTED", region_id, source_id,
+                        f"Duplicate seq={seq} with matching hash",
+                    )
+                    result.drift_signals.append(sig)
+                    node.drift_signals.append(sig)
+                    result.quarantined = True
+                    result.accepted = False
+                    src.quarantined = True
+                    src.quarantine_reason = "replay_detected"
+                    src.violations += 1
+                    return result
+                else:
+                    desc = (
+                        f"Non-monotonic: got seq={seq}, "
+                        f"expected > {src.last_sequence}"
+                    )
+                    sig = self._signal(
+                        "SEQUENCE_VIOLATION",
+                        region_id, source_id, desc,
+                    )
+                    result.drift_signals.append(sig)
+                    node.drift_signals.append(sig)
+                    result.quarantined = True
+                    src.quarantined = True
+                    src.quarantine_reason = "sequence_violation"
+                    src.violations += 1
+
+        # Track hash for replay detection
+        if seq > 0 and payload_hash:
+            node._hashes[f"{source_id}:{seq}"] = payload_hash
+
+        # Update source sequence
+        if seq > src.last_sequence:
+            src.last_sequence = seq
+
+        # --- Watermark check ---
+        if event_time and node.watermark:
+            et_ms = _iso_to_ms(event_time)
+            wm_ms = _iso_to_ms(node.watermark)
+
+            if et_ms < wm_ms:
+                desc = (
+                    f"event_time {event_time} "
+                    f"below watermark {node.watermark}"
+                )
+                sig = self._signal(
+                    "LATE_ARRIVAL", region_id,
+                    source_id, desc,
+                )
+                result.drift_signals.append(sig)
+                node.drift_signals.append(sig)
+
+            elif et_ms > wm_ms + (self._stall_threshold_ms * 2):
+                # Far above watermark → clock skew
+                desc = (
+                    f"event_time {event_time} far above "
+                    f"watermark {node.watermark}"
+                )
+                sig = self._signal(
+                    "CLOCK_SKEW", region_id,
+                    source_id, desc,
+                )
+                result.drift_signals.append(sig)
+                node.drift_signals.append(sig)
+
+        # Advance watermark
+        if event_time:
+            if not node.watermark or event_time > node.watermark:
+                node.watermark = event_time
+                result.watermark_advanced = True
+
+        # Update source event time
+        if event_time:
+            src.last_event_time = event_time
+
+        # --- Beacon divergence check ---
+        if event_time:
+            for beacon_id in node.beacon_refs:
+                beacon = self._beacons.get(beacon_id)
+                if beacon and beacon.reference_time and beacon.healthy:
+                    delta_ms = _ms_delta(event_time, beacon.reference_time)
+                    if delta_ms > beacon.tolerance_ms:
+                        sig = self._signal(
+                            "BEACON_DIVERGENCE", region_id, source_id,
+                            f"Divergence {delta_ms:.0f}ms from beacon "
+                            f"{beacon_id} (tolerance {beacon.tolerance_ms}ms)",
+                        )
+                        result.drift_signals.append(sig)
+                        node.drift_signals.append(sig)
+
+        return result
+
+    def check_beacon(self, beacon_id: str, reference_time: str) -> list[dict]:
+        """Update a beacon's reference time and check for divergence."""
+        beacon = self._beacons.get(beacon_id)
+        if not beacon:
+            return []
+
+        beacon.reference_time = reference_time
+        signals = []
+
+        # Check all region nodes with this beacon
+        region_id = beacon.region_id
+        for node in self._nodes.get(region_id, []):
+            if beacon_id not in node.beacon_refs:
+                continue
+            if node.watermark:
+                delta_ms = _ms_delta(node.watermark, reference_time)
+                if delta_ms > beacon.tolerance_ms:
+                    sig = self._signal(
+                        "BEACON_DIVERGENCE", region_id, "",
+                        f"Watermark divergence {delta_ms:.0f}ms from "
+                        f"beacon {beacon_id}",
+                    )
+                    signals.append(sig)
+                    node.drift_signals.append(sig)
+
+        return signals
+
+    def check_stalls(self, current_time: str = "") -> list[dict]:
+        """Check all sources for watermark stalls (SIGNAL_LOSS)."""
+        if not current_time:
+            current_time = _now_iso()
+
+        signals = []
+        now_ms = _iso_to_ms(current_time)
+
+        for region_id, nodes in self._nodes.items():
+            for node in nodes:
+                for src in node.sources.values():
+                    if src.last_event_time and src.envelope_count > 0:
+                        delta = now_ms - _iso_to_ms(src.last_event_time)
+                        if delta > self._stall_threshold_ms:
+                            desc = (
+                                f"No evidence for "
+                                f"{delta:.0f}ms "
+                                f"(threshold "
+                                f"{self._stall_threshold_ms:.0f}"
+                                f"ms)"
+                            )
+                            sig = self._signal(
+                                "SIGNAL_LOSS",
+                                region_id,
+                                src.source_id,
+                                desc,
+                            )
+                            signals.append(sig)
+                            node.drift_signals.append(sig)
+
+        return signals
+
+    def region_status(self, region_id: str) -> dict:
+        """Get sync status for a region."""
+        nodes = self._nodes.get(region_id, [])
+        if not nodes:
+            return {"region_id": region_id, "status": "unknown"}
+
+        node = nodes[0]
+        beacon_ids = node.beacon_refs
+        beacons_healthy = sum(
+            1 for bid in beacon_ids
+            if self._beacons.get(bid, TimeBeacon(beacon_id="")).healthy
+        )
+
+        # Compute time skew from beacons
+        skew_ms = 0.0
+        if node.watermark:
+            for bid in beacon_ids:
+                b = self._beacons.get(bid)
+                if b and b.reference_time and b.healthy:
+                    d = _ms_delta(
+                        node.watermark, b.reference_time,
+                    )
+                    skew_ms = max(skew_ms, d)
+
+        replay_flags = sum(
+            1 for s in node.drift_signals if s["type"] == "REPLAY_DETECTED"
+        )
+
+        return {
+            "id": region_id,
+            "status": self._compute_region_health(node),
+            "sync_nodes": len(nodes),
+            "sync_nodes_healthy": sum(1 for _ in nodes),
+            "watermark_advancing": node.watermark != "",
+            "last_watermark": node.watermark,
+            "time_skew_ms": round(skew_ms, 1),
+            "watermark_lag_s": 0.0,  # TODO: compute from stall check
+            "replay_flags": replay_flags,
+            "beacons": len(beacon_ids),
+            "beacons_healthy": beacons_healthy,
+            "envelope_count": node.envelope_count,
+        }
+
+    def summary(self) -> list[dict]:
+        """Get sync status for all regions (matches sync.jsonl shape)."""
+        return [self.region_status(r) for r in self._regions]
+
+    def authority_check(self) -> bool:
+        """Verify no region exceeds max authority percentage."""
+        if self._total_envelopes == 0:
+            return True
+        for region_id, count in self._region_envelope_counts.items():
+            pct = count / self._total_envelopes
+            if pct > self._max_authority_pct:
+                return False
+        return True
+
+    def authority_distribution(self) -> dict[str, float]:
+        """Return per-region authority fractions."""
+        total = max(self._total_envelopes, 1)
+        return {
+            r: count / total
+            for r, count in self._region_envelope_counts.items()
+        }
+
+    def all_drift_signals(self) -> list[dict]:
+        """Collect all drift signals across all nodes."""
+        signals = []
+        for nodes in self._nodes.values():
+            for node in nodes:
+                signals.extend(node.drift_signals)
+        return signals
+
+    # -------------------------------------------------------------------
+    # Internal
+    # -------------------------------------------------------------------
+
+    def _signal(
+        self,
+        signal_type: str,
+        region_id: str,
+        source_id: str,
+        description: str,
+    ) -> dict:
+        return {
+            "type": signal_type,
+            "region_id": region_id,
+            "source_id": source_id,
+            "description": description,
+            "timestamp": _now_iso(),
+        }
+
+    def _compute_region_health(self, node: SyncNode) -> str:
+        quarantined = sum(
+            1 for s in node.sources.values() if s.quarantined
+        )
+        if quarantined > len(node.sources) * 0.5:
+            return "degraded"
+        replay_count = sum(
+            1 for s in node.drift_signals if s["type"] == "REPLAY_DETECTED"
+        )
+        if replay_count > 0:
+            return "degraded"
+        return "OK"
+
+    @staticmethod
+    def _hash_envelope(envelope: dict) -> str:
+        """Hash envelope for replay comparison."""
+        pid = envelope.get('producer_id', '')
+        ph = envelope.get('payload_hash', '')
+        raw = f"{pid}:{ph}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:20]

--- a/tests/test_sync_plane.py
+++ b/tests/test_sync_plane.py
@@ -1,0 +1,495 @@
+"""Tests for mesh/sync_plane.py — multi-region sync plane.
+
+Run:  pytest tests/test_sync_plane.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mesh.sync_plane import (  # noqa: E402
+    SyncPlane,
+    TimeBeacon,
+    _iso_to_ms,
+    _ms_delta,
+)
+
+REGIONS = ["East", "West", "Central"]
+
+
+def _envelope(
+    producer_id: str = "src-1",
+    region_id: str = "East",
+    event_time: str = "2026-02-19T00:00:01Z",
+    sequence_number: int = 1,
+    payload_hash: str = "abc123",
+    timestamp: str = "",
+) -> dict:
+    """Minimal envelope dict for sync plane ingestion."""
+    env = {
+        "producer_id": producer_id,
+        "region_id": region_id,
+        "event_time": event_time,
+        "sequence_number": sequence_number,
+        "payload_hash": payload_hash,
+    }
+    env["timestamp"] = timestamp or event_time
+    return env
+
+
+# ── Setup & Topology ──────────────────────────────────────
+
+
+class TestSyncPlaneSetup:
+    """Basic topology and configuration."""
+
+    def test_3_region_init(self):
+        sp = SyncPlane(REGIONS)
+        assert sp.regions == REGIONS
+        assert sp.total_envelopes == 0
+
+    def test_authority_distribution_starts_balanced(self):
+        sp = SyncPlane(REGIONS)
+        dist = sp.authority_distribution()
+        assert len(dist) == 3
+        for pct in dist.values():
+            assert pct == 0.0
+
+    def test_beacon_registration(self):
+        sp = SyncPlane(REGIONS)
+        beacon = TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+        )
+        sp.add_beacon(beacon)
+        status = sp.region_status("East")
+        assert status["beacons"] >= 1
+
+
+# ── Monotonic Sequence ────────────────────────────────────
+
+
+class TestMonotonicSequence:
+    """Monotonic source sequence enforcement."""
+
+    def test_ascending_sequence_accepted(self):
+        sp = SyncPlane(REGIONS)
+        r1 = sp.ingest(_envelope(sequence_number=1))
+        r2 = sp.ingest(_envelope(sequence_number=2))
+        r3 = sp.ingest(_envelope(sequence_number=3))
+        assert r1.accepted
+        assert r2.accepted
+        assert r3.accepted
+        assert not any(
+            r.quarantined for r in [r1, r2, r3]
+        )
+
+    def test_out_of_order_fires_violation(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(sequence_number=1))
+        sp.ingest(_envelope(sequence_number=5))
+        result = sp.ingest(_envelope(
+            sequence_number=3,
+            payload_hash="different",
+        ))
+        assert result.quarantined
+        signals = [
+            s for s in result.drift_signals
+            if s["type"] == "SEQUENCE_VIOLATION"
+        ]
+        assert len(signals) == 1
+
+    def test_quarantined_source_tracked(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(sequence_number=1))
+        sp.ingest(_envelope(sequence_number=5))
+        sp.ingest(_envelope(
+            sequence_number=3,
+            payload_hash="different",
+        ))
+        status = sp.region_status("East")
+        assert status["status"] in ("OK", "degraded")
+
+    def test_repeated_violations_accumulate(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(sequence_number=1))
+        sp.ingest(_envelope(sequence_number=10))
+        # Two violations from same source
+        sp.ingest(_envelope(
+            sequence_number=5, payload_hash="h1",
+        ))
+        sp.ingest(_envelope(
+            sequence_number=7, payload_hash="h2",
+        ))
+        all_signals = sp.all_drift_signals()
+        violations = [
+            s for s in all_signals
+            if s["type"] == "SEQUENCE_VIOLATION"
+        ]
+        assert len(violations) == 2
+
+
+# ── Watermark ─────────────────────────────────────────────
+
+
+class TestWatermark:
+    """Watermark-based window closure."""
+
+    def test_watermark_advances_on_in_order(self):
+        sp = SyncPlane(REGIONS)
+        t1 = "2026-02-19T00:00:01Z"
+        t2 = "2026-02-19T00:00:02Z"
+        r1 = sp.ingest(_envelope(
+            event_time=t1, sequence_number=1,
+        ))
+        r2 = sp.ingest(_envelope(
+            event_time=t2, sequence_number=2,
+        ))
+        assert r1.watermark_advanced
+        assert r2.watermark_advanced
+
+    def test_late_arrival_detected(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:10Z",
+            sequence_number=1,
+        ))
+        result = sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:01Z",
+            sequence_number=2,
+        ))
+        late = [
+            s for s in result.drift_signals
+            if s["type"] == "LATE_ARRIVAL"
+        ]
+        assert len(late) == 1
+
+    def test_clock_skew_detected(self):
+        sp = SyncPlane(
+            REGIONS,
+            watermark_stall_threshold_ms=1000.0,
+        )
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:00Z",
+            sequence_number=1,
+        ))
+        # > 2x stall threshold = 2000ms
+        result = sp.ingest(_envelope(
+            event_time="2026-02-19T00:01:00Z",
+            sequence_number=2,
+        ))
+        skew = [
+            s for s in result.drift_signals
+            if s["type"] == "CLOCK_SKEW"
+        ]
+        assert len(skew) == 1
+
+    def test_stall_fires_signal_loss(self):
+        sp = SyncPlane(
+            REGIONS,
+            watermark_stall_threshold_ms=5000.0,
+        )
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:00Z",
+            sequence_number=1,
+        ))
+        signals = sp.check_stalls("2026-02-19T00:00:15Z")
+        loss = [
+            s for s in signals
+            if s["type"] == "SIGNAL_LOSS"
+        ]
+        assert len(loss) >= 1
+
+
+# ── Beacon ────────────────────────────────────────────────
+
+
+class TestBeacon:
+    """Independent time beacon validation."""
+
+    def test_within_tolerance_no_signal(self):
+        sp = SyncPlane(REGIONS)
+        sp.add_beacon(TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+            tolerance_ms=500.0,
+        ))
+        result = sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:00Z",
+            sequence_number=1,
+        ))
+        bcn = [
+            s for s in result.drift_signals
+            if s["type"] == "BEACON_DIVERGENCE"
+        ]
+        assert len(bcn) == 0
+
+    def test_divergence_fires_signal(self):
+        sp = SyncPlane(REGIONS)
+        sp.add_beacon(TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+            tolerance_ms=500.0,
+        ))
+        result = sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:10Z",
+            sequence_number=1,
+        ))
+        bcn = [
+            s for s in result.drift_signals
+            if s["type"] == "BEACON_DIVERGENCE"
+        ]
+        assert len(bcn) == 1
+
+    def test_check_beacon_updates_and_detects(self):
+        sp = SyncPlane(REGIONS)
+        sp.add_beacon(TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+            tolerance_ms=500.0,
+        ))
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:00Z",
+            sequence_number=1,
+        ))
+        signals = sp.check_beacon(
+            "ntp-east", "2026-02-19T00:01:00Z",
+        )
+        assert len(signals) >= 1
+        assert signals[0]["type"] == "BEACON_DIVERGENCE"
+
+
+# ── Replay Detection ──────────────────────────────────────
+
+
+class TestReplayDetection:
+    """Replay detection via sequence + hash matching."""
+
+    def test_duplicate_seq_same_hash_is_replay(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(
+            sequence_number=1, payload_hash="hash_a",
+        ))
+        result = sp.ingest(_envelope(
+            sequence_number=1, payload_hash="hash_a",
+        ))
+        assert not result.accepted
+        assert result.quarantined
+        replay = [
+            s for s in result.drift_signals
+            if s["type"] == "REPLAY_DETECTED"
+        ]
+        assert len(replay) == 1
+
+    def test_duplicate_seq_diff_hash_is_violation(self):
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(
+            sequence_number=1, payload_hash="hash_a",
+        ))
+        result = sp.ingest(_envelope(
+            sequence_number=1, payload_hash="hash_b",
+        ))
+        assert result.quarantined
+        viol = [
+            s for s in result.drift_signals
+            if s["type"] == "SEQUENCE_VIOLATION"
+        ]
+        assert len(viol) == 1
+        replay = [
+            s for s in result.drift_signals
+            if s["type"] == "REPLAY_DETECTED"
+        ]
+        assert len(replay) == 0
+
+    def test_legitimate_late_not_replay(self):
+        """Late arrival with new sequence is not replay."""
+        sp = SyncPlane(REGIONS)
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:10Z",
+            sequence_number=1,
+        ))
+        result = sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:01Z",
+            sequence_number=2,
+            payload_hash="new_hash",
+        ))
+        replay = [
+            s for s in result.drift_signals
+            if s["type"] == "REPLAY_DETECTED"
+        ]
+        assert len(replay) == 0
+
+
+# ── Region Authority ──────────────────────────────────────
+
+
+class TestRegionAuthority:
+    """Region authority cap enforcement."""
+
+    def test_balanced_passes(self):
+        sp = SyncPlane(REGIONS, max_authority_pct=0.40)
+        for i in range(30):
+            region = REGIONS[i % 3]
+            t = f"2026-02-19T00:00:{i + 1:02d}Z"
+            sp.ingest(_envelope(
+                producer_id=f"src-{region}",
+                region_id=region,
+                sequence_number=i + 1,
+                event_time=t,
+            ))
+        assert sp.authority_check()
+
+    def test_imbalanced_fails(self):
+        sp = SyncPlane(
+            REGIONS, max_authority_pct=0.40,
+        )
+        # 10 East, 1 West, 1 Central → East 83%
+        for i in range(10):
+            t = f"2026-02-19T00:00:{i + 1:02d}Z"
+            sp.ingest(_envelope(
+                producer_id="src-east",
+                region_id="East",
+                sequence_number=i + 1,
+                event_time=t,
+            ))
+        sp.ingest(_envelope(
+            producer_id="src-west",
+            region_id="West",
+            sequence_number=1,
+        ))
+        sp.ingest(_envelope(
+            producer_id="src-central",
+            region_id="Central",
+            sequence_number=1,
+        ))
+        assert not sp.authority_check()
+
+
+# ── Integration ───────────────────────────────────────────
+
+
+class TestIntegration:
+    """End-to-end sync plane scenarios."""
+
+    def test_healthy_to_skew_to_recovery(self):
+        """Healthy → skew → recovery."""
+        sp = SyncPlane(
+            REGIONS,
+            watermark_stall_threshold_ms=5000.0,
+        )
+        sp.add_beacon(TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+            tolerance_ms=500.0,
+        ))
+
+        # Phase 1: Healthy in-order evidence
+        for i in range(1, 6):
+            t = f"2026-02-19T00:00:{i:02d}Z"
+            result = sp.ingest(_envelope(
+                event_time=t,
+                sequence_number=i,
+            ))
+            assert result.accepted
+
+        # Phase 2: Clock skew — far-future event
+        sp2 = SyncPlane(
+            REGIONS,
+            watermark_stall_threshold_ms=1000.0,
+        )
+        sp2.ingest(_envelope(
+            event_time="2026-02-19T00:00:01Z",
+            sequence_number=1,
+        ))
+        skew_r = sp2.ingest(_envelope(
+            event_time="2026-02-19T00:01:00Z",
+            sequence_number=2,
+        ))
+        skew = [
+            s for s in skew_r.drift_signals
+            if s["type"] == "CLOCK_SKEW"
+        ]
+        assert len(skew) >= 1
+
+        # Phase 3: Recovery — normal with fresh plane
+        sp3 = SyncPlane(REGIONS)
+        for i in range(1, 4):
+            t = f"2026-02-19T00:02:{i:02d}Z"
+            r = sp3.ingest(_envelope(
+                event_time=t,
+                sequence_number=i,
+            ))
+            assert r.accepted
+            assert not r.quarantined
+
+    def test_summary_matches_sync_jsonl_shape(self):
+        """Summary has all sync.jsonl fields."""
+        sp = SyncPlane(REGIONS)
+        sp.add_beacon(TimeBeacon(
+            beacon_id="ntp-east",
+            region_id="East",
+            reference_time="2026-02-19T00:00:00Z",
+        ))
+        sp.ingest(_envelope(
+            event_time="2026-02-19T00:00:01Z",
+            sequence_number=1,
+        ))
+
+        summary = sp.summary()
+        assert len(summary) == 3
+
+        east = [
+            r for r in summary if r["id"] == "East"
+        ][0]
+        expected_keys = {
+            "id", "status", "sync_nodes",
+            "sync_nodes_healthy",
+            "watermark_advancing", "last_watermark",
+            "time_skew_ms", "watermark_lag_s",
+            "replay_flags", "beacons",
+            "beacons_healthy", "envelope_count",
+        }
+        assert expected_keys.issubset(set(east.keys()))
+        assert east["status"] == "OK"
+        assert east["watermark_advancing"] is True
+        assert east["envelope_count"] == 1
+
+
+# ── Utility Functions ─────────────────────────────────────
+
+
+class TestUtilities:
+    """Helper function coverage."""
+
+    def test_iso_to_ms(self):
+        ms = _iso_to_ms("2026-02-19T00:00:00Z")
+        assert ms > 0
+
+    def test_iso_to_ms_empty(self):
+        assert _iso_to_ms("") == 0.0
+
+    def test_ms_delta(self):
+        delta = _ms_delta(
+            "2026-02-19T00:00:00Z",
+            "2026-02-19T00:00:01Z",
+        )
+        assert abs(delta - 1000.0) < 1.0
+
+    def test_missing_fields_rejected(self):
+        sp = SyncPlane(REGIONS)
+        result = sp.ingest({
+            "producer_id": "", "region_id": "",
+        })
+        assert not result.accepted
+
+    def test_unknown_region_rejected(self):
+        sp = SyncPlane(REGIONS)
+        result = sp.ingest(_envelope(region_id="Mars"))
+        assert not result.accepted


### PR DESCRIPTION
## Summary
- Adds `mesh/sync_plane.py` with `SyncPlane` coordinator, `SyncNode` per-region tracking, and `TimeBeacon` independent time references
- Implements 6 drift signal types: `SEQUENCE_VIOLATION`, `LATE_ARRIVAL`, `CLOCK_SKEW`, `BEACON_DIVERGENCE`, `REPLAY_DETECTED`, `SIGNAL_LOSS`
- Extends `EvidenceEnvelope` with `event_time` and `sequence_number` fields (backward-compatible defaults)
- 26 tests covering setup, monotonic sequences, watermarks, beacons, replay detection, region authority, and integration scenarios

Closes #102

## Test plan
- [x] `pytest tests/test_sync_plane.py -v` — 26/26 pass
- [x] `pytest tests/ -v -m "not benchmark"` — 1029 pass, no regressions
- [x] `flake8` — lint clean
- [ ] CI pipeline green (all 12 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)