### PR TITLE
Security: remove stack-trace exposure in dashboard APIs

### DIFF
--- a/dashboard/api_server.py
+++ b/dashboard/api_server.py
@@ -416,7 +416,7 @@ def query_iris(body: Dict[str, Any]):
     try:
         response = engine.resolve(query)
     except Exception:
-        logger.exception("IRIS resolution failed")
+        logger.error("IRIS resolution failed")
         raise HTTPException(status_code=500, detail="IRIS query failed")
     return response.to_dict()
 

--- a/dashboard/server/api.py
+++ b/dashboard/server/api.py
@@ -313,7 +313,7 @@ if HAS_FASTAPI:
             result["resolved_at"] = datetime.now(timezone.utc).isoformat()
             return result
         except Exception:
-            logger.exception("IRIS query failed")
+            logger.error("IRIS query failed")
             return {"status": "ERROR", "summary": "IRIS query failed", "confidence": 0}
 
     @app.get("/api/drifts")


### PR DESCRIPTION
## Summary
- replace traceback logging (`logger.exception`) with non-traceback logging (`logger.error`) on IRIS API failure paths
- keep stable error responses (`IRIS query failed`) for callers

## Files
- dashboard/server/api.py
- dashboard/api_server.py

## Validation
- python -m ruff check dashboard/server/api.py dashboard/api_server.py
- python -m pytest tests/test_api.py tests/test_dashboard_api_wiring.py -q
