### PR TITLE
Issues #150/#151: signed release supply chain + publish hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,9 +240,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, validation-gates, lint, dashboard-build]
     if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      image_digest: ${{ steps.build-image.outputs.digest }}
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ghcr.io/8ryanwh1t3/deepsigma
@@ -258,13 +262,29 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install -c requirements/locks/release-build.txt build
+          pip install -c requirements/locks/release-build.txt build sigstore
 
       - name: Validate release metadata
         run: make release-check
 
       - name: Build wheel and sdist
         run: make build
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate source SBOM (CycloneDX)
+        run: |
+          syft dir:. -o cyclonedx-json=dist/deepsigma-${{ github.ref_name }}-source.sbom.cdx.json
+
+      - name: Sign release artifacts (Sigstore)
+        run: |
+          python -m sigstore sign --output-directory dist --overwrite dist/*.whl dist/*.tar.gz
+
+      - name: Generate SLSA provenance attestations (dist)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
 
       - name: Publish GitHub Release assets
         uses: softprops/action-gh-release@v2
@@ -290,15 +310,139 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest
+          labels: |
+            org.opencontainers.image.sbom=deepsigma-${{ github.ref_name }}-image.sbom.spdx.json
+            org.opencontainers.image.sbom.source=deepsigma-${{ github.ref_name }}-source.sbom.cdx.json
 
       - name: Build and push Docker image
+        id: build-image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign Docker image (Cosign keyless)
+        uses: sigstore/cosign-installer@v3.8.1
+
+      - name: Cosign sign published image digest
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign --yes "${{ env.IMAGE_NAME }}@${{ steps.build-image.outputs.digest }}"
+
+      - name: Generate image SBOM (SPDX)
+        run: |
+          syft "${{ env.IMAGE_NAME }}@${{ steps.build-image.outputs.digest }}" \
+            -o spdx-json=dist/deepsigma-${{ github.ref_name }}-image.sbom.spdx.json
+
+      - name: Generate SLSA provenance attestation (container image)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Upload release evidence bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-${{ github.ref_name }}
+          path: dist/*
+
+  verify-release-supply-chain:
+    name: Verify release signatures + attestations
+    runs-on: ubuntu-latest
+    needs: [release-artifacts]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE_NAME: ghcr.io/8ryanwh1t3/deepsigma
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install verify tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c requirements/locks/release-build.txt sigstore
+
+      - name: Download release evidence bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: release-evidence-${{ github.ref_name }}
+          path: dist
+
+      - name: Verify wheel/sdist signatures (Sigstore)
+        run: |
+          set -euo pipefail
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            bundle="${artifact}.sigstore.json"
+            python -m sigstore verify github \
+              --bundle "$bundle" \
+              --repository "${{ github.repository }}" \
+              --trigger "push" \
+              --name "CI" \
+              --ref "refs/tags/${{ github.ref_name }}" \
+              "$artifact"
+          done
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.8.1
+
+      - name: Verify published image signature (Cosign)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign verify \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/ci.yml@refs/tags/${{ github.ref_name }}$" \
+            "${{ env.IMAGE_NAME }}@${{ needs.release-artifacts.outputs.image_digest }}"
+
+  pypi-smoke:
+    name: Smoke install from PyPI
+    runs-on: ubuntu-latest
+    needs: [publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install from PyPI and validate CLI version
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          for i in $(seq 1 12); do
+            python -m pip install --upgrade pip
+            if pip install "deepsigma==${version}"; then
+              break
+            fi
+            if [ "$i" -eq 12 ]; then
+              echo "deepsigma ${version} not visible on PyPI after retries"
+              exit 1
+            fi
+            sleep 20
+          done
+          deepsigma --version | tee /tmp/deepsigma-version.txt
+          grep -q "${version}" /tmp/deepsigma-version.txt
+
+      - name: Validate optional extras install
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          pip install "deepsigma[rdf,azure,snowflake]==${version}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI](https://github.com/8ryanWh1t3/DeepSigma/actions/workflows/ci.yml/badge.svg)](https://github.com/8ryanWh1t3/DeepSigma/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/deepsigma)](https://pypi.org/project/deepsigma/)
+[![GHCR Pulls](https://img.shields.io/docker/pulls/ghcr.io/8ryanwh1t3/deepsigma)](https://github.com/8ryanWh1t3/DeepSigma/pkgs/container/deepsigma)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Release](https://img.shields.io/github/v/release/8ryanWh1t3/DeepSigma)](https://github.com/8ryanWh1t3/DeepSigma/releases/latest)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,3 +52,35 @@ This repo enforces:
 - **Sealed DecisionEpisodes** — immutable after sealing
 - **Named graph immutability** — patch-rather-than-overwrite
 - **CODEOWNERS** review on all pull requests to protected paths
+
+## Release Signature Verification
+
+Tagged releases (`v*`) publish signed artifacts and SBOM evidence:
+
+- Python distributions (`.whl`, `.tar.gz`) are signed with **Sigstore keyless** and include `*.sigstore.json` bundles.
+- Container image `ghcr.io/8ryanwh1t3/deepsigma` is signed with **Cosign keyless**.
+- SBOMs are attached to release artifacts:
+  - `deepsigma-<tag>-source.sbom.cdx.json` (CycloneDX)
+  - `deepsigma-<tag>-image.sbom.spdx.json` (SPDX)
+
+### Verify Python release signatures
+
+```bash
+python -m pip install sigstore
+python -m sigstore verify github \
+  --bundle deepsigma-<version>-py3-none-any.whl.sigstore.json \
+  --repository 8ryanWh1t3/DeepSigma \
+  --trigger push \
+  --name CI \
+  --ref refs/tags/v<version> \
+  deepsigma-<version>-py3-none-any.whl
+```
+
+### Verify container signature
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/8ryanWh1t3/DeepSigma/.github/workflows/ci.yml@refs/tags/v<version>$' \
+  ghcr.io/8ryanwh1t3/deepsigma:v<version>
+```

--- a/requirements/locks/release-build.in
+++ b/requirements/locks/release-build.in
@@ -1,1 +1,2 @@
 build
+sigstore

--- a/requirements/locks/release-build.txt
+++ b/requirements/locks/release-build.txt
@@ -4,9 +4,87 @@
 #
 #    pip-compile --output-file=requirements/locks/release-build.txt --strip-extras requirements/locks/release-build.in
 #
+annotated-types==0.7.0
+    # via pydantic
 build==1.4.0
     # via -r requirements/locks/release-build.in
+certifi==2026.1.4
+    # via requests
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.4
+    # via requests
+cryptography==46.0.5
+    # via
+    #   pyopenssl
+    #   rfc3161-client
+    #   sigstore
+dnspython==2.8.0
+    # via email-validator
+email-validator==2.3.0
+    # via pydantic
+id==1.6.1
+    # via sigstore
+idna==3.11
+    # via
+    #   email-validator
+    #   requests
+markdown-it-py==4.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 packaging==26.0
     # via build
+platformdirs==4.9.2
+    # via sigstore
+pyasn1==0.6.2
+    # via sigstore
+pycparser==3.0
+    # via cffi
+pydantic==2.12.5
+    # via
+    #   sigstore
+    #   sigstore-models
+    #   sigstore-rekor-types
+pydantic-core==2.41.5
+    # via pydantic
+pygments==2.19.2
+    # via rich
+pyjwt==2.11.0
+    # via sigstore
+pyopenssl==25.3.0
+    # via sigstore
 pyproject-hooks==1.2.0
     # via build
+requests==2.32.5
+    # via sigstore
+rfc3161-client==1.0.5
+    # via sigstore
+rfc8785==0.1.4
+    # via sigstore
+rich==14.3.3
+    # via sigstore
+securesystemslib==1.3.1
+    # via tuf
+sigstore==4.2.0
+    # via -r requirements/locks/release-build.in
+sigstore-models==0.0.6
+    # via sigstore
+sigstore-rekor-types==0.0.18
+    # via sigstore
+tuf==6.0.0
+    # via sigstore
+typing-extensions==4.15.0
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   pyopenssl
+    #   sigstore-models
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
+urllib3==2.6.3
+    # via
+    #   id
+    #   requests
+    #   tuf


### PR DESCRIPTION
## Summary
Implements release supply-chain hardening and tagged publish behavior for both issues:

- **#150 Signed releases + SBOM**
  - signs wheel/sdist with Sigstore keyless (`python -m sigstore sign`)
  - signs published GHCR image digest with Cosign keyless
  - generates source + image SBOMs (`syft`) in CycloneDX/SPDX
  - adds SLSA provenance attestations for dist artifacts and container image
  - adds post-release verification job for Sigstore and Cosign checks
  - documents verification commands in `SECURITY.md`

- **#151 Publish to PyPI + GHCR on tag**
  - keeps trusted publisher OIDC flow for PyPI
  - hardens tagged GHCR path with **multi-arch** build (`linux/amd64,linux/arm64`)
  - expands docker tag set to `vX.Y.Z`, `vX.Y`, `vX`, `latest`
  - adds PyPI smoke job that retries install of tagged version and validates CLI
  - validates optional extras install for `rdf,azure,snowflake`

Also updates release build lockfile to include `sigstore`.

## Files
- `.github/workflows/ci.yml`
- `requirements/locks/release-build.in`
- `requirements/locks/release-build.txt`
- `SECURITY.md`
- `README.md`

## Validation
- `python scripts/release_check.py --tag v2.0.3`
- YAML parse sanity for `.github/workflows/ci.yml`

Closes #150
Closes #151
