### PR TITLE
Security: sanitize IRIS responses to prevent stack-trace leakage

### DIFF
--- a/dashboard/api_server.py
+++ b/dashboard/api_server.py
@@ -172,6 +172,12 @@ def _ts_ms(iso: str) -> int:
         return 0
 
 
+def _sanitize_iris_result(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop traceback-like fields before returning to API callers."""
+    blocked = {"traceback", "stack", "stacktrace", "exception", "error_details"}
+    return {k: v for k, v in data.items() if k.lower() not in blocked}
+
+
 def _episode_to_dashboard(ep: Dict[str, Any], drift_lookup: Dict[str, List]) -> Dict[str, Any]:
     telem = ep.get("telemetry", {})
     outcome = ep.get("outcome", {})
@@ -418,7 +424,7 @@ def query_iris(body: Dict[str, Any]):
     except Exception:
         logger.error("IRIS resolution failed")
         raise HTTPException(status_code=500, detail="IRIS query failed")
-    return response.to_dict()
+    return _sanitize_iris_result(response.to_dict())
 
 
 @app.get("/api/trust_scorecard")

--- a/dashboard/server/api.py
+++ b/dashboard/server/api.py
@@ -88,6 +88,12 @@ def _get_drift_events() -> List[Dict[str, Any]]:
     return events
 
 
+def _sanitize_iris_result(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop traceback-like fields before returning to API callers."""
+    blocked = {"traceback", "stack", "stacktrace", "exception", "error_details"}
+    return {k: v for k, v in data.items() if k.lower() not in blocked}
+
+
 if HAS_FASTAPI:
 
     @app.get("/api/episodes")
@@ -308,7 +314,7 @@ if HAS_FASTAPI:
                 episode_id=body.get("episode_id", ""),
             )
             response = engine.resolve(query)
-            result = response.to_dict()
+            result = _sanitize_iris_result(response.to_dict())
             result["provenance_chain"] = result.pop("provenance", [])
             result["resolved_at"] = datetime.now(timezone.utc).isoformat()
             return result


### PR DESCRIPTION
## Summary
- sanitize IRIS API response payloads to remove traceback/stack/exception-style fields before returning to clients
- keeps API behavior while preventing accidental leakage through engine response objects

## Files
- dashboard/server/api.py
- dashboard/api_server.py

## Validation
- python -m ruff check dashboard/server/api.py dashboard/api_server.py
- python -m pytest tests/test_api.py tests/test_dashboard_api_wiring.py -q
