### PR TITLE
feat: Snowflake connector contract compliance (#94)

### DIFF
--- a/adapters/snowflake/warehouse.py
+++ b/adapters/snowflake/warehouse.py
@@ -1,12 +1,18 @@
 """Snowflake Data Warehouse connector.
 
-Uses the Snowflake SQL REST API (``POST /api/v2/statements``) for queries.
+Uses the Snowflake SQL REST API (``POST /api/v2/statements``).
+
+Production features:
+- ConnectorV1 contract compliance (list_records, get_record)
+- Column mapping configuration for evidence field extraction
+- Table, view, and query source modes
+- JWT, OAuth, and PAT authentication
 
 Usage::
 
     connector = SnowflakeWarehouseConnector()
-    rows = connector.query("SELECT * FROM my_table LIMIT 10")
-    tables = connector.list_tables()
+    records = connector.list_records(table="users")
+    record  = connector.get_record("rec-id", table="users")
 """
 from __future__ import annotations
 
@@ -20,6 +26,16 @@ from adapters._connector_helpers import to_iso, uuid_from_hash
 from adapters.snowflake._auth import SnowflakeAuth
 
 logger = logging.getLogger(__name__)
+
+# Default column mapping: Snowflake column → canonical field
+_DEFAULT_COLUMN_MAP: Dict[str, str] = {
+    "ID": "record_id",
+    "CREATED_AT": "created_at",
+    "UPDATED_AT": "observed_at",
+    "TITLE": "content.title",
+    "BODY": "content.body",
+    "TAGS": "labels.tags",
+}
 
 
 class SnowflakeWarehouseConnector:
@@ -37,11 +53,102 @@ class SnowflakeWarehouseConnector:
 
     source_name = "snowflake"
 
-    def __init__(self, auth: Optional[SnowflakeAuth] = None) -> None:
+    def __init__(
+        self,
+        auth: Optional[SnowflakeAuth] = None,
+        column_map: Optional[Dict[str, str]] = None,
+    ) -> None:
         self._auth = auth or SnowflakeAuth()
-        self._database = os.environ.get("SNOWFLAKE_DATABASE", "")
-        self._schema = os.environ.get("SNOWFLAKE_SCHEMA", "PUBLIC")
-        self._warehouse = os.environ.get("SNOWFLAKE_WAREHOUSE", "")
+        self._database = os.environ.get(
+            "SNOWFLAKE_DATABASE", "",
+        )
+        self._schema = os.environ.get(
+            "SNOWFLAKE_SCHEMA", "PUBLIC",
+        )
+        self._warehouse = os.environ.get(
+            "SNOWFLAKE_WAREHOUSE", "",
+        )
+        self._column_map = column_map or dict(
+            _DEFAULT_COLUMN_MAP,
+        )
+
+    # ── ConnectorV1 contract ─────────────────────────────────────
+
+    def list_records(
+        self, **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
+        """List canonical records from a Snowflake table.
+
+        Parameters
+        ----------
+        table : str
+            Table name (required keyword argument).
+        sql : str, optional
+            Custom SQL query (overrides table).
+        limit : int, optional
+            Max rows to return (default 1000).
+        """
+        sql = kwargs.get("sql", "")
+        table = kwargs.get("table", "")
+        limit = kwargs.get("limit", 1000)
+
+        if sql:
+            rows = self.query(sql)
+            tbl = table or "query"
+        elif table:
+            fqt = (
+                f"{self._database}"
+                f".{self._schema}.{table}"
+            )
+            stmt = (
+                f"SELECT * FROM {fqt}"
+                f" ORDER BY 1 DESC LIMIT {limit}"
+            )
+            rows = self.query(stmt)
+            tbl = table
+        else:
+            raise ValueError(
+                "table or sql is required "
+                "for list_records()"
+            )
+        return self.to_canonical(rows, tbl)
+
+    def get_record(
+        self, record_id: str, **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get a single canonical record by primary key.
+
+        Parameters
+        ----------
+        record_id : str
+            Primary key value.
+        table : str
+            Table name (required keyword argument).
+        pk_column : str, optional
+            Primary key column name (default ``ID``).
+        """
+        table = kwargs.get("table", "")
+        if not table:
+            raise ValueError(
+                "table is required for get_record()"
+            )
+        pk_col = kwargs.get("pk_column", "ID")
+        fqt = (
+            f"{self._database}"
+            f".{self._schema}.{table}"
+        )
+        sql = (
+            f"SELECT * FROM {fqt}"
+            f" WHERE {pk_col} = '{record_id}'"
+            f" LIMIT 1"
+        )
+        rows = self.query(sql)
+        if not rows:
+            raise LookupError(
+                f"Record {record_id} not found "
+                f"in {table}"
+            )
+        return self.to_canonical(rows, table)[0]
 
     # ── Public API ───────────────────────────────────────────────
 
@@ -52,59 +159,117 @@ class SnowflakeWarehouseConnector:
 
     def list_tables(self) -> List[Dict[str, Any]]:
         """List tables in the configured database/schema."""
-        sql = f"SHOW TABLES IN {self._database}.{self._schema}"
+        sql = (
+            f"SHOW TABLES IN"
+            f" {self._database}.{self._schema}"
+        )
         result = self._execute_statement(sql)
         return self._parse_result(result)
 
-    def get_table_schema(self, table: str) -> List[Dict[str, Any]]:
+    def get_table_schema(
+        self, table: str,
+    ) -> List[Dict[str, Any]]:
         """Describe a table's column definitions."""
-        sql = f"DESCRIBE TABLE {self._database}.{self._schema}.{table}"
+        fqt = (
+            f"{self._database}"
+            f".{self._schema}.{table}"
+        )
+        sql = f"DESCRIBE TABLE {fqt}"
         result = self._execute_statement(sql)
         return self._parse_result(result)
 
-    def to_envelopes(self, records: List[Dict[str, Any]]) -> list:
-        """Wrap canonical records in RecordEnvelope instances (ConnectorV1)."""
+    def to_envelopes(
+        self, records: List[Dict[str, Any]],
+    ) -> list:
+        """Wrap canonical records in RecordEnvelopes."""
         from connectors.contract import canonical_to_envelope
-        instance = self._auth.account if self._auth else "unknown"
-        return [canonical_to_envelope(r, source_instance=instance) for r in records]
+        inst = (
+            self._auth.account if self._auth
+            else "unknown"
+        )
+        return [
+            canonical_to_envelope(
+                r, source_instance=inst,
+            )
+            for r in records
+        ]
 
-    def to_canonical(self, rows: List[Dict[str, Any]], table_name: str) -> List[Dict[str, Any]]:
+    def to_canonical(
+        self,
+        rows: List[Dict[str, Any]],
+        table_name: str,
+    ) -> List[Dict[str, Any]]:
         """Transform SQL rows to canonical records."""
         records = []
         for row in rows:
             pk = self._find_pk(row)
-            fqn = f"{self._database}.{self._schema}.{table_name}"
-            record_id = uuid_from_hash("snowflake", f"{fqn}.{pk}") if pk else ""
+            fqn = (
+                f"{self._database}"
+                f".{self._schema}.{table_name}"
+            )
+            rec_id = (
+                uuid_from_hash("snowflake", f"{fqn}.{pk}")
+                if pk else ""
+            )
 
+            # Use column mapping for dates
+            created_col = self._mapped_value(
+                row, "created_at",
+            )
+            updated_col = self._mapped_value(
+                row, "observed_at",
+            )
+
+            prov_ref = (
+                f"snowflake://{self._auth.account}"
+                f"/{fqn}/{pk}"
+            )
             records.append({
-                "record_id": record_id,
+                "record_id": rec_id,
                 "record_type": self._infer_type(row),
-                "created_at": to_iso(str(row.get("CREATED_AT", row.get("created_at", "")))),
-                "observed_at": to_iso(str(row.get("UPDATED_AT", row.get("updated_at", "")))),
+                "created_at": to_iso(str(created_col)),
+                "observed_at": to_iso(str(updated_col)),
                 "source": {
                     "system": "snowflake",
-                    "actor": {"id": "", "type": "system"},
+                    "actor": {
+                        "id": "", "type": "system",
+                    },
                 },
-                "provenance": [
-                    {
-                        "type": "source",
-                        "ref": f"snowflake://{self._auth.account}/{fqn}/{pk}",
-                    }
-                ],
+                "provenance": [{
+                    "type": "source",
+                    "ref": prov_ref,
+                }],
                 "confidence": {"score": 0.90},
-                "ttl": 86400000,  # 24h default for warehouse data
-                "content": {k: v for k, v in row.items()},
-                "labels": {"tags": [f"table:{table_name}"]},
+                "ttl": 86400000,
+                "content": dict(row.items()),
+                "labels": {
+                    "tags": [f"table:{table_name}"],
+                },
             })
         return records
 
-    def sync_table(self, table_name: str, since: Optional[str] = None) -> Dict[str, Any]:
+    def sync_table(
+        self,
+        table_name: str,
+        since: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Sync rows from a table, optionally since a timestamp."""
-        fqt = f"{self._database}.{self._schema}.{table_name}"
+        fqt = (
+            f"{self._database}"
+            f".{self._schema}.{table_name}"
+        )
         if since:
-            sql = f"SELECT * FROM {fqt} WHERE UPDATED_AT > '{since}' ORDER BY UPDATED_AT"
+            sql = (
+                f"SELECT * FROM {fqt}"
+                f" WHERE UPDATED_AT > '{since}'"
+                f" ORDER BY UPDATED_AT"
+            )
         else:
-            sql = f"SELECT * FROM {fqt} ORDER BY UPDATED_AT DESC LIMIT 1000"
+            sql = (
+                f"SELECT * FROM {fqt}"
+                f" ORDER BY UPDATED_AT DESC"
+                f" LIMIT 1000"
+            )
 
         rows = self.query(sql)
         records = self.to_canonical(rows, table_name)
@@ -113,10 +278,37 @@ class SnowflakeWarehouseConnector:
             "records": records,
         }
 
+    def _mapped_value(
+        self, row: Dict[str, Any], field: str,
+    ) -> Any:
+        """Resolve a canonical field via column map.
+
+        Checks mapped column name and case variants.
+        Falls back to default map if instance was
+        created without __init__ (mock testing).
+        """
+        col_map = getattr(
+            self, "_column_map", _DEFAULT_COLUMN_MAP,
+        )
+        # Reverse lookup: canonical field → source col
+        for src_col, tgt_field in col_map.items():
+            if tgt_field == field:
+                if src_col in row:
+                    return row[src_col]
+                lower = src_col.lower()
+                if lower in row:
+                    return row[lower]
+        return ""
+
     # ── SQL REST API ─────────────────────────────────────────────
 
-    def _execute_statement(self, sql: str) -> Dict[str, Any]:
-        url = f"{self._auth.base_url}/api/v2/statements"
+    def _execute_statement(
+        self, sql: str,
+    ) -> Dict[str, Any]:
+        url = (
+            f"{self._auth.base_url}"
+            f"/api/v2/statements"
+        )
         payload = {
             "statement": sql,
             "timeout": 60,
@@ -130,15 +322,26 @@ class SnowflakeWarehouseConnector:
         headers["Accept"] = "application/json"
 
         data = json.dumps(payload).encode()
-        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        req = urllib.request.Request(
+            url, data=data,
+            headers=headers, method="POST",
+        )
 
-        with urllib.request.urlopen(req, timeout=60) as resp:
+        with urllib.request.urlopen(
+            req, timeout=60,
+        ) as resp:
             return json.loads(resp.read())
 
     @staticmethod
-    def _parse_result(result: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Parse Snowflake SQL REST API response into row dicts."""
-        columns = [col["name"] for col in result.get("resultSetMetaData", {}).get("rowType", [])]
+    def _parse_result(
+        result: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Parse Snowflake SQL REST API response."""
+        meta = result.get("resultSetMetaData", {})
+        columns = [
+            col["name"]
+            for col in meta.get("rowType", [])
+        ]
         rows = []
         for data_row in result.get("data", []):
             rows.append(dict(zip(columns, data_row)))
@@ -147,10 +350,12 @@ class SnowflakeWarehouseConnector:
     @staticmethod
     def _find_pk(row: Dict[str, Any]) -> str:
         """Find primary key value from a row."""
-        for key in ("ID", "id", "PK", "pk", "PRIMARY_KEY"):
+        pk_names = (
+            "ID", "id", "PK", "pk", "PRIMARY_KEY",
+        )
+        for key in pk_names:
             if key in row and row[key]:
                 return str(row[key])
-        # Fallback: first column
         for v in row.values():
             if v:
                 return str(v)
@@ -160,8 +365,14 @@ class SnowflakeWarehouseConnector:
     def _infer_type(row: Dict[str, Any]) -> str:
         """Infer canonical record_type from row content."""
         keys = {k.lower() for k in row.keys()}
-        if any(k in keys for k in ("metric", "value", "measurement", "score")):
+        metric_keys = (
+            "metric", "value", "measurement", "score",
+        )
+        entity_keys = (
+            "name", "entity", "account", "customer",
+        )
+        if any(k in keys for k in metric_keys):
             return "Metric"
-        if any(k in keys for k in ("name", "entity", "account", "customer")):
+        if any(k in keys for k in entity_keys):
             return "Entity"
         return "Claim"

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -1,4 +1,8 @@
-"""Tests for adapters.snowflake — Cortex AI + Data Warehouse connectors."""
+"""Tests for Snowflake connectors (Cortex AI + Warehouse).
+
+Covers auth, Cortex connector, warehouse connector,
+ConnectorV1 contract, column mapping, and exhaust adapter.
+"""
 from __future__ import annotations
 
 import json
@@ -11,48 +15,77 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
-# ── Auth tests ───────────────────────────────────────────────────────────────
+# ── Auth tests ──────────────────────────────────────────────
+
 
 class TestSnowflakeAuth:
     def test_pat_token_headers(self):
         from adapters.snowflake._auth import SnowflakeAuth
-        auth = SnowflakeAuth(account="xy12345", token="my-oauth-token")
+        auth = SnowflakeAuth(
+            account="xy12345", token="my-oauth-token",
+        )
         headers = auth.get_headers()
-        assert headers["Authorization"] == "Bearer my-oauth-token"
-        assert headers["X-Snowflake-Authorization-Token-Type"] == "OAUTH"
+        assert headers["Authorization"] == (
+            "Bearer my-oauth-token"
+        )
+        tok_type = headers[
+            "X-Snowflake-Authorization-Token-Type"
+        ]
+        assert tok_type == "OAUTH"
 
     def test_pat_programmatic_token(self):
         from adapters.snowflake._auth import SnowflakeAuth
-        auth = SnowflakeAuth(account="xy12345", token="ver:1:abc123")
+        auth = SnowflakeAuth(
+            account="xy12345", token="ver:1:abc123",
+        )
         headers = auth.get_headers()
-        assert headers["X-Snowflake-Authorization-Token-Type"] == "PROGRAMMATIC_ACCESS_TOKEN"
+        tok_type = headers[
+            "X-Snowflake-Authorization-Token-Type"
+        ]
+        assert tok_type == "PROGRAMMATIC_ACCESS_TOKEN"
 
     def test_no_auth_raises(self):
         from adapters.snowflake._auth import SnowflakeAuth
         auth = SnowflakeAuth(account="xy12345")
-        with pytest.raises(RuntimeError, match="No Snowflake auth"):
+        with pytest.raises(
+            RuntimeError, match="No Snowflake auth",
+        ):
             auth.get_headers()
 
     def test_base_url(self):
         from adapters.snowflake._auth import SnowflakeAuth
-        auth = SnowflakeAuth(account="xy12345.us-east-1")
-        assert auth.base_url == "https://xy12345.us-east-1.snowflakecomputing.com"
+        auth = SnowflakeAuth(
+            account="xy12345.us-east-1",
+        )
+        expected = (
+            "https://xy12345.us-east-1"
+            ".snowflakecomputing.com"
+        )
+        assert auth.base_url == expected
 
     def test_jwt_requires_cryptography(self):
         from adapters.snowflake._auth import SnowflakeAuth
-        auth = SnowflakeAuth(account="xy12345", user="USER", private_key_path="/nonexistent/key.pem")
-        # Will fail because cryptography not installed or key doesn't exist
+        auth = SnowflakeAuth(
+            account="xy12345",
+            user="USER",
+            private_key_path="/nonexistent/key.pem",
+        )
         with pytest.raises(Exception):
             auth.get_headers()
 
 
-# ── Cortex connector tests ───────────────────────────────────────────────────
+# ── Cortex connector tests ──────────────────────────────────
+
 
 def _mock_sse_response(chunks):
     """Create a mock SSE response with data lines."""
     lines = []
     for chunk in chunks:
-        data = json.dumps({"choices": [{"delta": {"content": chunk}}]})
+        data = json.dumps({
+            "choices": [
+                {"delta": {"content": chunk}},
+            ],
+        })
         lines.append(f"data: {data}\n".encode())
     lines.append(b"data: [DONE]\n")
 
@@ -65,7 +98,9 @@ def _mock_sse_response(chunks):
 
 def _mock_json_response(data):
     mock_resp = MagicMock()
-    mock_resp.read.return_value = json.dumps(data).encode()
+    mock_resp.read.return_value = json.dumps(
+        data,
+    ).encode()
     mock_resp.__enter__ = lambda s: s
     mock_resp.__exit__ = MagicMock(return_value=False)
     return mock_resp
@@ -74,33 +109,49 @@ def _mock_json_response(data):
 class TestCortexConnector:
     @patch("urllib.request.urlopen")
     def test_complete_basic(self, mock_urlopen):
-        from adapters.snowflake.cortex import CortexConnector
+        from adapters.snowflake.cortex import (
+            CortexConnector,
+        )
         from adapters.snowflake._auth import SnowflakeAuth
 
         auth = SnowflakeAuth(account="test", token="tok")
         connector = CortexConnector(auth=auth)
 
-        mock_urlopen.return_value = _mock_sse_response(["Hello", " world"])
-        chunks = connector.complete("mistral-large", [{"role": "user", "content": "Hi"}])
+        mock_urlopen.return_value = _mock_sse_response(
+            ["Hello", " world"],
+        )
+        msgs = [{"role": "user", "content": "Hi"}]
+        chunks = connector.complete(
+            "mistral-large", msgs,
+        )
         assert chunks == ["Hello", " world"]
 
     @patch("urllib.request.urlopen")
     def test_complete_sync(self, mock_urlopen):
-        from adapters.snowflake.cortex import CortexConnector
+        from adapters.snowflake.cortex import (
+            CortexConnector,
+        )
         from adapters.snowflake._auth import SnowflakeAuth
 
         auth = SnowflakeAuth(account="test", token="tok")
         connector = CortexConnector(auth=auth)
 
-        mock_urlopen.return_value = _mock_sse_response(["Hello", " world"])
-        result = connector.complete_sync("mistral-large", [{"role": "user", "content": "Hi"}])
+        mock_urlopen.return_value = _mock_sse_response(
+            ["Hello", " world"],
+        )
+        msgs = [{"role": "user", "content": "Hi"}]
+        result = connector.complete_sync(
+            "mistral-large", msgs,
+        )
         assert result["response"] == "Hello world"
         assert result["model"] == "mistral-large"
         assert result["usage"]["chunks"] == 2
 
     @patch("urllib.request.urlopen")
     def test_embed(self, mock_urlopen):
-        from adapters.snowflake.cortex import CortexConnector
+        from adapters.snowflake.cortex import (
+            CortexConnector,
+        )
         from adapters.snowflake._auth import SnowflakeAuth
 
         auth = SnowflakeAuth(account="test", token="tok")
@@ -110,15 +161,19 @@ class TestCortexConnector:
             "data": [
                 {"embedding": [0.1, 0.2, 0.3]},
                 {"embedding": [0.4, 0.5, 0.6]},
-            ]
+            ],
         })
-        result = connector.embed("e5-base-v2", ["text1", "text2"])
+        result = connector.embed(
+            "e5-base-v2", ["text1", "text2"],
+        )
         assert len(result["embeddings"]) == 2
         assert result["model"] == "e5-base-v2"
 
     @patch("urllib.request.urlopen")
     def test_complete_empty_stream(self, mock_urlopen):
-        from adapters.snowflake.cortex import CortexConnector
+        from adapters.snowflake.cortex import (
+            CortexConnector,
+        )
         from adapters.snowflake._auth import SnowflakeAuth
 
         auth = SnowflakeAuth(account="test", token="tok")
@@ -129,45 +184,66 @@ class TestCortexConnector:
         assert result["response"] == ""
 
 
-# ── Warehouse connector tests ────────────────────────────────────────────────
+# ── Warehouse connector tests ───────────────────────────────
+
+
+def _make_warehouse(column_map=None):
+    from adapters.snowflake.warehouse import (
+        SnowflakeWarehouseConnector,
+    )
+    from adapters.snowflake._auth import SnowflakeAuth
+
+    auth = SnowflakeAuth(account="test", token="tok")
+    with patch.dict("os.environ", {
+        "SNOWFLAKE_DATABASE": "TESTDB",
+        "SNOWFLAKE_SCHEMA": "PUBLIC",
+        "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+    }):
+        return SnowflakeWarehouseConnector(
+            auth=auth, column_map=column_map,
+        )
+
 
 class TestSnowflakeWarehouseConnector:
-    def _make_connector(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
-        from adapters.snowflake._auth import SnowflakeAuth
-
-        auth = SnowflakeAuth(account="test", token="tok")
-        with patch.dict("os.environ", {
-            "SNOWFLAKE_DATABASE": "TESTDB",
-            "SNOWFLAKE_SCHEMA": "PUBLIC",
-            "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
-        }):
-            return SnowflakeWarehouseConnector(auth=auth)
-
     @patch("urllib.request.urlopen")
     def test_query(self, mock_urlopen):
-        connector = self._make_connector()
+        c = _make_warehouse()
         mock_urlopen.return_value = _mock_json_response({
-            "resultSetMetaData": {"rowType": [{"name": "ID"}, {"name": "NAME"}]},
+            "resultSetMetaData": {
+                "rowType": [
+                    {"name": "ID"},
+                    {"name": "NAME"},
+                ],
+            },
             "data": [["1", "Alice"], ["2", "Bob"]],
         })
-        rows = connector.query("SELECT * FROM users")
+        rows = c.query("SELECT * FROM users")
         assert len(rows) == 2
         assert rows[0]["ID"] == "1"
         assert rows[0]["NAME"] == "Alice"
 
     @patch("urllib.request.urlopen")
     def test_list_tables(self, mock_urlopen):
-        connector = self._make_connector()
+        c = _make_warehouse()
         mock_urlopen.return_value = _mock_json_response({
-            "resultSetMetaData": {"rowType": [{"name": "name"}, {"name": "kind"}]},
-            "data": [["users", "TABLE"], ["orders", "TABLE"]],
+            "resultSetMetaData": {
+                "rowType": [
+                    {"name": "name"},
+                    {"name": "kind"},
+                ],
+            },
+            "data": [
+                ["users", "TABLE"],
+                ["orders", "TABLE"],
+            ],
         })
-        tables = connector.list_tables()
+        tables = c.list_tables()
         assert len(tables) == 2
 
     def test_parse_result_empty(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
+        from adapters.snowflake.warehouse import (
+            SnowflakeWarehouseConnector,
+        )
         rows = SnowflakeWarehouseConnector._parse_result({
             "resultSetMetaData": {"rowType": []},
             "data": [],
@@ -175,69 +251,236 @@ class TestSnowflakeWarehouseConnector:
         assert rows == []
 
     def test_to_canonical(self):
-        connector = self._make_connector()
+        c = _make_warehouse()
         rows = [
             {"ID": "1", "name": "Alice", "score": 95},
             {"ID": "2", "name": "Bob", "score": 87},
         ]
-        records = connector.to_canonical(rows, "users")
+        records = c.to_canonical(rows, "users")
         assert len(records) == 2
-        assert records[0]["record_id"]  # not empty
-        assert records[0]["source"]["system"] == "snowflake"
+        assert records[0]["record_id"]
+        sys = records[0]["source"]["system"]
+        assert sys == "snowflake"
         assert records[0]["confidence"]["score"] == 0.90
-        assert "table:users" in records[0]["labels"]["tags"]
+        tags = records[0]["labels"]["tags"]
+        assert "table:users" in tags
 
     def test_to_canonical_provenance(self):
-        connector = self._make_connector()
-        records = connector.to_canonical([{"ID": "42", "value": 100}], "metrics")
+        c = _make_warehouse()
+        records = c.to_canonical(
+            [{"ID": "42", "value": 100}], "metrics",
+        )
         prov = records[0]["provenance"][0]
         assert prov["type"] == "source"
         assert "snowflake://test/" in prov["ref"]
         assert "metrics" in prov["ref"]
 
     def test_infer_type_metric(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
-        assert SnowflakeWarehouseConnector._infer_type({"value": 100, "metric": "latency"}) == "Metric"
+        from adapters.snowflake.warehouse import (
+            SnowflakeWarehouseConnector as SWC,
+        )
+        row = {"value": 100, "metric": "latency"}
+        assert SWC._infer_type(row) == "Metric"
 
     def test_infer_type_entity(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
-        assert SnowflakeWarehouseConnector._infer_type({"name": "Alice", "email": "a@b.com"}) == "Entity"
+        from adapters.snowflake.warehouse import (
+            SnowflakeWarehouseConnector as SWC,
+        )
+        row = {"name": "Alice", "email": "a@b.com"}
+        assert SWC._infer_type(row) == "Entity"
 
     def test_infer_type_claim(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
-        assert SnowflakeWarehouseConnector._infer_type({"result": "pass", "detail": "ok"}) == "Claim"
+        from adapters.snowflake.warehouse import (
+            SnowflakeWarehouseConnector as SWC,
+        )
+        row = {"result": "pass", "detail": "ok"}
+        assert SWC._infer_type(row) == "Claim"
 
     @patch("urllib.request.urlopen")
     def test_sync_table(self, mock_urlopen):
-        connector = self._make_connector()
+        c = _make_warehouse()
         mock_urlopen.return_value = _mock_json_response({
-            "resultSetMetaData": {"rowType": [{"name": "ID"}, {"name": "NAME"}]},
+            "resultSetMetaData": {
+                "rowType": [
+                    {"name": "ID"},
+                    {"name": "NAME"},
+                ],
+            },
             "data": [["1", "Alice"]],
         })
-        result = connector.sync_table("users")
+        result = c.sync_table("users")
         assert result["synced"] == 1
         assert len(result["records"]) == 1
 
     def test_find_pk(self):
-        from adapters.snowflake.warehouse import SnowflakeWarehouseConnector
-        assert SnowflakeWarehouseConnector._find_pk({"ID": "42", "name": "test"}) == "42"
-        assert SnowflakeWarehouseConnector._find_pk({"pk": "99"}) == "99"
-        assert SnowflakeWarehouseConnector._find_pk({"col1": "val1"}) == "val1"
+        from adapters.snowflake.warehouse import (
+            SnowflakeWarehouseConnector as SWC,
+        )
+        assert SWC._find_pk(
+            {"ID": "42", "name": "test"},
+        ) == "42"
+        assert SWC._find_pk({"pk": "99"}) == "99"
+        assert SWC._find_pk({"col1": "val1"}) == "val1"
 
     def test_to_canonical_deterministic(self):
-        connector = self._make_connector()
+        c = _make_warehouse()
         rows = [{"ID": "42"}]
-        r1 = connector.to_canonical(rows, "t")[0]
-        r2 = connector.to_canonical(rows, "t")[0]
+        r1 = c.to_canonical(rows, "t")[0]
+        r2 = c.to_canonical(rows, "t")[0]
         assert r1["record_id"] == r2["record_id"]
 
 
-# ── Exhaust adapter tests ───────────────────────────────────────────────────
+# ── ConnectorV1 contract tests ──────────────────────────────
+
+
+class TestSnowflakeV1Contract:
+    """Verify list_records / get_record protocol."""
+
+    @patch("urllib.request.urlopen")
+    def test_list_records_by_table(
+        self, mock_urlopen,
+    ):
+        c = _make_warehouse()
+        mock_urlopen.return_value = _mock_json_response({
+            "resultSetMetaData": {
+                "rowType": [
+                    {"name": "ID"},
+                    {"name": "NAME"},
+                ],
+            },
+            "data": [["1", "Alice"]],
+        })
+        records = c.list_records(table="users")
+        assert len(records) == 1
+        sys = records[0]["source"]["system"]
+        assert sys == "snowflake"
+
+    @patch("urllib.request.urlopen")
+    def test_list_records_by_sql(
+        self, mock_urlopen,
+    ):
+        c = _make_warehouse()
+        mock_urlopen.return_value = _mock_json_response({
+            "resultSetMetaData": {
+                "rowType": [{"name": "ID"}],
+            },
+            "data": [["1"], ["2"]],
+        })
+        records = c.list_records(
+            sql="SELECT ID FROM t", table="t",
+        )
+        assert len(records) == 2
+
+    def test_list_records_requires_table_or_sql(self):
+        c = _make_warehouse()
+        with pytest.raises(ValueError):
+            c.list_records()
+
+    @patch("urllib.request.urlopen")
+    def test_get_record(self, mock_urlopen):
+        c = _make_warehouse()
+        mock_urlopen.return_value = _mock_json_response({
+            "resultSetMetaData": {
+                "rowType": [
+                    {"name": "ID"},
+                    {"name": "NAME"},
+                ],
+            },
+            "data": [["42", "Alice"]],
+        })
+        rec = c.get_record("42", table="users")
+        assert rec["record_id"]
+        sys = rec["source"]["system"]
+        assert sys == "snowflake"
+
+    def test_get_record_requires_table(self):
+        c = _make_warehouse()
+        with pytest.raises(ValueError):
+            c.get_record("42")
+
+    @patch("urllib.request.urlopen")
+    def test_get_record_not_found(
+        self, mock_urlopen,
+    ):
+        c = _make_warehouse()
+        mock_urlopen.return_value = _mock_json_response({
+            "resultSetMetaData": {
+                "rowType": [{"name": "ID"}],
+            },
+            "data": [],
+        })
+        with pytest.raises(LookupError):
+            c.get_record("999", table="users")
+
+    @patch("urllib.request.urlopen")
+    def test_to_envelopes(self, mock_urlopen):
+        c = _make_warehouse()
+        mock_urlopen.return_value = _mock_json_response({
+            "resultSetMetaData": {
+                "rowType": [{"name": "ID"}],
+            },
+            "data": [["1"]],
+        })
+        records = c.list_records(table="t")
+        envelopes = c.to_envelopes(records)
+        assert len(envelopes) == 1
+        assert envelopes[0].source == "snowflake"
+        assert envelopes[0].source_instance == "test"
+
+
+# ── Column mapping tests ────────────────────────────────────
+
+
+class TestColumnMapping:
+    """Verify configurable column mapping."""
+
+    def test_default_mapping(self):
+        c = _make_warehouse()
+        rows = [{
+            "ID": "1",
+            "CREATED_AT": "2024-01-01T00:00:00Z",
+            "UPDATED_AT": "2024-01-02T00:00:00Z",
+        }]
+        records = c.to_canonical(rows, "t")
+        assert "2024-01-01" in records[0]["created_at"]
+        assert "2024-01-02" in records[0]["observed_at"]
+
+    def test_custom_mapping(self):
+        custom = {
+            "INSERTED_TS": "created_at",
+            "MODIFIED_TS": "observed_at",
+        }
+        c = _make_warehouse(column_map=custom)
+        rows = [{
+            "ID": "1",
+            "INSERTED_TS": "2024-06-01T00:00:00Z",
+            "MODIFIED_TS": "2024-06-02T00:00:00Z",
+        }]
+        records = c.to_canonical(rows, "t")
+        created = records[0]["created_at"]
+        observed = records[0]["observed_at"]
+        assert "2024-06-01" in created
+        assert "2024-06-02" in observed
+
+    def test_missing_mapped_columns(self):
+        c = _make_warehouse()
+        rows = [{"ID": "1", "OTHER": "val"}]
+        records = c.to_canonical(rows, "t")
+        assert records[0]["created_at"] == ""
+        assert records[0]["observed_at"] == ""
+
+
+# ── Exhaust adapter tests ──────────────────────────────────
+
 
 class TestCortexExhaustAdapter:
     @patch("urllib.request.urlopen")
-    def test_complete_with_exhaust(self, mock_urlopen):
-        from adapters.snowflake.exhaust import CortexExhaustAdapter
+    def test_complete_with_exhaust(
+        self, mock_urlopen,
+    ):
+        from adapters.snowflake.exhaust import (
+            CortexExhaustAdapter,
+        )
 
         mock_connector = MagicMock()
         mock_connector.complete_sync.return_value = {
@@ -245,20 +488,33 @@ class TestCortexExhaustAdapter:
             "model": "mistral-large",
             "usage": {"chunks": 1},
         }
-        mock_urlopen.return_value = _mock_json_response({"ok": True})
+        mock_urlopen.return_value = _mock_json_response(
+            {"ok": True},
+        )
 
         adapter = CortexExhaustAdapter(mock_connector)
-        result = adapter.complete_with_exhaust("mistral-large", [{"role": "user", "content": "Hi"}])
+        msgs = [{"role": "user", "content": "Hi"}]
+        result = adapter.complete_with_exhaust(
+            "mistral-large", msgs,
+        )
         assert result["response"] == "Hello"
         mock_connector.complete_sync.assert_called_once()
 
     @patch("urllib.request.urlopen")
-    def test_exhaust_events_emitted(self, mock_urlopen):
-        from adapters.snowflake.exhaust import CortexExhaustAdapter
+    def test_exhaust_events_emitted(
+        self, mock_urlopen,
+    ):
+        from adapters.snowflake.exhaust import (
+            CortexExhaustAdapter,
+        )
 
         mock_connector = MagicMock()
-        mock_connector.complete_sync.return_value = {"response": "x", "usage": {"chunks": 1}}
-        mock_urlopen.return_value = _mock_json_response({"ok": True})
+        mock_connector.complete_sync.return_value = {
+            "response": "x", "usage": {"chunks": 1},
+        }
+        mock_urlopen.return_value = _mock_json_response(
+            {"ok": True},
+        )
 
         adapter = CortexExhaustAdapter(mock_connector)
         adapter.complete_with_exhaust("model", [])
@@ -266,7 +522,9 @@ class TestCortexExhaustAdapter:
         call_args = mock_urlopen.call_args[0][0]
         body = json.loads(call_args.data)
         assert len(body) == 3
-        event_types = [e["event_type"] for e in body]
+        event_types = [
+            e["event_type"] for e in body
+        ]
         assert "prompt" in event_types
         assert "response" in event_types
         assert "metric" in event_types


### PR DESCRIPTION
## Summary
- Add `list_records()` and `get_record()` for ConnectorV1 contract compliance
- Add configurable column mapping (`column_map` constructor param) for flexible evidence field extraction
- Support table, view, and custom SQL query source modes
- Fix `_mapped_value` to gracefully handle mock-created instances (fixture tests)

## Test plan
- [x] 32 Snowflake tests pass (auth, cortex, warehouse, contract, mapping, exhaust)
- [x] 3 fixture tests restored (previously broken by missing `_column_map`)
- [x] Full suite: 1055 passed, no regressions
- [x] Lint clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)