### PR TITLE
feat(helm): chart install validation and helm test smoke checks (#190)

### DIFF
--- a/.github/workflows/helm_chart_validate.yml
+++ b/.github/workflows/helm_chart_validate.yml
@@ -1,0 +1,53 @@
+name: Helm Chart Validation
+
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - "docs/deployment/HELM.md"
+      - ".github/workflows/helm_chart_validate.yml"
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - "docs/deployment/HELM.md"
+      - ".github/workflows/helm_chart_validate.yml"
+
+jobs:
+  chart-lint-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Helm lint
+        run: helm lint charts/deepsigma
+      - name: Helm template
+        run: helm template deepsigma charts/deepsigma >/tmp/deepsigma-render.yaml
+
+  kind-install-test:
+    runs-on: ubuntu-latest
+    needs: chart-lint-template
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Setup kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: deepsigma
+      - name: Install chart
+        run: |
+          helm upgrade --install deepsigma charts/deepsigma --namespace deepsigma --create-namespace
+          kubectl -n deepsigma rollout status deploy/deepsigma --timeout=180s
+      - name: Helm test smoke checks
+        run: helm test deepsigma -n deepsigma
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide
+          kubectl -n deepsigma get all
+          kubectl -n deepsigma describe deploy deepsigma || true
+          kubectl -n deepsigma logs deploy/deepsigma --all-containers=true --tail=200 || true
+          kubectl -n deepsigma get events --sort-by=.metadata.creationTimestamp | tail -n 100 || true
+          helm get all deepsigma -n deepsigma || true

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ DeepSigma/
 | [NAV.md](docs/NAV.md) | Full navigation index |
 | [ABOUT.md](docs/ABOUT.md) | Reality Await Layer (RAL) |
 | [OPS_RUNBOOK.md](docs/OPS_RUNBOOK.md) | Operations + incident playbooks |
+| [HELM.md](docs/deployment/HELM.md) | Helm install/test runbook (kind/minikube) |
 | [STATELESS_API_SCALE_GUIDE.md](docs/scaling/STATELESS_API_SCALE_GUIDE.md) | 3-replica benchmark + sizing guidance |
 | [STABILITY.md](docs/STABILITY.md) | Versioning policy + stability guarantees |
 | [docs/99-docs-map.md](docs/99-docs-map.md) | Complete docs map |

--- a/charts/deepsigma/Chart.yaml
+++ b/charts/deepsigma/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: deepsigma
+description: Helm chart for DeepSigma dashboard/API service
+home: https://github.com/8ryanWh1t3/DeepSigma
+type: application
+version: 0.1.0
+appVersion: "2.0.3"
+keywords:
+  - deepsigma
+  - coherence-ops
+  - governance
+maintainers:
+  - name: DeepSigma

--- a/charts/deepsigma/templates/NOTES.txt
+++ b/charts/deepsigma/templates/NOTES.txt
@@ -1,0 +1,7 @@
+DeepSigma installed.
+
+Check service:
+  kubectl get svc {{ include "deepsigma.fullname" . }}
+
+Run smoke tests:
+  helm test {{ .Release.Name }}

--- a/charts/deepsigma/templates/_helpers.tpl
+++ b/charts/deepsigma/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "deepsigma.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "deepsigma.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "deepsigma.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "deepsigma.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "deepsigma.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deepsigma.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "deepsigma.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deepsigma.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/deepsigma/templates/deployment.yaml
+++ b/charts/deepsigma/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deepsigma.fullname" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "deepsigma.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "deepsigma.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "deepsigma.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: deepsigma
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/deepsigma/templates/service.yaml
+++ b/charts/deepsigma/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deepsigma.fullname" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "deepsigma.selectorLabels" . | nindent 4 }}

--- a/charts/deepsigma/templates/serviceaccount.yaml
+++ b/charts/deepsigma/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "deepsigma.serviceAccountName" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/deepsigma/templates/tests/test-smoke.yaml
+++ b/charts/deepsigma/templates/tests/test-smoke.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "deepsigma.fullname" . }}-smoke"
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: smoke
+      image: curlimages/curl:8.7.1
+      command: ['sh', '-c']
+      args:
+        - >-
+          set -euo pipefail;
+          curl -fsS "http://{{ include "deepsigma.fullname" . }}:{{ .Values.service.port }}/healthz";
+          curl -fsS "http://{{ include "deepsigma.fullname" . }}:{{ .Values.service.port }}/api/health";

--- a/charts/deepsigma/values.yaml
+++ b/charts/deepsigma/values.yaml
@@ -1,0 +1,40 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/8ryanwh1t3/deepsigma-dashboard
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources: {}
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+env: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/deployment/HELM.md
+++ b/docs/deployment/HELM.md
@@ -1,0 +1,41 @@
+# Helm Deployment and Validation
+
+This document defines the install/test path for issue #190.
+
+## Chart location
+
+- `charts/deepsigma`
+
+## Local install path (kind)
+
+```bash
+kind create cluster --name deepsigma
+helm upgrade --install deepsigma charts/deepsigma --namespace deepsigma --create-namespace
+kubectl -n deepsigma rollout status deploy/deepsigma --timeout=180s
+helm test deepsigma -n deepsigma
+```
+
+## Local install path (minikube)
+
+```bash
+minikube start
+helm upgrade --install deepsigma charts/deepsigma --namespace deepsigma --create-namespace
+kubectl -n deepsigma rollout status deploy/deepsigma --timeout=180s
+helm test deepsigma -n deepsigma
+```
+
+## Diagnostics when install/test fails
+
+```bash
+kubectl get pods -n deepsigma -o wide
+kubectl describe deploy deepsigma -n deepsigma
+kubectl logs deploy/deepsigma -n deepsigma --all-containers=true --tail=200
+kubectl get events -n deepsigma --sort-by=.metadata.creationTimestamp | tail -n 50
+helm get all deepsigma -n deepsigma
+```
+
+## CI coverage
+
+- `helm lint` and `helm template` render checks
+- kind cluster install smoke path
+- `helm test` smoke checks


### PR DESCRIPTION
## Summary
- add new Helm chart at `charts/deepsigma` for dashboard/API deployment
- add `helm test` smoke pod that checks `/healthz` and `/api/health`
- add CI workflow for chart lint/template and kind install + helm test
- document kind/minikube install paths and failure diagnostics runbook

## Acceptance Mapping (#190)
- [x] kind/minikube install path tested/documented
- [x] `helm test` smoke checks implemented
- [x] CI check for chart lint/template render
- [x] failure diagnostics documented

## Notes
- Helm CLI is not installed in this local runtime, so lint/template execution is validated in CI workflow

Closes #190
