### PR TITLE
Add KPI issue templates + canonical label policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: KPI Label Policy
+    url: https://github.com/8ryanWh1t3/DeepSigma/blob/main/docs/docs/governance/LABEL_POLICY.md
+    about: "Canonical label strings (KPI/severity/type). Use these exactly."

--- a/.github/ISSUE_TEMPLATE/kpi_authority_modeling.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_authority_modeling.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Authority Modeling"
+description: "Work that strengthens authority/versioning: roles, precedence, signatures, approval chains."
+title: "[KPI][Authority Modeling] "
+labels: ["kpi:authority_modeling"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_automation_depth.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_automation_depth.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Automation Depth"
+description: "Work that increases automation (CI gates, scripts, one-command demos, PR comment bots)."
+title: "[KPI][Automation Depth] "
+labels: ["kpi:automation_depth"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_data_integration.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_data_integration.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Data Integration"
+description: "Work on connectors, schemas, adapters, fixtures, ingestion pathways."
+title: "[KPI][Data Integration] "
+labels: ["kpi:data_integration"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_economic_measurability.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_economic_measurability.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Economic Measurability"
+description: "Work proving economics: ROI models, time saved, risk prevented, measurable outcomes."
+title: "[KPI][Economic Measurability] "
+labels: ["kpi:economic_measurability"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_enterprise_readiness.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_enterprise_readiness.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Enterprise Readiness"
+description: "Work for pilot adoption: docs, branch protection, runbooks, packaging, minimal ops."
+title: "[KPI][Enterprise Readiness] "
+labels: ["kpi:enterprise_readiness"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_operational_maturity.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_operational_maturity.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Operational Maturity"
+description: "Work improving operations: pilot drills, gates, runbooks, observability, policy."
+title: "[KPI][Operational Maturity] "
+labels: ["kpi:operational_maturity"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_scalability.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_scalability.yml
@@ -1,0 +1,41 @@
+name: "KPI Portfolio — Scalability"
+description: "Work proving scale: performance, batching, concurrency, multi-user, large datasets."
+title: "[KPI][Scalability] "
+labels: ["kpi:scalability"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/kpi_technical_completeness.yml
+++ b/.github/ISSUE_TEMPLATE/kpi_technical_completeness.yml
@@ -1,0 +1,51 @@
+name: "KPI Portfolio — Technical Completeness"
+description: "Work that increases completeness of core system surfaces (CLI, schema, tests, packaging, determinism)."
+title: "[KPI][Technical Completeness] "
+labels: ["kpi:technical_completeness"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Labeling rules**
+        - This issue already has the KPI label.
+        - You MUST add exactly one `sev:*` and one `type:*` label after creation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity (choose one)
+      options: ["sev:P0", "sev:P1", "sev:P2", "sev:P3"]
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type (choose one)
+      options: ["type:feature", "type:bug", "type:debt", "type:doc"]
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: "What changes, and why does it increase technical completeness?"
+      placeholder: "Example: Add schema validation for KPI files so malformed data cannot render."
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables (checklist)
+      placeholder: |
+        - [ ] Code change
+        - [ ] Tests updated/added
+        - [ ] Docs updated
+        - [ ] CI green
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / Verification
+      placeholder: "Commands, logs, screenshots, or steps proving it's done."
+    validations:
+      required: true

--- a/docs/docs/governance/LABEL_POLICY.md
+++ b/docs/docs/governance/LABEL_POLICY.md
@@ -1,0 +1,31 @@
+# Label Policy (Canonical)
+
+## KPI labels (exact)
+- kpi:technical_completeness
+- kpi:automation_depth
+- kpi:authority_modeling
+- kpi:enterprise_readiness
+- kpi:scalability
+- kpi:data_integration
+- kpi:economic_measurability
+- kpi:operational_maturity
+
+## Severity labels (exact)
+- sev:P0
+- sev:P1
+- sev:P2
+- sev:P3
+
+## Type labels (exact)
+- type:feature
+- type:bug
+- type:debt
+- type:doc
+
+## Rules
+1) Every issue that should move the Repo Radar MUST have exactly:
+   - 1 KPI label
+   - 1 Severity label
+   - 1 Type label
+2) No alternate spellings. No duplicates. No synonyms.
+3) If an issue has sev:P0 and is open, KPI is capped (per kpi_issue_map.yaml).


### PR DESCRIPTION
Adds 8 KPI portfolio issue templates and canonical label policy documentation to keep issue->radar labeling deterministic.