### PR TITLE
docs: README golden-path proof artifacts (issue #135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,49 @@ deepsigma golden-path sharepoint \
   --fixture src/demos/golden_path/fixtures/sharepoint_small --clean
 ```
 
+## Golden-Path Proof Artifacts
+
+![Credibility Index dashboard proof](docs/assets/dashboard_credibility_index.svg)
+![Drift detection and patch proof](docs/assets/dashboard_drift_patch.svg)
+
+```bash
+# Golden Path run (ingest -> drift -> patch -> recall)
+PYTHONPATH=src python -m tools.golden_path_cli golden-path sharepoint \
+  --fixture src/demos/golden_path/fixtures/sharepoint_small \
+  --output golden_path_output --clean
+
+# Trust Scorecard (includes WHY retrieval SLO check)
+PYTHONPATH=src python -m tools.trust_scorecard \
+  --input golden_path_output \
+  --output golden_path_output/trust_scorecard.json
+```
+
+```text
+============================================================
+  GOLDEN PATH
+============================================================
+  [1] CONNECT              PASS
+  [2] NORMALIZE            PASS
+  [3] EXTRACT              PASS
+  [4] SEAL                 PASS
+  [5] DRIFT                PASS
+  [6] PATCH                PASS
+  [7] RECALL               PASS
+...
+  IRIS:       WHY=RESOLVED, WHAT_CHANGED=RESOLVED, STATUS=RESOLVED
+  Drift:      6 events
+  Patch:      applied
+============================================================
+Trust Scorecard written to golden_path_output/trust_scorecard.json
+  SLOs:    ALL PASS
+```
+
+Trust Scorecard highlights from the same run:
+- `iris_why_latency_ms`: `1.4` (`<= 60000` target, retrieval <= 60s)
+- `patch_applied`: `true`
+- `drift_events_detected`: `6`
+- `all_steps_passed`: `true`
+
 ---
 
 ## Court-Grade Proof (60 seconds)

--- a/docs/assets/dashboard_credibility_index.svg
+++ b/docs/assets/dashboard_credibility_index.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#141f35"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="url(#bg)"/>
+  <rect x="40" y="40" width="1120" height="640" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="80" y="94" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="28">Credibility Index Dashboard</text>
+  <text x="80" y="126" fill="#93c5fd" font-family="Menlo, Monaco, Consolas, monospace" font-size="16">Tenant: demo-sharepoint-small</text>
+
+  <rect x="80" y="160" width="320" height="180" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="104" y="206" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Credibility Index</text>
+  <text x="104" y="262" fill="#22c55e" font-family="Menlo, Monaco, Consolas, monospace" font-size="52" font-weight="bold">75.0 (B)</text>
+  <text x="104" y="300" fill="#94a3b8" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Updated: 2026-02-22T23:39Z</text>
+
+  <rect x="430" y="160" width="320" height="180" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="454" y="206" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Claim Status Lights</text>
+  <circle cx="470" cy="248" r="10" fill="#22c55e"/><text x="490" y="254" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Green: 2</text>
+  <circle cx="470" cy="278" r="10" fill="#f59e0b"/><text x="490" y="284" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Yellow: 1</text>
+  <circle cx="470" cy="308" r="10" fill="#ef4444"/><text x="490" y="314" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Red: 0</text>
+
+  <rect x="780" y="160" width="340" height="180" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="804" y="206" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Trust Scorecard</text>
+  <text x="804" y="246" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="15">IRIS WHY latency: 1.4ms (&lt; 60000ms)</text>
+  <text x="804" y="276" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="15">Steps passed: 7/7</text>
+  <text x="804" y="306" fill="#22c55e" font-family="Menlo, Monaco, Consolas, monospace" font-size="18" font-weight="bold">SLOs: ALL PASS</text>
+
+  <rect x="80" y="380" width="1040" height="250" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="104" y="422" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Golden Path Evidence (Summary)</text>
+  <text x="104" y="460" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="15">CONNECT PASS · NORMALIZE PASS · EXTRACT PASS · SEAL PASS · DRIFT PASS · PATCH PASS · RECALL PASS</text>
+  <text x="104" y="490" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="15">IRIS: WHY=RESOLVED, WHAT_CHANGED=RESOLVED, STATUS=RESOLVED</text>
+  <text x="104" y="520" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="15">Drift events: 6 · Patch applied: true · Elapsed: 21ms</text>
+</svg>

--- a/docs/assets/dashboard_drift_patch.svg
+++ b/docs/assets/dashboard_drift_patch.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0f1a"/>
+      <stop offset="100%" stop-color="#142033"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="url(#bg2)"/>
+  <rect x="40" y="40" width="1120" height="640" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="80" y="94" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="28">Drift Detection and Patch View</text>
+  <text x="80" y="126" fill="#93c5fd" font-family="Menlo, Monaco, Consolas, monospace" font-size="16">Loop: drift-cycle-001 -&gt; patch-cycle-001</text>
+
+  <rect x="80" y="160" width="500" height="220" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="104" y="206" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Open Drift Signals</text>
+  <rect x="104" y="228" width="452" height="42" rx="8" fill="#450a0a" stroke="#7f1d1d"/>
+  <text x="122" y="255" fill="#fecaca" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">DRIFT-2026-001 | Assumption expired | Severity: SEV-1</text>
+  <rect x="104" y="282" width="452" height="42" rx="8" fill="#1f2937" stroke="#374151"/>
+  <text x="122" y="309" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Evidence: expiry_date &lt; today, owner assigned, patch required</text>
+  <text x="104" y="350" fill="#fca5a5" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">State before remediation: CI impacted by open drift + expired assumption</text>
+
+  <rect x="620" y="160" width="500" height="220" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="644" y="206" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Applied Patch</text>
+  <rect x="644" y="228" width="452" height="42" rx="8" fill="#052e16" stroke="#14532d"/>
+  <text x="662" y="255" fill="#bbf7d0" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">PATCH-2026-001 | Assumption refreshed | Drift closed</text>
+  <rect x="644" y="282" width="452" height="42" rx="8" fill="#1f2937" stroke="#374151"/>
+  <text x="662" y="309" fill="#cbd5e1" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Links: decision DLR + drift issue + patch record + updated seal</text>
+  <text x="644" y="350" fill="#86efac" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">State after remediation: drift closed, CI recovers to compliant range</text>
+
+  <rect x="80" y="420" width="1040" height="210" rx="10" fill="#111827" stroke="#475569"/>
+  <text x="104" y="462" fill="#e2e8f0" font-family="Menlo, Monaco, Consolas, monospace" font-size="20">Drift -&gt; Patch Timeline</text>
+  <line x1="130" y1="520" x2="1070" y2="520" stroke="#334155" stroke-width="4"/>
+  <circle cx="220" cy="520" r="12" fill="#ef4444"/>
+  <text x="196" y="555" fill="#fecaca" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Drift detected</text>
+  <circle cx="600" cy="520" r="12" fill="#f59e0b"/>
+  <text x="555" y="555" fill="#fde68a" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Patch prepared</text>
+  <circle cx="950" cy="520" r="12" fill="#22c55e"/>
+  <text x="910" y="555" fill="#bbf7d0" font-family="Menlo, Monaco, Consolas, monospace" font-size="14">Recovery verified</text>
+</svg>


### PR DESCRIPTION
## Summary
- add two local proof visuals under `docs/assets/` for README embedding
- add README "Golden-Path Proof Artifacts" section with:
  - dashboard proof images
  - executable Golden Path + Trust Scorecard commands
  - CLI transcript showing 7/7 PASS, drift->patch completion, and SLOs ALL PASS
  - explicit WHY retrieval <= 60s evidence from scorecard metrics

## Acceptance Mapping (#135)
- [x] 2 proof visuals embedded in README
- [x] CLI transcript with Golden Path + retrieval + drift->patch evidence
- [x] Assets stored locally in `docs/assets/`
- [x] README quick start references `make demo`
- [x] Trust Scorecard output shown with `SLOs: ALL PASS`

Closes #135
