### PR TITLE
feat: one-command money demo path (issue #133)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: ci pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack
 
 ci:
 	python scripts/compute_ci.py
+
+demo:
+	bash run_money_demo.sh
 
 pilot-in-a-box:
 	python scripts/pilot_in_a_box.py

--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ When assumptions decay, **Drift** fires. When drift exceeds tolerance, a **Patch
 ```bash
 pip install deepsigma
 
+# One-command Money Demo (recommended first run)
+make demo
+
 # Health check
 deepsigma doctor
 
 # Score coherence (0–100, A–F)
 python -m coherence_ops score ./coherence_ops/examples/sample_episodes.json --json
 
-# Drift → Patch in 60 seconds
+# Drift → Patch canonical entrypoint
 python -m coherence_ops.examples.drift_patch_cycle
 
 # Full 7-step Golden Path (no credentials needed)

--- a/docs/OPS_RUNBOOK.md
+++ b/docs/OPS_RUNBOOK.md
@@ -10,6 +10,7 @@
 
 | Task | Command |
 |------|---------|
+| Run Money Demo (recommended) | `make demo` |
 | Run Money Demo (canonical) | `python -m coherence_ops.examples.drift_patch_cycle` |
 | Score episodes | `python -m coherence_ops score ./coherence_ops/examples/sample_episodes.json --json` |
 | Run full test suite | `pytest tests/ -v` |
@@ -29,6 +30,9 @@ The Money Demo is the canonical proof-of-life for the Drift → Patch loop.
 
 ```bash
 # From repo root with venv active:
+make demo
+
+# or canonical Python entrypoint:
 python -m coherence_ops.examples.drift_patch_cycle
 ```
 

--- a/run_money_demo.sh
+++ b/run_money_demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="$ROOT_DIR/docs/examples/demo-stack/drift_patch_cycle_run"
+export PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+step() {
+  printf "\n[%s] %s\n" "$1" "$2"
+}
+
+step "1/3" "Running Money Demo (Drift -> Patch cycle)"
+python -m coherence_ops.examples.drift_patch_cycle
+
+step "2/3" "Verifying demo contract"
+python -m pytest tests/test_money_demo.py -q
+
+step "3/3" "Done"
+echo "Artifacts: $OUTPUT_DIR"
+echo "Evidence:  $ROOT_DIR/docs/examples/demo-stack/MONEY_DEMO_EVIDENCE.md"
+
+if command -v open >/dev/null 2>&1; then
+  open "$OUTPUT_DIR" >/dev/null 2>&1 || true
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$OUTPUT_DIR" >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
## Summary
- add `run_money_demo.sh` as one-command demo runner
- add `make demo` target in `Makefile`
- update docs to make `make demo` the recommended first-run entrypoint

## Validation
- `make demo`
  - runs Drift->Patch cycle
  - runs `tests/test_money_demo.py` contract
  - prints artifact and evidence paths

Closes #133
