### PR TITLE
Issue #199: add pilot results snapshot + closeout checklist

### DIFF
--- a/docs/docs/pilot/PILOT_RESULTS_2026-02-22.md
+++ b/docs/docs/pilot/PILOT_RESULTS_2026-02-22.md
@@ -1,0 +1,53 @@
+# Pilot Results Snapshot (2026-02-22)
+
+## Status
+- Pilot substrate is operational on `main`.
+- Deterministic Drift→Patch loop is reproducible.
+- CI and issue-label gates are active.
+- Remaining closeout action: collect 2 new-user WHY-60 times and final go/no-go signoff.
+
+## Verified Evidence
+- Current Coherence Index: `100`
+  - Source: `pilot/reports/ci_report.json`
+- Deterministic drill (`scripts/pilot_in_a_box.py`)
+  - Baseline CI: `100`
+  - FAIL injection CI: `30`
+  - PATCH remediation CI: `100`
+- WHY challenge script present and runnable:
+  - `scripts/why_60s_challenge.py`
+- Duplicate-file prevention guard:
+  - `scripts/check_no_dupe_files.py`
+  - `.github/workflows/no_dupes.yml`
+
+## Merge-Block Gate Evidence
+- Example failing CI run (blocked before merge):
+  - `https://github.com/8ryanWh1t3/DeepSigma/actions/runs/22283419597`
+- Example failing CI run (blocked before merge):
+  - `https://github.com/8ryanWh1t3/DeepSigma/actions/runs/22282703970`
+- This demonstrates required checks can fail and prevent clean merge progression until fixed.
+
+## Branch Protection Baseline
+`main` enforcement target:
+- Pull request required before merge
+- Required checks enabled (`coherence-ci`, `no-dupes`)
+- Conversation resolution required
+- At least 1 approval required
+- Force push disabled
+
+## Operator Closeout Checklist
+- [ ] Run WHY-60 challenge with 2 new users and record times
+- [ ] Attach screenshots/log evidence from those runs
+- [ ] Record final pilot go/no-go decision
+
+### WHY-60 Validation Log
+| User | Date | Time (s) | Pass (`<=60`) | Notes |
+|---|---|---:|---|---|
+| User 1 |  |  |  |  |
+| User 2 |  |  |  |  |
+
+## Related Pilot Docs
+- Scope: `docs/docs/pilot/PILOT_SCOPE.md`
+- DRI model: `docs/docs/pilot/DRI_MODEL.md`
+- Branch protection: `docs/docs/pilot/BRANCH_PROTECTION.md`
+- Pilot contract: `docs/docs/pilot/PILOT_CONTRACT_ONEPAGER.md`
+- War plan: `docs/docs/pilot/ISSUE_WAR_PLAN.md`

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -12,6 +12,7 @@ This folder contains the canonical pilot dataset: Decisions (DLR), Assumptions, 
 - DRI model: `docs/docs/pilot/DRI_MODEL.md`
 - Branch protection: `docs/docs/pilot/BRANCH_PROTECTION.md`
 - Contract: `docs/docs/pilot/PILOT_CONTRACT_ONEPAGER.md`
+- Results snapshot: `docs/docs/pilot/PILOT_RESULTS_2026-02-22.md`
 
 ## Release Notes
 - `docs/docs/release/RELEASE_NOTES_v2.0.3.md`


### PR DESCRIPTION
## Summary
Adds a canonical pilot results snapshot with hard evidence links and a final operator closeout checklist.

### Added
- `docs/docs/pilot/PILOT_RESULTS_2026-02-22.md`
  - current CI state and deterministic drill results
  - merge-block gate evidence links (failed CI runs)
  - branch protection baseline
  - explicit remaining tasks (WHY-60 with 2 new users + final go/no-go)
  - validation log table template
- `pilot/README.md` link to the results snapshot

This keeps issue #199 grounded in a single source-of-truth artifact and makes remaining manual closeout steps explicit.

Closes #199
