### PR TITLE
Connector SDK + plugin scaffolder + protocol harness

### DIFF
--- a/docs/CONNECTOR_SDK.md
+++ b/docs/CONNECTOR_SDK.md
@@ -1,0 +1,57 @@
+# Connector SDK
+
+Build a custom ConnectorV1 plugin quickly and safely.
+
+## Quickstart (< 100 lines)
+
+```bash
+deepsigma new-connector my-api
+pytest -q tests/test_my_api_connector.py
+```
+
+Generated scaffold includes:
+- connector class (`src/adapters/my_api/connector.py`)
+- protocol harness test (`tests/test_my_api_connector.py`)
+- MCP tool stubs (`src/adapters/my_api/mcp_tools.py`)
+- README (`src/adapters/my_api/README.md`)
+
+## ConnectorV1 protocol
+
+`adapters.contract.ConnectorV1` defines three core methods:
+
+- `source_name: str`
+  - Canonical source id (e.g., `sharepoint`, `dataverse`, `csv`)
+- `list_records(**kwargs) -> list[dict]`
+  - Return canonical records
+- `get_record(record_id, **kwargs) -> dict`
+  - Return a single canonical record
+- `to_envelopes(records) -> list[RecordEnvelope]`
+  - Convert canonical records to schema-validated envelopes
+
+## Contract rules
+
+1. Every record must include `record_id`.
+2. `source_name` must be stable and non-empty.
+3. `to_envelopes` must produce envelopes passing `validate_envelope`.
+4. Connectors should be read-only by default and avoid writing upstream data.
+5. Redaction/data-boundary behavior should follow `docs/136.md` / policy docs.
+
+## Protocol harness
+
+Use the reusable harness to validate any connector:
+
+```python
+from adapters.testing.harness import assert_connector_v1
+
+assert_connector_v1(connector)
+```
+
+This verifies list/get/envelope behavior and schema validity.
+
+## Community example connector
+
+A reference implementation is provided:
+- `src/adapters/community/csv_connector.py`
+- `tests/test_connector_protocol_harness.py`
+
+It demonstrates the minimal path from source rows to valid envelopes.

--- a/src/adapters/community/README.md
+++ b/src/adapters/community/README.md
@@ -1,0 +1,9 @@
+# Community Connector Example: CSV
+
+This folder contains a community-style connector implementation built using the Connector SDK pattern.
+
+- Module: `src/adapters/community/csv_connector.py`
+- Class: `CSVFileConnector`
+- Contract: `adapters.contract.ConnectorV1`
+
+Use this as a reference for custom connector development.

--- a/src/adapters/community/__init__.py
+++ b/src/adapters/community/__init__.py
@@ -1,0 +1,1 @@
+"""Community connector examples."""

--- a/src/adapters/community/csv_connector.py
+++ b/src/adapters/community/csv_connector.py
@@ -1,0 +1,64 @@
+"""Community example connector: CSV file -> canonical records -> envelopes."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from adapters.contract import RecordEnvelope
+
+
+class CSVFileConnector:
+    """Simple read-only ConnectorV1 example using CSV as a source."""
+
+    source_name = "csv"
+
+    def __init__(self, csv_path: str | Path, source_instance: str = "local") -> None:
+        self.csv_path = Path(csv_path)
+        self.source_instance = source_instance
+
+    def list_records(self, **kwargs: Any) -> list[dict[str, Any]]:
+        limit = int(kwargs.get("limit", 0) or 0)
+        rows: list[dict[str, Any]] = []
+        with self.csv_path.open("r", encoding="utf-8", newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                record_id = row.get("record_id") or row.get("id")
+                if not record_id:
+                    continue
+                rows.append(
+                    {
+                        "record_id": str(record_id),
+                        "record_type": row.get("record_type", "Row"),
+                        "source": {"system": self.source_name},
+                        "observed_at": row.get("observed_at", ""),
+                        "provenance": [{"ref": f"csv://{self.csv_path.name}#{record_id}"}],
+                        "raw": row,
+                    }
+                )
+                if limit and len(rows) >= limit:
+                    break
+        return rows
+
+    def get_record(self, record_id: str, **kwargs: Any) -> dict[str, Any]:
+        for rec in self.list_records(**kwargs):
+            if rec["record_id"] == record_id:
+                return rec
+        raise KeyError(f"Record not found: {record_id}")
+
+    def to_envelopes(self, records: list[dict[str, Any]]) -> list[RecordEnvelope]:
+        envs: list[RecordEnvelope] = []
+        for rec in records:
+            envs.append(
+                RecordEnvelope(
+                    source=self.source_name,
+                    source_instance=self.source_instance,
+                    record_id=rec["record_id"],
+                    record_type=rec.get("record_type", "Row"),
+                    provenance={"uri": rec.get("provenance", [{}])[0].get("ref", "")},
+                    raw=rec,
+                    metadata={"origin": "community_csv_connector"},
+                )
+            )
+        return envs

--- a/src/adapters/testing/harness.py
+++ b/src/adapters/testing/harness.py
@@ -1,0 +1,55 @@
+"""Connector protocol test harness for ConnectorV1 implementations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adapters.contract import ConnectorV1, validate_envelope
+
+
+class ConnectorProtocolError(AssertionError):
+    """Raised when a connector violates ConnectorV1 contract expectations."""
+
+
+def assert_connector_v1(
+    connector: ConnectorV1,
+    *,
+    list_kwargs: dict[str, Any] | None = None,
+    get_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Validate a connector instance against core ConnectorV1 contract rules."""
+    if not getattr(connector, "source_name", ""):
+        raise ConnectorProtocolError("connector.source_name must be non-empty")
+
+    list_kwargs = list_kwargs or {}
+    records = connector.list_records(**list_kwargs)
+    if not isinstance(records, list):
+        raise ConnectorProtocolError("list_records() must return a list")
+    if not records:
+        raise ConnectorProtocolError("list_records() returned no records for protocol test")
+
+    first = records[0]
+    if not isinstance(first, dict):
+        raise ConnectorProtocolError("list_records() items must be dicts")
+    if "record_id" not in first:
+        raise ConnectorProtocolError("record missing required key: record_id")
+
+    rid = first["record_id"]
+    fetched = connector.get_record(rid, **(get_kwargs or {}))
+    if not isinstance(fetched, dict):
+        raise ConnectorProtocolError("get_record() must return a dict")
+    if fetched.get("record_id") != rid:
+        raise ConnectorProtocolError("get_record() returned mismatched record_id")
+
+    envelopes = connector.to_envelopes([fetched])
+    if not isinstance(envelopes, list) or not envelopes:
+        raise ConnectorProtocolError("to_envelopes() must return a non-empty list")
+
+    envelope = envelopes[0]
+    payload = envelope.to_dict() if hasattr(envelope, "to_dict") else envelope
+    if not isinstance(payload, dict):
+        raise ConnectorProtocolError("envelope must be dict-like")
+
+    errors = validate_envelope(payload)
+    if errors:
+        raise ConnectorProtocolError(f"envelope schema validation failed: {errors}")

--- a/src/deepsigma/cli/main.py
+++ b/src/deepsigma/cli/main.py
@@ -5,6 +5,7 @@ Commands:
     deepsigma doctor                          Environment health check
     deepsigma demo excel [--out DIR]          Excel-first Money Demo
     deepsigma retention sweep --tenant <id>   TTL retention sweep + compaction
+    deepsigma new-connector <name>           Scaffold ConnectorV1 plugin
     deepsigma validate boot <xlsx>            BOOT contract validation
     deepsigma mdpt index --csv <file>         Generate MDPT Prompt Index
     deepsigma golden-path <source> [opts]     7-step Golden Path loop
@@ -49,6 +50,7 @@ def main(argv: list[str] | None = None) -> int:
         mdpt_index,
         retention,
         rekey,
+        new_connector,
         validate_boot,
     )
 
@@ -60,6 +62,7 @@ def main(argv: list[str] | None = None) -> int:
     golden_path.register(subparsers)
     compact.register(subparsers)
     rekey.register(subparsers)
+    new_connector.register(subparsers)
 
     args = parser.parse_args(argv)
 

--- a/src/deepsigma/cli/new_connector.py
+++ b/src/deepsigma/cli/new_connector.py
@@ -1,0 +1,73 @@
+"""deepsigma new-connector — scaffold a ConnectorV1 plugin."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates" / "connector"
+
+
+def _slug(name: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", name).strip("_").lower()
+    if not s:
+        raise ValueError("Connector name must contain letters or numbers")
+    return s
+
+
+def _class_name(slug: str) -> str:
+    return "".join(part.capitalize() for part in slug.split("_")) + "Connector"
+
+
+def _render(text: str, context: dict[str, str]) -> str:
+    out = text
+    for key, value in context.items():
+        out = out.replace("{{ " + key + " }}", value)
+    return out
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("new-connector", help="Scaffold a ConnectorV1 plugin")
+    p.add_argument("name", help="Connector name (e.g. csv, zendesk, my-api)")
+    p.add_argument("--out-dir", default="src/adapters", help="Base output directory")
+    p.add_argument("--tests-dir", default="tests", help="Directory for generated test file")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    slug = _slug(args.name)
+    class_name = _class_name(slug)
+    base = Path(args.out_dir).resolve()
+    target = base / slug
+    tests_dir = Path(args.tests_dir).resolve()
+
+    target.mkdir(parents=True, exist_ok=True)
+    tests_dir.mkdir(parents=True, exist_ok=True)
+
+    import_path = f"adapters.{slug}.connector"
+    context = {
+        "connector_slug": slug,
+        "connector_class": class_name,
+        "import_path": import_path,
+    }
+
+    mappings = {
+        "connector.py.tpl": target / "connector.py",
+        "mcp_tools.py.tpl": target / "mcp_tools.py",
+        "README.md.tpl": target / "README.md",
+        "test_connector.py.tpl": tests_dir / f"test_{slug}_connector.py",
+    }
+
+    for src_name, dst in mappings.items():
+        src = _TEMPLATE_DIR / src_name
+        rendered = _render(src.read_text(encoding="utf-8"), context)
+        dst.write_text(rendered, encoding="utf-8")
+
+    init_file = target / "__init__.py"
+    if not init_file.exists():
+        init_file.write_text("\n", encoding="utf-8")
+
+    print(f"Created connector scaffold: {target}")
+    print(f"Created test scaffold: {tests_dir / f'test_{slug}_connector.py'}")
+    return 0

--- a/src/deepsigma/templates/connector/README.md.tpl
+++ b/src/deepsigma/templates/connector/README.md.tpl
@@ -1,0 +1,13 @@
+# {{ connector_class }}
+
+Generated connector scaffold.
+
+## Files
+- `connector.py` — ConnectorV1-compatible class scaffold
+- `test_{{ connector_slug }}_connector.py` — protocol harness test
+- `mcp_tools.py` — MCP tool stubs
+
+## Next steps
+1. Implement `list_records` and `get_record`
+2. Run tests
+3. Validate with protocol harness (`assert_connector_v1`)

--- a/src/deepsigma/templates/connector/connector.py.tpl
+++ b/src/deepsigma/templates/connector/connector.py.tpl
@@ -1,0 +1,37 @@
+"""{{ connector_class }} — generated connector scaffold."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from adapters.contract import RecordEnvelope
+
+
+class {{ connector_class }}:
+    """ConnectorV1-compatible scaffold."""
+
+    source_name = "{{ connector_slug }}"
+
+    def list_records(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return canonical records from the source."""
+        return []
+
+    def get_record(self, record_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Return a single canonical record by record_id."""
+        raise KeyError(f"Record not found: {record_id}")
+
+    def to_envelopes(self, records: list[dict[str, Any]]) -> list[RecordEnvelope]:
+        """Convert canonical records into RecordEnvelope objects."""
+        envelopes: list[RecordEnvelope] = []
+        for rec in records:
+            envelopes.append(
+                RecordEnvelope(
+                    source=self.source_name,
+                    source_instance="generated",
+                    record_id=rec.get("record_id", ""),
+                    record_type=rec.get("record_type", "Record"),
+                    provenance={"uri": rec.get("uri", "")},
+                    raw=rec,
+                )
+            )
+        return envelopes

--- a/src/deepsigma/templates/connector/mcp_tools.py.tpl
+++ b/src/deepsigma/templates/connector/mcp_tools.py.tpl
@@ -1,0 +1,13 @@
+"""MCP tool stubs for {{ connector_class }}."""
+
+from __future__ import annotations
+
+
+def tool_list_records(arguments: dict) -> dict:
+    """Stub: wire this to your connector's list_records()."""
+    return {"status": "todo", "tool": "list_records", "args": arguments}
+
+
+def tool_get_record(arguments: dict) -> dict:
+    """Stub: wire this to your connector's get_record()."""
+    return {"status": "todo", "tool": "get_record", "args": arguments}

--- a/src/deepsigma/templates/connector/test_connector.py.tpl
+++ b/src/deepsigma/templates/connector/test_connector.py.tpl
@@ -1,0 +1,26 @@
+"""Tests for {{ connector_class }} scaffold."""
+
+from __future__ import annotations
+
+from {{ import_path }} import {{ connector_class }}
+from adapters.testing.harness import assert_connector_v1
+
+
+class _{{ connector_class }}ForTest({{ connector_class }}):
+    def list_records(self, **kwargs):
+        return [
+            {
+                "record_id": "sample-001",
+                "record_type": "Sample",
+                "source": {"system": self.source_name},
+                "provenance": [{"ref": "sample://1"}],
+                "raw": {"x": 1},
+            }
+        ]
+
+    def get_record(self, record_id: str, **kwargs):
+        return self.list_records()[0]
+
+
+def test_protocol_harness_passes():
+    assert_connector_v1(_{{ connector_class }}ForTest())

--- a/tests/fixtures/community_connector_rows.csv
+++ b/tests/fixtures/community_connector_rows.csv
@@ -1,0 +1,3 @@
+record_id,record_type,observed_at,name,value
+row-001,Metric,2026-02-22T00:00:00Z,latency_ms,123
+row-002,Metric,2026-02-22T00:01:00Z,error_rate,0.01

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -8,8 +8,11 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
 if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(1, str(REPO_ROOT))
 
 CSV_FIXTURE = REPO_ROOT / "tests" / "fixtures" / "promptcapabilities_export.csv"
 VALID_BOOT = REPO_ROOT / "tests" / "fixtures" / "valid_boot.xlsx"
@@ -85,3 +88,30 @@ class TestDemoExcel:
         rc = main(["demo", "excel", "--out", str(tmp_path)])
         assert rc == 0
         assert (tmp_path / "workbook.xlsx").exists()
+
+
+class TestNewConnector:
+    def test_new_connector_scaffolds_files(self, tmp_path):
+        from deepsigma.cli.main import main
+
+        out_dir = tmp_path / "adapters"
+        tests_dir = tmp_path / "tests"
+
+        rc = main(
+            [
+                "new-connector",
+                "sample-api",
+                "--out-dir",
+                str(out_dir),
+                "--tests-dir",
+                str(tests_dir),
+            ]
+        )
+        assert rc == 0
+
+        connector_dir = out_dir / "sample_api"
+        assert (connector_dir / "__init__.py").exists()
+        assert (connector_dir / "connector.py").exists()
+        assert (connector_dir / "mcp_tools.py").exists()
+        assert (connector_dir / "README.md").exists()
+        assert (tests_dir / "test_sample_api_connector.py").exists()

--- a/tests/test_connector_protocol_harness.py
+++ b/tests/test_connector_protocol_harness.py
@@ -1,0 +1,14 @@
+"""Protocol harness tests for ConnectorV1 implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adapters.community.csv_connector import CSVFileConnector
+from adapters.testing.harness import assert_connector_v1
+
+
+def test_csv_connector_passes_protocol_harness() -> None:
+    fixture = Path(__file__).parent / "fixtures" / "community_connector_rows.csv"
+    connector = CSVFileConnector(csv_path=fixture, source_instance="fixture-csv")
+    assert_connector_v1(connector)


### PR DESCRIPTION
## Summary
- add Connector SDK documentation and protocol expectations
- add `deepsigma new-connector` scaffold command with templates
- add reusable connector protocol test harness and tests
- add community CSV connector example

## Validation
- `ruff check tests/test_cli_smoke.py src/deepsigma/cli/new_connector.py src/deepsigma/cli/main.py src/adapters/testing/harness.py src/adapters/community/csv_connector.py tests/test_connector_protocol_harness.py`
- `PYTHONPATH=src pytest -q tests/test_cli_smoke.py -k "new_connector or no_args_prints_help"`
- `PYTHONPATH=src pytest -q tests/test_connector_protocol_harness.py`
- `PYTHONPATH=src python -m deepsigma.cli.main new-connector sample_api --out-dir <tmp>/adapters --tests-dir <tmp>/tests`

Closes #140
