### PR TITLE
chore: move root markdown files into docs/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,10 +41,8 @@ docs
 CHANGELOG.md
 CONTRIBUTING.md
 GLOSSARY.md
-HERO_DEMO.md
 NAV.md
 SECURITY.md
-START_HERE.md
 LICENSE
 
 # Test artifacts

--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ DeepSigma/
 
 | | |
 |---|---|
-| [START_HERE.md](START_HERE.md) | Front door |
-| [HERO_DEMO.md](HERO_DEMO.md) | 5-minute hands-on walkthrough |
+| [START_HERE.md](docs/START_HERE.md) | Front door |
+| [HERO_DEMO.md](docs/HERO_DEMO.md) | 5-minute hands-on walkthrough |
 | [NAV.md](docs/NAV.md) | Full navigation index |
 | [ABOUT.md](docs/ABOUT.md) | Reality Await Layer (RAL) |
 | [OPS_RUNBOOK.md](docs/OPS_RUNBOOK.md) | Operations + incident playbooks |
-| [STABILITY.md](STABILITY.md) | Versioning policy + stability guarantees |
+| [STABILITY.md](docs/STABILITY.md) | Versioning policy + stability guarantees |
 | [docs/99-docs-map.md](docs/99-docs-map.md) | Complete docs map |
 
 ---

--- a/docs/99-docs-map.md
+++ b/docs/99-docs-map.md
@@ -20,7 +20,7 @@ last_updated: "2026-02-16"
 | Project vision & mission | [`docs/00-vision.md`](00-vision.md) | `category/declaration.md`, `README.md` |
 | Terminology & naming | [`docs/01-language-map.md`](01-language-map.md) | `GLOSSARY.md`, `ontology/triad.md` |
 | Core concepts (triad, loop) | [`docs/02-core-concepts.md`](02-core-concepts.md) | `ontology/triad.md`, `category/declaration.md`, `START_HERE.md` |
-| Quickstart (run commands) | [`HERO_DEMO.md`](../HERO_DEMO.md) | `docs/05-quickstart.md`, `coherence_ops/README.md` |
+| Quickstart (run commands) | [`HERO_DEMO.md`](HERO_DEMO.md) | `docs/05-quickstart.md`, `coherence_ops/README.md` |
 | DLR specification | [`canonical/dlr_spec.md`](../canonical/dlr_spec.md) | `docs/20-dlr-claim-native.md`, `llm_data_model/02_schema/` |
 | RS specification | [`canonical/rs_spec.md`](../canonical/rs_spec.md) | `llm_data_model/06_ontology/coherence_ops_alignment.md` |
 | DS specification | [`canonical/ds_spec.md`](../canonical/ds_spec.md) | `llm_data_model/06_ontology/coherence_ops_alignment.md` |
@@ -67,4 +67,4 @@ last_updated: "2026-02-16"
 3. **Operational guides** live in `/docs/`. They explain *how to use* the specs in context.
 4. **Theory & ontology** live in `/ontology/`. They explain *why* the model works this way.
 5. **LLM data model** lives in `/llm_data_model/`. It’s a parallel, LLM-optimized projection of the canonical model.
-6. **If in doubt**, start at [`NAV.md`](../NAV.md) or [`START_HERE.md`](../START_HERE.md).
+6. **If in doubt**, start at [`NAV.md`](NAV.md) or [`START_HERE.md`](START_HERE.md).

--- a/docs/HERO_DEMO.md
+++ b/docs/HERO_DEMO.md
@@ -234,14 +234,14 @@ Artifacts are written to [`examples/demo-stack/drift_patch_cycle_run/`](examples
 
 | Goal | Resource |
 |------|----------|
-| Canonical specs | [/docs/canonical/](docs/canonical/) — DLR, RS, DS, MG specifications |
-| Category claim | [/docs/category/declaration.md](docs/category/declaration.md) |
-| IRIS deep-dive | [docs/18-iris.md](docs/18-iris.md) |
-| JSON schemas | [/specs/](specs/) |
-| Mermaid diagrams | [/docs/mermaid/](docs/mermaid/) |
-| LLM-optimized data model | [/docs/llm_data_model/](docs/llm_data_model/) |
-| Full docs index | [docs/99-docs-map.md](docs/99-docs-map.md) |
-| Release checklist | [docs/release/CHECKLIST_v1.md](docs/release/CHECKLIST_v1.md) |
+| Canonical specs | [/docs/canonical/](canonical/) — DLR, RS, DS, MG specifications |
+| Category claim | [/docs/category/declaration.md](category/declaration.md) |
+| IRIS deep-dive | [18-iris.md](18-iris.md) |
+| JSON schemas | [/schemas/](../schemas/) |
+| Mermaid diagrams | [/docs/mermaid/](mermaid/) |
+| LLM-optimized data model | [/docs/llm_data_model/](llm_data_model/) |
+| Full docs index | [99-docs-map.md](99-docs-map.md) |
+| Release checklist | [release/CHECKLIST_v1.md](release/CHECKLIST_v1.md) |
 
 ---
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,7 +2,7 @@
 
 **Version:** v1.0.0
 **Status:** Beta — core architecture stable, experimental modules clearly marked
-**See also:** [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md) · [CHANGELOG.md](CHANGELOG.md)
+**See also:** [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md) · [CHANGELOG.md](../CHANGELOG.md)
 
 ---
 
@@ -148,10 +148,10 @@ DeepSigma follows [Semantic Versioning](https://semver.org/):
 
 ### How Breaking Changes Are Communicated
 
-1. Entry in [CHANGELOG.md](CHANGELOG.md) under `BREAKING` heading
+1. Entry in [CHANGELOG.md](../CHANGELOG.md) under `BREAKING` heading
 2. Note in relevant canonical spec or doc
 3. Migration path described if feasible
 
 ---
 
-*See also: [CHANGELOG.md](CHANGELOG.md) · [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md) · [roadmap/README.md](roadmap/README.md)*
+*See also: [CHANGELOG.md](../CHANGELOG.md) · [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md) · [roadmap/README.md](roadmap/README.md)*

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -29,7 +29,7 @@ This is **institutional drift** — silent, compounding decay of decision qualit
 
 Coherence Ops exists so that question has an instant, auditable answer — regardless of who asks or when.
 
-→ [Full economic tension analysis](docs/category/economic_tension.md)
+→ [Full economic tension analysis](category/economic_tension.md)
 
 ---
 
@@ -64,7 +64,7 @@ DECIDE ──→ SEAL ──→ MONITOR ──→ DRIFT? ──→ PATCH ──�
 |------|--------|------|
 | 1 | Read this page (done) | 60 sec |
 | 2 | Run the [Hero Demo](HERO_DEMO.md) | 4 min |
-| 3 | Browse [canonical specs](docs/canonical/) | when ready |
+| 3 | Browse [canonical specs](canonical/) | when ready |
 
 That's the entire onramp.
 
@@ -74,18 +74,18 @@ That's the entire onramp.
 
 | You need… | Go to |
 |------------|-------|
-| Why this matters (economic) | [category/economic_tension.md](docs/category/economic_tension.md) |
-| Executive brief | [category/boardroom_brief.md](docs/category/boardroom_brief.md) |
-| Risk model | [category/risk_model.md](docs/category/risk_model.md) |
-| Normative specs (DLR, RS, DS, MG) | [/canonical/](docs/canonical/) |
-| JSON schemas | [/schemas/core/](schemas/core/) |
-| Python library + CLI | [/coherence_ops/](coherence_ops/) |
-| End-to-end examples | [/docs/examples/](docs/examples/) |
-| LLM-optimized data model | [/docs/llm_data_model/](docs/llm_data_model/) |
-| Operational runbooks | [/docs/runtime/](docs/runtime/) |
-| Extended docs | [/docs/](docs/) |
-| Full navigation | [NAV.md](docs/NAV.md) |
-| Docs de-duplication map | [docs/99-docs-map.md](docs/99-docs-map.md) |
+| Why this matters (economic) | [category/economic_tension.md](category/economic_tension.md) |
+| Executive brief | [category/boardroom_brief.md](category/boardroom_brief.md) |
+| Risk model | [category/risk_model.md](category/risk_model.md) |
+| Normative specs (DLR, RS, DS, MG) | [/canonical/](canonical/) |
+| JSON schemas | [/schemas/core/](../schemas/core/) |
+| Python library + CLI | [/coherence_ops/](../src/coherence_ops/) |
+| End-to-end examples | [/docs/examples/](examples/) |
+| LLM-optimized data model | [/docs/llm_data_model/](llm_data_model/) |
+| Operational runbooks | [/docs/runtime/](runtime/) |
+| Extended docs | [/docs/](./) |
+| Full navigation | [NAV.md](NAV.md) |
+| Docs de-duplication map | [99-docs-map.md](99-docs-map.md) |
 
 ---
 
@@ -94,12 +94,12 @@ That's the entire onramp.
 | File | What It Does |
 |------|-------------|
 | [HERO_DEMO.md](HERO_DEMO.md) | 5-min walkthrough: Decision → Seal → Drift → Patch → Memory |
-| [canonical/dlr_spec.md](docs/canonical/dlr_spec.md) | Decision Ledger Record spec |
-| [canonical/rs_spec.md](docs/canonical/rs_spec.md) | Reasoning Scaffold spec |
-| [canonical/ds_spec.md](docs/canonical/ds_spec.md) | Decision Scaffold spec |
-| [canonical/mg_spec.md](docs/canonical/mg_spec.md) | Memory Graph spec |
+| [canonical/dlr_spec.md](canonical/dlr_spec.md) | Decision Ledger Record spec |
+| [canonical/rs_spec.md](canonical/rs_spec.md) | Reasoning Scaffold spec |
+| [canonical/ds_spec.md](canonical/ds_spec.md) | Decision Scaffold spec |
+| [canonical/mg_spec.md](canonical/mg_spec.md) | Memory Graph spec |
 | [examples/sample_decision_episode_001.json](examples/sample_decision_episode_001.json) | Complete sealed episode (JSON) |
-| [coherence_ops/examples/e2e_seal_to_report.py](coherence_ops/examples/e2e_seal_to_report.py) | Full pipeline: episode → coherence report |
+| [coherence_ops/examples/e2e_seal_to_report.py](../src/coherence_ops/examples/e2e_seal_to_report.py) | Full pipeline: episode → coherence report |
 
 ---
 
@@ -115,7 +115,7 @@ That's the entire onramp.
 | **Patch** | Corrective DLR referencing the drifted original |
 | **IRIS** | Query engine: WHY / WHAT_CHANGED / WHAT_DRIFTED / RECALL / STATUS |
 
-Full glossary: [GLOSSARY.md](docs/GLOSSARY.md)
+Full glossary: [GLOSSARY.md](GLOSSARY.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Moves `HERO_DEMO.md`, `STABILITY.md`, `START_HERE.md` from repo root into `docs/`
- Reduces root to the canonical 10-folder structure (`src/`, `tests/`, `docs/`, `dashboard/`, `schemas/`, `artifacts/`, `prompts/`, `sample_data/`, `scripts/`, `.github/`)
- Rebases ~32 internal links from root-relative to docs/-relative
- Fixes ~15 pre-existing broken links in `docs/` files that already referenced these as siblings
- Removes stale `.dockerignore` entries (files now under `docs/` which is already excluded)

## Files changed
- `README.md` — 3 link paths updated
- `.dockerignore` — removed 2 lines (`HERO_DEMO.md`, `START_HERE.md`)
- `docs/99-docs-map.md` — 3 link paths updated
- `docs/START_HERE.md` — 21 link paths rebased
- `docs/HERO_DEMO.md` — 8 link paths rebased
- `docs/STABILITY.md` — 3 link paths rebased

## Test plan
- [ ] CI green (no Python/Docker changes — lint, tests, builds unaffected)
- [ ] Spot-check links on GitHub PR file preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)