### PR TITLE
Issue #147: envelope-level encryption at rest + rekey CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ postgresql = [
 local = [
     "httpx>=0.25.0",
 ]
+encrypt = [
+    "cryptography>=42.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/8ryanWh1t3/DeepSigma"

--- a/src/adapters/openclaw/runtime.py
+++ b/src/adapters/openclaw/runtime.py
@@ -63,6 +63,8 @@ class SandboxConfig:
         Whether to allow WASI filesystem access.
     allow_network : bool
         Whether to allow WASI network access.
+    encrypt_at_rest : bool
+        Whether evidence persistence should use at-rest encryption.
     """
 
     memory_limit_mb: int = DEFAULT_MEMORY_LIMIT_MB
@@ -75,6 +77,7 @@ class SandboxConfig:
     )
     allow_filesystem: bool = False
     allow_network: bool = False
+    encrypt_at_rest: bool = False
 
 
 class SandboxViolation(Exception):

--- a/src/credibility_engine/store.py
+++ b/src/credibility_engine/store.py
@@ -17,6 +17,8 @@ import json
 import os
 import re
 import threading
+import warnings
+from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -75,6 +77,7 @@ class CredibilityStore:
         self,
         data_dir: str | Path | None = None,
         tenant_id: str | None = None,
+        encrypt_at_rest: bool = False,
     ) -> None:
         if data_dir is not None:
             # Explicit data_dir takes precedence (backward compat / testing)
@@ -89,6 +92,92 @@ class CredibilityStore:
             self.data_dir = candidate
         self.tenant_id = _validate_tenant_id(tenant_id or DEFAULT_TENANT_ID)
         self.data_dir.mkdir(parents=True, exist_ok=True)  # lgtm [py/path-injection]
+        self.encrypt_at_rest = encrypt_at_rest
+        self._master_key = os.environ.get("DEEPSIGMA_MASTER_KEY", "")
+        self._encryption_enabled = False
+        self._aesgcm: Any = None
+        if self.encrypt_at_rest:
+            self._initialize_encryption()
+
+    def _initialize_encryption(self) -> None:
+        if not self._master_key:
+            warnings.warn(
+                "encrypt_at_rest=True but DEEPSIGMA_MASTER_KEY is unset; "
+                "falling back to plaintext persistence",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+        try:
+            from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
+        except ImportError:
+            warnings.warn(
+                "encrypt_at_rest=True but cryptography is not installed; "
+                "falling back to plaintext persistence",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+        key = self._derive_tenant_key(self._master_key)
+        self._aesgcm = AESGCM(key)
+        self._encryption_enabled = True
+
+    def _derive_tenant_key(self, master_key: str) -> bytes:
+        salt = f"deepsigma:{self.tenant_id}".encode("utf-8")
+        return hashlib.pbkdf2_hmac(
+            "sha256",
+            master_key.encode("utf-8"),
+            salt,
+            200_000,
+            dklen=32,
+        )
+
+    def _is_encrypted_envelope(self, obj: Any) -> bool:
+        return (
+            isinstance(obj, dict)
+            and "encrypted_payload" in obj
+            and "nonce" in obj
+        )
+
+    def _encrypt_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        if not self._encryption_enabled or self._aesgcm is None:
+            return record
+        plaintext = json.dumps(record, default=str, separators=(",", ":")).encode("utf-8")
+        nonce = os.urandom(12)
+        aad = self.tenant_id.encode("utf-8")
+        ciphertext = self._aesgcm.encrypt(nonce, plaintext, aad)
+        return {
+            "enc": "AES-256-GCM",
+            "enc_version": 1,
+            "tenant_id": self.tenant_id,
+            "nonce": b64encode(nonce).decode("utf-8"),
+            "encrypted_payload": b64encode(ciphertext).decode("utf-8"),
+        }
+
+    def _decrypt_record_with(
+        self,
+        envelope: dict[str, Any],
+        aesgcm: Any,
+    ) -> dict[str, Any]:
+        nonce = b64decode(envelope["nonce"])
+        ciphertext = b64decode(envelope["encrypted_payload"])
+        aad = self.tenant_id.encode("utf-8")
+        plaintext = aesgcm.decrypt(nonce, ciphertext, aad)
+        obj = json.loads(plaintext.decode("utf-8"))
+        if isinstance(obj, dict):
+            obj.setdefault("tenant_id", self.tenant_id)
+        return obj
+
+    def _decode_record(self, raw: dict[str, Any]) -> dict[str, Any]:
+        if not self._is_encrypted_envelope(raw):
+            raw.setdefault("tenant_id", self.tenant_id)
+            return raw
+        if not self._encryption_enabled or self._aesgcm is None:
+            raise RuntimeError(
+                "Encrypted record found but decryption is unavailable. "
+                "Set DEEPSIGMA_MASTER_KEY and enable encrypt_at_rest."
+            )
+        return self._decrypt_record_with(raw, self._aesgcm)
 
     def _safe_path(self, filename: str) -> Path:
         """Resolve a validated filename under the tenant data directory."""
@@ -112,9 +201,12 @@ class CredibilityStore:
         enriched.setdefault("tenant_id", self.tenant_id)
         enriched.setdefault("timestamp", _now_iso())
         filepath = self._safe_path(filename)
+        serialized = enriched
+        if filename != self.PACKET_FILE and self._encryption_enabled:
+            serialized = self._encrypt_record(enriched)
         with _write_lock:
             with open(filepath, "a", encoding="utf-8") as f:
-                f.write(json.dumps(enriched, default=str) + "\n")
+                f.write(json.dumps(serialized, default=str) + "\n")
 
     def load_latest(self, filename: str) -> dict[str, Any] | None:
         """Load the last record from a JSONL file."""
@@ -128,9 +220,7 @@ class CredibilityStore:
                 if stripped:
                     last_line = stripped
         if last_line:
-            record = json.loads(last_line)
-            record.setdefault("tenant_id", self.tenant_id)
-            return record
+            return self._decode_record(json.loads(last_line))
         return None
 
     def load_last_n(self, filename: str, n: int = 10) -> list[dict[str, Any]]:
@@ -144,9 +234,7 @@ class CredibilityStore:
                 stripped = line.strip()
                 if stripped:
                     lines.append(stripped)
-        records = [json.loads(line) for line in lines[-n:]]
-        for r in records:
-            r.setdefault("tenant_id", self.tenant_id)
+        records = [self._decode_record(json.loads(line)) for line in lines[-n:]]
         return records
 
     def load_all(self, filename: str) -> list[dict[str, Any]]:
@@ -159,19 +247,20 @@ class CredibilityStore:
             for line in f:
                 stripped = line.strip()
                 if stripped:
-                    record = json.loads(stripped)
-                    record.setdefault("tenant_id", self.tenant_id)
-                    records.append(record)
+                    records.append(self._decode_record(json.loads(stripped)))
         return records
 
     def write_json(self, filename: str, data: dict[str, Any]) -> None:
         """Write a single JSON file (non-JSONL, for packets)."""
         enriched = dict(data)
         enriched.setdefault("tenant_id", self.tenant_id)
+        serialized = enriched
+        if filename != self.PACKET_FILE and self._encryption_enabled:
+            serialized = self._encrypt_record(enriched)
         filepath = self._safe_path(filename)
         with _write_lock:
             with open(filepath, "w", encoding="utf-8") as f:
-                json.dump(enriched, f, indent=2, default=str)
+                json.dump(serialized, f, indent=2, default=str)
                 f.write("\n")
 
     def load_json(self, filename: str) -> dict[str, Any] | None:
@@ -182,7 +271,7 @@ class CredibilityStore:
         with open(filepath, encoding="utf-8") as f:
             record = json.load(f)
         if isinstance(record, dict):
-            record.setdefault("tenant_id", self.tenant_id)
+            record = self._decode_record(record)
         return record
 
     def write_batch(self, filename: str, records: list[dict[str, Any]]) -> None:
@@ -198,7 +287,10 @@ class CredibilityStore:
                     enriched = dict(record)
                     enriched.setdefault("tenant_id", self.tenant_id)
                     enriched.setdefault("timestamp", _now_iso())
-                    f.write(json.dumps(enriched, default=str) + "\n")
+                    serialized = enriched
+                    if filename != self.PACKET_FILE and self._encryption_enabled:
+                        serialized = self._encrypt_record(enriched)
+                    f.write(json.dumps(serialized, default=str) + "\n")
 
     # -- Convenience methods ---------------------------------------------------
 
@@ -274,9 +366,7 @@ class CredibilityStore:
             for line in f:
                 stripped = line.strip()
                 if stripped:
-                    record = json.loads(stripped)
-                    record.setdefault("tenant_id", self.tenant_id)
-                    records.append(record)
+                    records.append(self._decode_record(json.loads(stripped)))
         return records
 
     def load_cold(self, filename: str) -> list[dict[str, Any]]:
@@ -289,9 +379,7 @@ class CredibilityStore:
             for line in f:
                 stripped = line.strip()
                 if stripped:
-                    record = json.loads(stripped)
-                    record.setdefault("tenant_id", self.tenant_id)
-                    records.append(record)
+                    records.append(self._decode_record(json.loads(stripped)))
         return records
 
     def write_warm(self, filename: str, records: list[dict[str, Any]]) -> None:
@@ -306,7 +394,10 @@ class CredibilityStore:
                 for record in records:
                     enriched = dict(record)
                     enriched.setdefault("tenant_id", self.tenant_id)
-                    f.write(json.dumps(enriched, default=str) + "\n")
+                    serialized = enriched
+                    if self._encryption_enabled:
+                        serialized = self._encrypt_record(enriched)
+                    f.write(json.dumps(serialized, default=str) + "\n")
 
     def write_cold(self, filename: str, records: list[dict[str, Any]]) -> None:
         """Write records to the cold-tier file."""
@@ -320,4 +411,63 @@ class CredibilityStore:
                 for record in records:
                     enriched = dict(record)
                     enriched.setdefault("tenant_id", self.tenant_id)
-                    f.write(json.dumps(enriched, default=str) + "\n")
+                    serialized = enriched
+                    if self._encryption_enabled:
+                        serialized = self._encrypt_record(enriched)
+                    f.write(json.dumps(serialized, default=str) + "\n")
+
+    def rekey(self, previous_master_key: str) -> dict[str, int]:
+        """Re-encrypt tenant records with the current DEEPSIGMA_MASTER_KEY.
+
+        Sealed packet artifacts are intentionally left plaintext.
+        """
+        if not self.encrypt_at_rest:
+            raise RuntimeError("Rekey requires encrypt_at_rest=True")
+        if not self._master_key or not self._encryption_enabled:
+            raise RuntimeError(
+                "Rekey requires DEEPSIGMA_MASTER_KEY and cryptography support"
+            )
+        if not previous_master_key:
+            raise RuntimeError("previous_master_key is required")
+
+        try:
+            from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
+        except ImportError as exc:
+            raise RuntimeError("cryptography is required for rekey") from exc
+
+        old_aes = AESGCM(self._derive_tenant_key(previous_master_key))
+        stats = {"files": 0, "records": 0}
+        for path in sorted(self.data_dir.glob("*")):
+            if path.is_dir():
+                continue
+            if path.name == self.PACKET_FILE:
+                continue
+            if path.suffix == ".jsonl":
+                lines = path.read_text(encoding="utf-8").splitlines()
+                rewritten: list[str] = []
+                for line in lines:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    raw = json.loads(stripped)
+                    if self._is_encrypted_envelope(raw):
+                        record = self._decrypt_record_with(raw, old_aes)
+                    else:
+                        record = raw
+                        record.setdefault("tenant_id", self.tenant_id)
+                    rewritten.append(json.dumps(self._encrypt_record(record), default=str))
+                    stats["records"] += 1
+                with _write_lock:
+                    path.write_text("\n".join(rewritten) + ("\n" if rewritten else ""), encoding="utf-8")
+                stats["files"] += 1
+            elif path.suffix == ".json":
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if self._is_encrypted_envelope(raw):
+                    record = self._decrypt_record_with(raw, old_aes)
+                else:
+                    record = raw
+                with _write_lock:
+                    path.write_text(json.dumps(self._encrypt_record(record), indent=2) + "\n", encoding="utf-8")
+                stats["files"] += 1
+                stats["records"] += 1
+        return stats

--- a/src/deepsigma/cli/main.py
+++ b/src/deepsigma/cli/main.py
@@ -8,6 +8,7 @@ Commands:
     deepsigma mdpt index --csv <file>         Generate MDPT Prompt Index
     deepsigma golden-path <source> [opts]     7-step Golden Path loop
     deepsigma compact --input <dir>           Compact JSONL evidence files
+    deepsigma rekey --tenant <id>             Rekey encrypted evidence at rest
 """
 from __future__ import annotations
 
@@ -45,6 +46,7 @@ def main(argv: list[str] | None = None) -> int:
         doctor,
         golden_path,
         mdpt_index,
+        rekey,
         validate_boot,
     )
 
@@ -54,6 +56,7 @@ def main(argv: list[str] | None = None) -> int:
     mdpt_index.register(subparsers)
     golden_path.register(subparsers)
     compact.register(subparsers)
+    rekey.register(subparsers)
 
     args = parser.parse_args(argv)
 

--- a/src/deepsigma/cli/rekey.py
+++ b/src/deepsigma/cli/rekey.py
@@ -1,0 +1,61 @@
+"""deepsigma rekey — rotate encrypted credibility evidence keys."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from credibility_engine.store import CredibilityStore
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "rekey",
+        help="Re-encrypt tenant credibility evidence with current master key",
+    )
+    p.add_argument("--tenant", required=True, help="Tenant ID to rekey")
+    p.add_argument(
+        "--data-dir",
+        default=None,
+        help="Optional explicit credibility data directory",
+    )
+    p.add_argument(
+        "--previous-master-key-env",
+        default="DEEPSIGMA_PREVIOUS_MASTER_KEY",
+        help="Env var name containing previous master key",
+    )
+    p.add_argument("--json", action="store_true", help="Output JSON")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    previous_key = os.environ.get(args.previous_master_key_env, "")
+    if not previous_key:
+        print(
+            f"Missing previous key: set ${args.previous_master_key_env}",
+        )
+        return 2
+
+    if not os.environ.get("DEEPSIGMA_MASTER_KEY", ""):
+        print("Missing current key: set $DEEPSIGMA_MASTER_KEY")
+        return 2
+
+    store = CredibilityStore(
+        data_dir=args.data_dir,
+        tenant_id=args.tenant,
+        encrypt_at_rest=True,
+    )
+    stats = store.rekey(previous_master_key=previous_key)
+    out = {
+        "tenant_id": args.tenant,
+        "files_rewritten": stats["files"],
+        "records_reencrypted": stats["records"],
+    }
+    if args.json:
+        print(json.dumps(out, indent=2))
+    else:
+        print(
+            f"Rekey complete for tenant={args.tenant}: "
+            f"files={stats['files']} records={stats['records']}"
+        )
+    return 0

--- a/tests/test_credibility_store_encryption.py
+++ b/tests/test_credibility_store_encryption.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from credibility_engine.store import CredibilityStore
+
+pytest.importorskip("cryptography.hazmat.primitives.ciphers.aead")
+
+
+def test_encrypt_at_rest_jsonl_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPSIGMA_MASTER_KEY", "current-master-key")
+    store = CredibilityStore(
+        data_dir=tmp_path,
+        tenant_id="alpha",
+        encrypt_at_rest=True,
+    )
+    store.append_claim({"claim_id": "C-1", "score": 0.9})
+
+    raw = (tmp_path / "claims.jsonl").read_text(encoding="utf-8").strip()
+    assert "encrypted_payload" in raw
+    assert "claim_id" not in raw
+
+    records = store.latest_claims()
+    assert len(records) == 1
+    assert records[0]["claim_id"] == "C-1"
+    assert records[0]["tenant_id"] == "alpha"
+
+
+def test_packet_remains_plaintext(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPSIGMA_MASTER_KEY", "current-master-key")
+    store = CredibilityStore(
+        data_dir=tmp_path,
+        tenant_id="alpha",
+        encrypt_at_rest=True,
+    )
+    packet = {"packet_id": "PKT-1", "status": "ok"}
+    store.save_packet(packet)
+    raw = json.loads((tmp_path / "packet_latest.json").read_text(encoding="utf-8"))
+    assert raw["packet_id"] == "PKT-1"
+    assert "encrypted_payload" not in raw
+
+
+def test_rekey_reencrypts_records(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPSIGMA_MASTER_KEY", "old-master-key")
+    old_store = CredibilityStore(
+        data_dir=tmp_path,
+        tenant_id="alpha",
+        encrypt_at_rest=True,
+    )
+    old_store.append_claim({"claim_id": "C-1", "score": 0.9})
+
+    monkeypatch.setenv("DEEPSIGMA_MASTER_KEY", "new-master-key")
+    new_store = CredibilityStore(
+        data_dir=tmp_path,
+        tenant_id="alpha",
+        encrypt_at_rest=True,
+    )
+    stats = new_store.rekey(previous_master_key="old-master-key")
+    assert stats["records"] >= 1
+
+    # New key reads successfully.
+    after = new_store.latest_claims()
+    assert after[0]["claim_id"] == "C-1"
+
+    # Old key can no longer decrypt after rotation.
+    monkeypatch.setenv("DEEPSIGMA_MASTER_KEY", "old-master-key")
+    stale_store = CredibilityStore(
+        data_dir=tmp_path,
+        tenant_id="alpha",
+        encrypt_at_rest=True,
+    )
+    try:
+        stale_store.latest_claims()
+        assert False, "Expected decrypt failure with old key"
+    except Exception:
+        pass

--- a/tests/test_openclaw_runtime.py
+++ b/tests/test_openclaw_runtime.py
@@ -123,6 +123,7 @@ class TestSandboxConfig:
         assert cfg.timeout_s == 5.0
         assert cfg.allow_filesystem is False
         assert cfg.allow_network is False
+        assert cfg.encrypt_at_rest is False
 
     def test_custom_limits(self):
         cfg = SandboxConfig(


### PR DESCRIPTION
## Summary
Implements envelope-level encryption at rest for tenant-scoped credibility evidence, with key rotation support.

### What changed
- Added `encrypt_at_rest` support in `CredibilityStore` with graceful plaintext fallback if `DEEPSIGMA_MASTER_KEY` or `cryptography` is unavailable.
- Added tenant-scoped key derivation from master key (`DEEPSIGMA_MASTER_KEY`) and AES-256-GCM envelope encryption for JSONL/JSON records.
- Persisted encrypted records using `encrypted_payload` + `nonce` envelope fields.
- Added transparent decrypt-on-read path for encrypted records.
- Ensured packet artifacts (`packet_latest.json`) remain plaintext by design.
- Added `CredibilityStore.rekey(previous_master_key=...)` to re-encrypt tenant records under the current key.
- Added `deepsigma rekey --tenant <id>` CLI command to perform rotation using env-provided previous/current keys.
- Added optional dependency extra `[encrypt]` in `pyproject.toml`.
- Added/updated tests for config flag and encrypted store behavior.

## Validation
- `ruff check src/credibility_engine/store.py src/deepsigma/cli/rekey.py src/adapters/openclaw/runtime.py src/deepsigma/cli/main.py tests/test_credibility_store_encryption.py tests/test_openclaw_runtime.py`
- `pytest -q tests/test_credibility_store_encryption.py tests/test_openclaw_runtime.py`

Closes #147
