### PR TITLE
feat: production-harden SharePoint connector (#93)

### DIFF
--- a/adapters/sharepoint/connector.py
+++ b/adapters/sharepoint/connector.py
@@ -1,11 +1,19 @@
 """SharePoint Graph API connector for DeepSigma canonical record ingestion.
 
-Implements the field mapping from ``llm_data_model/04_mappings/sharepoint_mapping.md``.
+Implements the field mapping from
+``llm_data_model/04_mappings/sharepoint_mapping.md``.
+
+Production features:
+- Azure AD client-credentials OAuth 2.0 (via AzureADAuth)
+- Automatic token caching and refresh
+- Rate-limit handling with exponential backoff (HTTP 429 / 503)
+- ConnectorV1 contract compliance (list_records, get_record, to_envelopes)
+- Configuration via environment variables (no secrets in code)
 
 Usage::
 
     connector = SharePointConnector()
-    records = connector.list_items("my-list-id")
+    records = connector.list_records(list_id="my-list-id")
     result  = connector.delta_sync("my-list-id")
 """
 from __future__ import annotations
@@ -13,15 +21,26 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
+import urllib.error
 import urllib.request
 from typing import Any, Dict, List, Optional
 
 from adapters._azure_auth import AzureADAuth
-from adapters._connector_helpers import strip_html, to_iso, uuid_from_hash
+from adapters._connector_helpers import (
+    strip_html,
+    to_iso,
+    uuid_from_hash,
+)
 
 logger = logging.getLogger(__name__)
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+
+# Retry configuration for 429 / 503 throttling
+_MAX_RETRIES = 4
+_INITIAL_BACKOFF_S = 1.0
+_BACKOFF_MULTIPLIER = 2.0
 
 # Content type → canonical record_type mapping
 _CONTENT_TYPE_MAP: Dict[str, str] = {
@@ -57,10 +76,19 @@ class SharePointConnector:
         client_secret: Optional[str] = None,
         site_id: Optional[str] = None,
     ) -> None:
-        self._tenant_id = tenant_id or os.environ.get("SP_TENANT_ID", "")
-        self._client_id = client_id or os.environ.get("SP_CLIENT_ID", "")
-        self._client_secret = client_secret or os.environ.get("SP_CLIENT_SECRET", "")
-        self._site_id = site_id or os.environ.get("SP_SITE_ID", "")
+        self._tenant_id = (
+            tenant_id or os.environ.get("SP_TENANT_ID", "")
+        )
+        self._client_id = (
+            client_id or os.environ.get("SP_CLIENT_ID", "")
+        )
+        self._client_secret = (
+            client_secret
+            or os.environ.get("SP_CLIENT_SECRET", "")
+        )
+        self._site_id = (
+            site_id or os.environ.get("SP_SITE_ID", "")
+        )
 
         self._auth = AzureADAuth(
             tenant_id=self._tenant_id,
@@ -72,31 +100,82 @@ class SharePointConnector:
         # Delta tokens per list for incremental sync
         self._delta_tokens: Dict[str, str] = {}
 
+    # ── ConnectorV1 contract ─────────────────────────────────────
+
+    def list_records(
+        self, **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
+        """List canonical records from a SharePoint list.
+
+        Parameters
+        ----------
+        list_id : str
+            SharePoint list ID (required keyword argument).
+        """
+        list_id: str = kwargs.get("list_id", "")
+        if not list_id:
+            raise ValueError(
+                "list_id is required for list_records()"
+            )
+        return self.list_items(list_id)
+
+    def get_record(
+        self, record_id: str, **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get a single canonical record by item ID.
+
+        Parameters
+        ----------
+        record_id : str
+            SharePoint item ID (raw Graph API id).
+        list_id : str
+            SharePoint list ID (required keyword argument).
+        """
+        list_id: str = kwargs.get("list_id", "")
+        if not list_id:
+            raise ValueError(
+                "list_id is required for get_record()"
+            )
+        return self.get_item(list_id, record_id)
+
     # ── Public API ───────────────────────────────────────────────
 
     def list_items(self, list_id: str) -> List[Dict[str, Any]]:
-        """Fetch all items from a SharePoint list and return canonical records."""
-        url = f"{GRAPH_BASE}/sites/{self._site_id}/lists/{list_id}/items?expand=fields"
+        """Fetch all items from a SharePoint list."""
+        url = (
+            f"{GRAPH_BASE}/sites/{self._site_id}"
+            f"/lists/{list_id}/items?expand=fields"
+        )
         data = self._graph_get(url)
         items = data.get("value", [])
         return [self._to_canonical(item, list_id) for item in items]
 
-    def get_item(self, list_id: str, item_id: str) -> Dict[str, Any]:
-        """Fetch a single list item and return a canonical record."""
-        url = f"{GRAPH_BASE}/sites/{self._site_id}/lists/{list_id}/items/{item_id}?expand=fields"
+    def get_item(
+        self, list_id: str, item_id: str,
+    ) -> Dict[str, Any]:
+        """Fetch a single list item as a canonical record."""
+        url = (
+            f"{GRAPH_BASE}/sites/{self._site_id}"
+            f"/lists/{list_id}/items/{item_id}"
+            f"?expand=fields"
+        )
         item = self._graph_get(url)
         return self._to_canonical(item, list_id)
 
     def delta_sync(self, list_id: str) -> Dict[str, Any]:
         """Incremental sync using Graph delta queries.
 
-        Returns ``{synced: str, created: int, updated: int, records: list}``.
+        Returns ``{synced, created, updated, records}``.
         """
         delta_token = self._delta_tokens.get(list_id)
         if delta_token:
             url = delta_token
         else:
-            url = f"{GRAPH_BASE}/sites/{self._site_id}/lists/{list_id}/items/delta?expand=fields"
+            url = (
+                f"{GRAPH_BASE}/sites/{self._site_id}"
+                f"/lists/{list_id}/items/delta"
+                f"?expand=fields"
+            )
 
         is_initial = not self._delta_tokens.get(list_id)
 
@@ -119,43 +198,75 @@ class SharePointConnector:
             "records": records,
         }
 
-    def subscribe(self, list_id: str, webhook_url: str, expiry_hours: int = 48) -> Dict[str, Any]:
-        """Create a Graph API webhook subscription for a list."""
+    def subscribe(
+        self,
+        list_id: str,
+        webhook_url: str,
+        expiry_hours: int = 48,
+    ) -> Dict[str, Any]:
+        """Create a Graph API webhook subscription."""
         from datetime import datetime, timedelta, timezone
 
-        expiry = (datetime.now(timezone.utc) + timedelta(hours=expiry_hours)).isoformat()
+        expiry = (
+            datetime.now(timezone.utc)
+            + timedelta(hours=expiry_hours)
+        ).isoformat()
+        resource = (
+            f"sites/{self._site_id}"
+            f"/lists/{list_id}/items"
+        )
         body = {
             "changeType": "created,updated,deleted",
             "notificationUrl": webhook_url,
-            "resource": f"sites/{self._site_id}/lists/{list_id}/items",
+            "resource": resource,
             "expirationDateTime": expiry,
         }
-        return self._graph_post(f"{GRAPH_BASE}/subscriptions", body)
+        url = f"{GRAPH_BASE}/subscriptions"
+        return self._graph_post(url, body)
 
     # ── Envelope contract ──────────────────────────────────────────
 
-    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
-        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+    def to_envelopes(
+        self, records: List[Dict[str, Any]],
+    ) -> list:
+        """Wrap canonical records in RecordEnvelopes."""
         from connectors.contract import canonical_to_envelope
-        instance = f"{self._site_id}" if self._site_id else "unknown"
-        return [canonical_to_envelope(r, source_instance=instance) for r in records]
+        inst = self._site_id or "unknown"
+        return [
+            canonical_to_envelope(r, source_instance=inst)
+            for r in records
+        ]
 
     # ── Field mapping ────────────────────────────────────────────
 
-    def _to_canonical(self, item: Dict[str, Any], list_id: str) -> Dict[str, Any]:
-        """Transform a Graph API list item to a canonical record envelope."""
+    def _to_canonical(
+        self, item: Dict[str, Any], list_id: str,
+    ) -> Dict[str, Any]:
+        """Transform a Graph API list item to a canonical record."""
         fields = item.get("fields", {})
-        item_id = str(item.get("id", fields.get("id", "")))
+        item_id = str(
+            item.get("id", fields.get("id", ""))
+        )
         content_type = fields.get("ContentType", {})
-        ct_name = content_type.get("Name", "") if isinstance(content_type, dict) else str(content_type)
+        if isinstance(content_type, dict):
+            ct_name = content_type.get("Name", "")
+        else:
+            ct_name = str(content_type)
 
-        record_type = _CONTENT_TYPE_MAP.get(ct_name, "Entity")
+        record_type = _CONTENT_TYPE_MAP.get(
+            ct_name, "Entity",
+        )
 
-        # Confidence: 0.8 for authored, 0.5 for auto-generated
-        author = fields.get("Author", item.get("createdBy", {}).get("user", {}).get("email", ""))
-        confidence = 0.5 if not author or author == "System Account" else 0.8
+        # Confidence: authored=0.8, auto-generated=0.5
+        created_by = item.get("createdBy", {})
+        user_email = (
+            created_by.get("user", {}).get("email", "")
+        )
+        author = fields.get("Author", user_email)
+        is_auto = not author or author == "System Account"
+        confidence = 0.5 if is_auto else 0.8
 
-        # TTL: 0 for policy/permanent, 604800000 (7d) for working docs
+        # TTL: 0 for permanent docs, 7d for working items
         ttl = 0 if record_type == "Document" else 604800000
 
         body = fields.get("Body", "")
@@ -182,12 +293,13 @@ class SharePointConnector:
                     "type": "human",
                 },
             },
-            "provenance": [
-                {
-                    "type": "source",
-                    "ref": f"sharepoint://{self._site_id}/{list_id}/{item_id}",
-                }
-            ],
+            "provenance": [{
+                "type": "source",
+                "ref": (
+                    f"sharepoint://{self._site_id}"
+                    f"/{list_id}/{item_id}"
+                ),
+            }],
             "confidence": {"score": confidence},
             "ttl": ttl,
             "content": {
@@ -210,32 +322,77 @@ class SharePointConnector:
             tags.append(f"approval:{moderation}")
         return tags
 
-    # ── HTTP helpers ─────────────────────────────────────────────
+    # ── HTTP helpers (with retry for 429 / 503) ────────────────
+
+    def _graph_request(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a Graph API request with retry on throttle.
+
+        Retries up to ``_MAX_RETRIES`` times on HTTP 429 or 503,
+        using exponential backoff and honouring the ``Retry-After``
+        header when present.
+        """
+        backoff = _INITIAL_BACKOFF_S
+        last_exc: Optional[Exception] = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            token = self._auth.get_token()
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            }
+            data = None
+            if body is not None:
+                data = json.dumps(body).encode()
+                headers["Content-Type"] = "application/json"
+
+            req = urllib.request.Request(
+                url,
+                data=data,
+                headers=headers,
+                method=method,
+            )
+            try:
+                with urllib.request.urlopen(
+                    req, timeout=30,
+                ) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                if exc.code not in (429, 503):
+                    raise
+                last_exc = exc
+                retry_after = exc.headers.get(
+                    "Retry-After",
+                )
+                if retry_after and retry_after.isdigit():
+                    wait = int(retry_after)
+                else:
+                    wait = backoff
+                logger.warning(
+                    "Graph API %s (attempt %d/%d), "
+                    "retrying in %ss: %s",
+                    exc.code,
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                    wait,
+                    url[:120],
+                )
+                time.sleep(wait)
+                backoff *= _BACKOFF_MULTIPLIER
+
+        raise last_exc  # type: ignore[misc]
 
     def _graph_get(self, url: str) -> Dict[str, Any]:
-        token = self._auth.get_token()
-        req = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/json",
-            },
-        )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            return json.loads(resp.read())
+        return self._graph_request(url)
 
-    def _graph_post(self, url: str, body: Dict[str, Any]) -> Dict[str, Any]:
-        token = self._auth.get_token()
-        data = json.dumps(body).encode()
-        req = urllib.request.Request(
-            url,
-            data=data,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-            method="POST",
+    def _graph_post(
+        self, url: str, body: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return self._graph_request(
+            url, method="POST", body=body,
         )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            return json.loads(resp.read())

--- a/tests/test_sharepoint_connector.py
+++ b/tests/test_sharepoint_connector.py
@@ -1,18 +1,30 @@
-"""Tests for adapters.sharepoint.connector — SharePoint Graph API connector."""
+"""Tests for SharePoint Graph API connector.
+
+Covers helper functions, canonical transformation, ConnectorV1
+contract methods (list_records, get_record), and 429 retry logic.
+"""
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
-
-
+import os
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from adapters._connector_helpers import strip_html, to_iso, uuid_from_hash, verify_webhook_hmac
+from adapters._connector_helpers import (  # noqa: E402
+    strip_html,
+    to_iso,
+    uuid_from_hash,
+    verify_webhook_hmac,
+)
 
 
-# ── Helper tests ──────────────────────────────────────────────────────────────
+# ── Helper tests ─────────────────────────────────────────────
+
 
 class TestUUIDFromHash:
     def test_deterministic(self):
@@ -50,7 +62,10 @@ class TestStripHTML:
         assert strip_html("<p>Hello</p>") == "Hello"
 
     def test_nested(self):
-        assert strip_html("<div><p>Hello <b>world</b></p></div>") == "Hello world"
+        result = strip_html(
+            "<div><p>Hello <b>world</b></p></div>"
+        )
+        assert result == "Hello world"
 
     def test_none(self):
         assert strip_html(None) == ""
@@ -63,26 +78,41 @@ class TestVerifyWebhookHMAC:
     def test_valid_signature(self):
         import hashlib
         import hmac as hmac_mod
+
         secret = "test-secret"
         body = b'{"test": true}'
-        sig = hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()
-        assert verify_webhook_hmac(body, secret, sig) is True
+        sig = hmac_mod.new(
+            secret.encode(), body, hashlib.sha256,
+        ).hexdigest()
+        assert verify_webhook_hmac(body, secret, sig)
 
     def test_invalid_signature(self):
-        assert verify_webhook_hmac(b"body", "secret", "bad-sig") is False
+        result = verify_webhook_hmac(
+            b"body", "secret", "bad-sig",
+        )
+        assert result is False
 
     def test_empty_secret(self):
-        assert verify_webhook_hmac(b"body", "", "sig") is False
+        result = verify_webhook_hmac(b"body", "", "sig")
+        assert result is False
 
 
-# ── SharePoint connector tests ───────────────────────────────────────────────
+# ── SharePoint connector tests ──────────────────────────────
 
-def _mock_graph_item(item_id="1", title="Test Item", content_type="Item", body="<p>Hello</p>"):
+
+def _mock_graph_item(
+    item_id="1",
+    title="Test Item",
+    content_type="Item",
+    body="<p>Hello</p>",
+):
     return {
         "id": item_id,
         "createdDateTime": "2024-01-15T10:00:00Z",
         "lastModifiedDateTime": "2024-01-16T12:00:00Z",
-        "createdBy": {"user": {"email": "user@example.com"}},
+        "createdBy": {
+            "user": {"email": "user@example.com"},
+        },
         "fields": {
             "id": item_id,
             "Title": title,
@@ -97,81 +127,108 @@ def _mock_graph_item(item_id="1", title="Test Item", content_type="Item", body="
 
 
 def _make_connector():
-    from adapters.sharepoint.connector import SharePointConnector
-    with patch.object(SharePointConnector, "__init__", lambda self, **kw: None):
-        c = SharePointConnector.__new__(SharePointConnector)
+    from adapters.sharepoint.connector import (
+        SharePointConnector,
+    )
+
+    with patch.object(
+        SharePointConnector,
+        "__init__",
+        lambda self, **kw: None,
+    ):
+        c = SharePointConnector.__new__(
+            SharePointConnector,
+        )
         c._site_id = "site-123"
         c._delta_tokens = {}
         c._auth = MagicMock()
         c._auth.get_token.return_value = "fake-token"
-        # Bind internal methods
         c._tenant_id = "t"
         c._client_id = "c"
         c._client_secret = "s"
         return c
 
 
+def _mock_urlopen(data):
+    """Create a mock urlopen context manager."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(
+        data,
+    ).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
 class TestSharePointConnector:
     def test_to_canonical_basic(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(), "list-1")
-        assert record["record_id"]
-        assert record["record_type"] == "Entity"  # "Item" maps to Entity
-        assert record["source"]["system"] == "sharepoint"
-        assert record["source"]["actor"]["id"] == "user@example.com"
-        assert record["content"]["title"] == "Test Item"
-        assert "Hello" in record["content"]["body"]
-        assert "<p>" not in record["content"]["body"]
+        rec = c._to_canonical(
+            _mock_graph_item(), "list-1",
+        )
+        assert rec["record_id"]
+        assert rec["record_type"] == "Entity"
+        assert rec["source"]["system"] == "sharepoint"
+        actor_id = rec["source"]["actor"]["id"]
+        assert actor_id == "user@example.com"
+        assert rec["content"]["title"] == "Test Item"
+        assert "Hello" in rec["content"]["body"]
+        assert "<p>" not in rec["content"]["body"]
 
     def test_to_canonical_document(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(content_type="Document"), "list-1")
-        assert record["record_type"] == "Document"
-        assert record["ttl"] == 0  # perpetual for docs
+        item = _mock_graph_item(content_type="Document")
+        rec = c._to_canonical(item, "list-1")
+        assert rec["record_type"] == "Document"
+        assert rec["ttl"] == 0
 
     def test_to_canonical_event(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(content_type="Event"), "list-1")
-        assert record["record_type"] == "Event"
+        item = _mock_graph_item(content_type="Event")
+        rec = c._to_canonical(item, "list-1")
+        assert rec["record_type"] == "Event"
 
     def test_to_canonical_confidence(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(), "list-1")
-        assert record["confidence"]["score"] == 0.8
+        rec = c._to_canonical(
+            _mock_graph_item(), "list-1",
+        )
+        assert rec["confidence"]["score"] == 0.8
 
     def test_to_canonical_auto_generated(self):
         c = _make_connector()
         item = _mock_graph_item()
         item["fields"]["Author"] = "System Account"
-        record = c._to_canonical(item, "list-1")
-        assert record["confidence"]["score"] == 0.5
+        rec = c._to_canonical(item, "list-1")
+        assert rec["confidence"]["score"] == 0.5
 
     def test_to_canonical_provenance(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(item_id="42"), "list-1")
-        assert record["provenance"][0]["ref"] == "sharepoint://site-123/list-1/42"
+        item = _mock_graph_item(item_id="42")
+        rec = c._to_canonical(item, "list-1")
+        ref = rec["provenance"][0]["ref"]
+        assert ref == "sharepoint://site-123/list-1/42"
 
     def test_to_canonical_dates(self):
         c = _make_connector()
-        record = c._to_canonical(_mock_graph_item(), "list-1")
-        assert "2024-01-15" in record["created_at"]
-        assert "2024-01-16" in record["observed_at"]
+        rec = c._to_canonical(
+            _mock_graph_item(), "list-1",
+        )
+        assert "2024-01-15" in rec["created_at"]
+        assert "2024-01-16" in rec["observed_at"]
 
     def test_to_canonical_tags(self):
         c = _make_connector()
         item = _mock_graph_item()
         item["fields"]["_ModerationStatus"] = "Approved"
-        record = c._to_canonical(item, "list-1")
-        assert "approval:Approved" in record["labels"]["tags"]
+        rec = c._to_canonical(item, "list-1")
+        assert "approval:Approved" in rec["labels"]["tags"]
 
     @patch("urllib.request.urlopen")
     def test_list_items(self, mock_urlopen):
         c = _make_connector()
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps({"value": [_mock_graph_item()]}).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
+        data = {"value": [_mock_graph_item()]}
+        mock_urlopen.return_value = _mock_urlopen(data)
 
         records = c.list_items("list-1")
         assert len(records) == 1
@@ -180,40 +237,235 @@ class TestSharePointConnector:
     @patch("urllib.request.urlopen")
     def test_get_item(self, mock_urlopen):
         c = _make_connector()
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(_mock_graph_item(item_id="42")).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
+        item = _mock_graph_item(item_id="42")
+        mock_urlopen.return_value = _mock_urlopen(item)
 
-        record = c.get_item("list-1", "42")
-        assert "42" in record["provenance"][0]["ref"]
+        rec = c.get_item("list-1", "42")
+        assert "42" in rec["provenance"][0]["ref"]
 
     @patch("urllib.request.urlopen")
     def test_delta_sync(self, mock_urlopen):
         c = _make_connector()
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps({
-            "value": [_mock_graph_item(), _mock_graph_item(item_id="2")],
-            "@odata.deltaLink": "https://graph.microsoft.com/delta?token=abc",
-        }).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
+        delta_url = (
+            "https://graph.microsoft.com/delta"
+            "?token=abc"
+        )
+        data = {
+            "value": [
+                _mock_graph_item(),
+                _mock_graph_item(item_id="2"),
+            ],
+            "@odata.deltaLink": delta_url,
+        }
+        mock_urlopen.return_value = _mock_urlopen(data)
 
         result = c.delta_sync("list-1")
         assert result["created"] == 2
         assert len(result["records"]) == 2
-        assert c._delta_tokens["list-1"] == "https://graph.microsoft.com/delta?token=abc"
+        assert c._delta_tokens["list-1"] == delta_url
 
     def test_deterministic_record_ids(self):
         c = _make_connector()
-        r1 = c._to_canonical(_mock_graph_item(item_id="42"), "list-1")
-        r2 = c._to_canonical(_mock_graph_item(item_id="42"), "list-1")
+        item = _mock_graph_item(item_id="42")
+        r1 = c._to_canonical(item, "list-1")
+        r2 = c._to_canonical(item, "list-1")
         assert r1["record_id"] == r2["record_id"]
 
     def test_different_items_different_ids(self):
         c = _make_connector()
-        r1 = c._to_canonical(_mock_graph_item(item_id="1"), "list-1")
-        r2 = c._to_canonical(_mock_graph_item(item_id="2"), "list-1")
+        r1 = c._to_canonical(
+            _mock_graph_item(item_id="1"), "list-1",
+        )
+        r2 = c._to_canonical(
+            _mock_graph_item(item_id="2"), "list-1",
+        )
         assert r1["record_id"] != r2["record_id"]
+
+
+# ── ConnectorV1 contract tests ──────────────────────────────
+
+
+class TestConnectorV1Contract:
+    """Verify list_records / get_record protocol methods."""
+
+    @patch("urllib.request.urlopen")
+    def test_list_records(self, mock_urlopen):
+        c = _make_connector()
+        data = {"value": [_mock_graph_item()]}
+        mock_urlopen.return_value = _mock_urlopen(data)
+
+        records = c.list_records(list_id="list-1")
+        assert len(records) == 1
+        assert records[0]["source"]["system"] == "sharepoint"
+
+    def test_list_records_requires_list_id(self):
+        c = _make_connector()
+        with pytest.raises(ValueError, match="list_id"):
+            c.list_records()
+
+    @patch("urllib.request.urlopen")
+    def test_get_record(self, mock_urlopen):
+        c = _make_connector()
+        item = _mock_graph_item(item_id="42")
+        mock_urlopen.return_value = _mock_urlopen(item)
+
+        rec = c.get_record("42", list_id="list-1")
+        assert "42" in rec["provenance"][0]["ref"]
+
+    def test_get_record_requires_list_id(self):
+        c = _make_connector()
+        with pytest.raises(ValueError, match="list_id"):
+            c.get_record("42")
+
+    @patch("urllib.request.urlopen")
+    def test_to_envelopes(self, mock_urlopen):
+        c = _make_connector()
+        data = {"value": [_mock_graph_item()]}
+        mock_urlopen.return_value = _mock_urlopen(data)
+
+        records = c.list_records(list_id="list-1")
+        envelopes = c.to_envelopes(records)
+        assert len(envelopes) == 1
+        assert envelopes[0].source == "sharepoint"
+        assert envelopes[0].source_instance == "site-123"
+
+
+# ── Rate-limit / 429 retry tests ────────────────────────────
+
+
+class TestThrottleRetry:
+    """Verify exponential backoff on HTTP 429 / 503."""
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_429_retry_succeeds(
+        self, mock_urlopen, mock_sleep,
+    ):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "http://graph", 429, "Too Many Requests",
+            {"Retry-After": "1"}, None,
+        )
+        ok = _mock_urlopen({"value": []})
+        mock_urlopen.side_effect = [err, ok]
+
+        c = _make_connector()
+        result = c._graph_get("http://graph/test")
+        assert result == {"value": []}
+        assert mock_sleep.call_count == 1
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_503_retry_succeeds(
+        self, mock_urlopen, mock_sleep,
+    ):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "http://graph", 503, "Service Unavailable",
+            {}, None,
+        )
+        ok = _mock_urlopen({"value": []})
+        mock_urlopen.side_effect = [err, ok]
+
+        c = _make_connector()
+        result = c._graph_get("http://graph/test")
+        assert result == {"value": []}
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_429_exhausted_raises(
+        self, mock_urlopen, mock_sleep,
+    ):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "http://graph", 429, "Too Many Requests",
+            {}, None,
+        )
+        mock_urlopen.side_effect = [err] * 10
+
+        c = _make_connector()
+        with pytest.raises(urllib.error.HTTPError):
+            c._graph_get("http://graph/test")
+
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retry_after_header_honoured(
+        self, mock_urlopen, mock_sleep,
+    ):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "http://graph", 429, "Throttled",
+            {"Retry-After": "5"}, None,
+        )
+        ok = _mock_urlopen({"value": []})
+        mock_urlopen.side_effect = [err, ok]
+
+        c = _make_connector()
+        c._graph_get("http://graph/test")
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("urllib.request.urlopen")
+    def test_non_retryable_error_raises(
+        self, mock_urlopen,
+    ):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "http://graph", 403, "Forbidden",
+            {}, None,
+        )
+        mock_urlopen.side_effect = err
+
+        c = _make_connector()
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            c._graph_get("http://graph/test")
+        assert exc.value.code == 403
+
+
+# ── Integration tests (skip without creds) ──────────────────
+
+_HAS_SP_CREDS = all(
+    os.environ.get(k)
+    for k in (
+        "SP_TENANT_ID", "SP_CLIENT_ID",
+        "SP_CLIENT_SECRET", "SP_SITE_ID",
+    )
+)
+
+
+@pytest.mark.skipif(
+    not _HAS_SP_CREDS,
+    reason="SharePoint credentials not configured",
+)
+class TestSharePointIntegration:
+    """Live integration tests — require real Azure AD creds.
+
+    Set SP_TENANT_ID, SP_CLIENT_ID, SP_CLIENT_SECRET,
+    SP_SITE_ID to enable.
+    """
+
+    def test_auth_token_acquisition(self):
+        from adapters.sharepoint.connector import (
+            SharePointConnector,
+        )
+
+        c = SharePointConnector()
+        token = c._auth.get_token()
+        assert token
+        assert len(token) > 20
+
+    def test_list_records_live(self):
+        from adapters.sharepoint.connector import (
+            SharePointConnector,
+        )
+
+        c = SharePointConnector()
+        list_id = os.environ.get("SP_TEST_LIST_ID", "")
+        if not list_id:
+            pytest.skip("SP_TEST_LIST_ID not set")
+        records = c.list_records(list_id=list_id)
+        assert isinstance(records, list)


### PR DESCRIPTION
## Summary
- Add `list_records()` and `get_record()` methods for ConnectorV1 contract compliance
- Add rate-limit handling with exponential backoff for HTTP 429 / 503 (honours `Retry-After` header)
- Add integration tests with `skip-if-no-creds` marker for live Azure AD testing
- Fix all E501 line-length violations

## Test plan
- [x] 36 unit tests pass (helpers, canonical, contract, retry, throttle)
- [x] 2 integration tests skip gracefully without credentials
- [x] Full suite: 1045 passed, no regressions
- [x] Lint clean

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)