### PR TITLE
SDK quickstart: add deepsigma init starter scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ DeepSigma/
 
 | | |
 |---|---|
+| [QUICKSTART.md](docs/QUICKSTART.md) | 5-minute starter path (`deepsigma init` + `make demo`) |
 | [START_HERE.md](docs/START_HERE.md) | Front door |
 | [HERO_DEMO.md](docs/HERO_DEMO.md) | 5-minute hands-on walkthrough |
 | [NAV.md](docs/NAV.md) | Full navigation index |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,6 +20,20 @@ pip install -e ".[dev,excel]"
 
 ## Commands
 
+### `deepsigma init`
+
+Scaffold a starter project with sample claims, drift scenario, IRIS queries, and a Trust Scorecard path.
+
+```bash
+deepsigma init my-project
+cd my-project
+make demo
+```
+
+Produces a runnable starter workspace with `data/`, `queries/`, `scenarios/`, and `out/` artifacts.
+
+---
+
 ### `deepsigma doctor`
 
 Environment health check — verifies Python version, dependencies, repo structure, and key paths.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,51 @@
+# Quickstart (Under 5 Minutes)
+
+This walkthrough gets you from zero to a working lattice with sample claims, a drift scenario, IRIS queries, and a Trust Scorecard.
+
+## 1) Create a fresh environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install deepsigma
+```
+
+## 2) Scaffold a starter project
+
+```bash
+deepsigma init my-project
+cd my-project
+```
+
+Generated content includes:
+- `data/sample_claims.json`
+- `data/sample_drift.json`
+- `scenarios/drift_scenario.md`
+- `queries/iris_queries.md`
+- `Makefile` with runnable demo targets
+
+## 3) Run the demo flow
+
+```bash
+make demo
+```
+
+This writes:
+- `out/score.json` (coherence score output)
+- `out/iris_why.json` (WHY retrieval)
+- `out/iris_drift.json` (WHAT_DRIFTED retrieval)
+- `out/trust_scorecard.json` (trust metrics + SLO checks)
+
+## 4) Verify key outputs
+
+```bash
+cat out/trust_scorecard.json
+cat out/iris_why.json
+```
+
+## Next Steps
+
+1. Connector setup: `docs/CONNECTOR_SDK.md`
+2. OpenClaw policy modules: `adapters/openclaw/`
+3. Dashboard: `dashboard/` and `docs/24-dashboard-api.md`

--- a/src/deepsigma/cli/init_project.py
+++ b/src/deepsigma/cli/init_project.py
@@ -1,0 +1,273 @@
+"""deepsigma init — scaffold a 5-minute starter project."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+_SAMPLE_EPISODES = [
+    {
+        "episodeId": "ep-demo-001",
+        "decisionType": "deploy",
+        "sealedAt": "2026-02-12T10:00:00Z",
+        "dteRef": {
+            "deadlineIso": "2026-02-12T10:05:00Z",
+            "ttlSeconds": 300,
+            "freshnessGate": "pass",
+        },
+        "actions": [
+            {
+                "type": "deploy_model",
+                "blastRadiusTier": "medium",
+                "idempotencyKey": "idem-deploy-001",
+                "rollbackPlan": "revert to v2.3",
+                "authorization": {"mode": "human_approved"},
+                "targetRefs": ["model-svc/v2.4"],
+            }
+        ],
+        "verification": {"result": "pass", "verifierId": "smoke-test-v1"},
+        "policy": {
+            "packId": "policy-pack-prod-v3",
+            "packHash": "sha256:abc123def456",
+            "evaluatedAt": "2026-02-12T09:59:50Z",
+            "result": "allow",
+        },
+        "outcome": {"code": "success", "detail": "model v2.4 deployed"},
+        "degrade": {"step": "none"},
+        "context": {"evidenceRefs": ["evidence:deploy-checklist-001"]},
+        "seal": {"sealHash": "sha256:seal001aaa", "sealedAt": "2026-02-12T10:00:00Z"},
+    },
+    {
+        "episodeId": "ep-demo-002",
+        "decisionType": "scale",
+        "sealedAt": "2026-02-12T10:15:00Z",
+        "dteRef": {
+            "deadlineIso": "2026-02-12T10:20:00Z",
+            "ttlSeconds": 300,
+            "freshnessGate": "pass",
+        },
+        "actions": [
+            {
+                "type": "scale_replicas",
+                "blastRadiusTier": "low",
+                "idempotencyKey": "idem-scale-002",
+                "rollbackPlan": "scale back to 3 replicas",
+                "authorization": {"mode": "auto"},
+                "targetRefs": ["inference-svc"],
+            }
+        ],
+        "verification": {"result": "pass", "verifierId": "replica-health-check"},
+        "policy": {
+            "packId": "policy-pack-prod-v3",
+            "packHash": "sha256:abc123def456",
+            "evaluatedAt": "2026-02-12T10:14:55Z",
+            "result": "allow",
+        },
+        "outcome": {"code": "success", "detail": "scaled to 5 replicas"},
+        "degrade": {"step": "none"},
+        "context": {"evidenceRefs": ["evidence:load-metrics-002"]},
+        "seal": {"sealHash": "sha256:seal002bbb", "sealedAt": "2026-02-12T10:15:00Z"},
+    },
+    {
+        "episodeId": "ep-demo-003",
+        "decisionType": "rollback",
+        "sealedAt": "2026-02-12T10:30:00Z",
+        "dteRef": {
+            "deadlineIso": "2026-02-12T10:32:00Z",
+            "ttlSeconds": 120,
+            "freshnessGate": "pass",
+        },
+        "actions": [
+            {
+                "type": "rollback_model",
+                "blastRadiusTier": "high",
+                "idempotencyKey": "idem-rollback-003",
+                "rollbackPlan": "no further rollback available",
+                "authorization": {"mode": "human_approved"},
+                "targetRefs": ["model-svc/v2.4"],
+            }
+        ],
+        "verification": {"result": "fail", "verifierId": "smoke-test-v1"},
+        "policy": {
+            "packId": "policy-pack-prod-v3",
+            "packHash": "sha256:abc123def456",
+            "evaluatedAt": "2026-02-12T10:29:50Z",
+            "result": "allow",
+        },
+        "outcome": {"code": "partial", "detail": "rollback executed but verification failed"},
+        "degrade": {"step": "safe_subset"},
+        "context": {"evidenceRefs": ["evidence:incident-003", "evidence:deploy-checklist-001"]},
+        "seal": {"sealHash": "sha256:seal003ccc", "sealedAt": "2026-02-12T10:30:00Z"},
+    },
+]
+
+_SAMPLE_DRIFT = [
+    {
+        "driftId": "drift-001",
+        "episodeId": "ep-demo-003",
+        "driftType": "verify",
+        "severity": "red",
+        "detectedAt": "2026-02-12T10:30:05Z",
+        "expectedBehaviour": "verification pass after rollback",
+        "actualBehaviour": "smoke-test-v1 returned fail",
+        "recommendedPatchType": "escalate_to_human",
+    }
+]
+
+_SAMPLE_CLAIMS = [
+    {
+        "claim_id": "claim-001",
+        "episode_id": "ep-demo-001",
+        "text": "Deployment decision prioritized service continuity.",
+        "confidence": 0.82,
+        "evidence_ref": "evidence:deploy-checklist-001",
+    },
+    {
+        "claim_id": "claim-002",
+        "episode_id": "ep-demo-003",
+        "text": "Rollback verification failure is a drift signal requiring patch.",
+        "confidence": 0.94,
+        "evidence_ref": "evidence:incident-003",
+    },
+]
+
+_SAMPLE_SUMMARY = {
+    "baseline_score": 84.0,
+    "baseline_grade": "B",
+    "patched_score": 92.0,
+    "patched_grade": "A",
+    "drift_events": 1,
+    "patch_applied": True,
+    "steps_completed": [
+        "connect",
+        "normalize",
+        "extract",
+        "seal",
+        "drift",
+        "patch",
+        "recall",
+    ],
+    "elapsed_ms": 1430,
+    "canonical_records": 3,
+    "iris_queries": {
+        "WHY": "RESOLVED",
+        "WHAT_CHANGED": "RESOLVED",
+        "STATUS": "RESOLVED",
+    },
+}
+
+
+def _slug(name: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", name).strip("-").lower()
+    if not s:
+        raise ValueError("Project name must contain letters or numbers")
+    return s
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("init", help="Scaffold a 5-minute starter lattice project")
+    p.add_argument("name", help="Project directory name")
+    p.add_argument(
+        "--out-dir",
+        default=".",
+        help="Base output directory where the project folder will be created",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    project_name = _slug(args.name)
+    root = Path(args.out_dir).resolve() / project_name
+
+    root.mkdir(parents=True, exist_ok=True)
+
+    _write_text(
+        root / "README.md",
+        f"""# {project_name}
+
+Starter project generated by `deepsigma init`.
+
+## Quick run
+
+```bash
+make demo
+```
+
+This generates:
+- `out/score.json` (coherence score)
+- `out/iris_why.json` (WHY retrieval query)
+- `out/iris_drift.json` (WHAT_DRIFTED query)
+- `out/trust_scorecard.json` (trust KPI snapshot)
+""",
+    )
+
+    _write_text(
+        root / "Makefile",
+        """PYTHON ?= python
+
+.PHONY: demo score iris trust
+
+demo: score iris trust
+\t@echo \"Quickstart complete. See out/*.json artifacts.\"
+
+score:
+\tmkdir -p out
+\t$(PYTHON) -m coherence_ops score ./data/sample_episodes.json --json > out/score.json
+
+iris:
+\tmkdir -p out
+\t$(PYTHON) -m coherence_ops iris query ./data/sample_episodes.json --type WHY --target ep-demo-003 --json > out/iris_why.json
+\t$(PYTHON) -m coherence_ops iris query ./data/sample_episodes.json --type WHAT_DRIFTED --json > out/iris_drift.json
+
+trust:
+\tmkdir -p out
+\t$(PYTHON) -m tools.trust_scorecard --input ./data/golden_path_sample --output ./out/trust_scorecard.json
+""",
+    )
+
+    _write_text(
+        root / "scenarios" / "drift_scenario.md",
+        """# Drift Scenario
+
+`ep-demo-003` shows a rollback with failed verification.
+
+- Drift type: `verify`
+- Severity: `red`
+- Expected: verification should pass after rollback
+- Actual: verifier stayed in fail state
+- Patch path: escalate to human + adjust guardrails
+""",
+    )
+
+    _write_text(
+        root / "queries" / "iris_queries.md",
+        """# IRIS Queries
+
+```bash
+python -m coherence_ops iris query ./data/sample_episodes.json --type WHY --target ep-demo-003 --json
+python -m coherence_ops iris query ./data/sample_episodes.json --type WHAT_DRIFTED --json
+```
+""",
+    )
+
+    _write_json(root / "data" / "sample_episodes.json", _SAMPLE_EPISODES)
+    _write_json(root / "data" / "sample_drift.json", _SAMPLE_DRIFT)
+    _write_json(root / "data" / "sample_claims.json", _SAMPLE_CLAIMS)
+    _write_json(root / "data" / "golden_path_sample" / "summary.json", _SAMPLE_SUMMARY)
+    _write_json(root / "data" / "golden_path_sample" / "step_2_normalize" / "validation.json", {"errors": []})
+
+    print(f"Initialized DeepSigma project: {root}")
+    print("Next: cd into the project and run `make demo`")
+    return 0

--- a/src/deepsigma/cli/main.py
+++ b/src/deepsigma/cli/main.py
@@ -2,6 +2,7 @@
 """DeepSigma unified CLI — product entrypoint.
 
 Commands:
+    deepsigma init <project-name>            Scaffold a 5-minute starter project
     deepsigma doctor                          Environment health check
     deepsigma demo excel [--out DIR]          Excel-first Money Demo
     deepsigma retention sweep --tenant <id>   TTL retention sweep + compaction
@@ -47,6 +48,7 @@ def main(argv: list[str] | None = None) -> int:
         demo_excel,
         doctor,
         golden_path,
+        init_project,
         mdpt_index,
         retention,
         rekey,
@@ -54,6 +56,7 @@ def main(argv: list[str] | None = None) -> int:
         validate_boot,
     )
 
+    init_project.register(subparsers)
     doctor.register(subparsers)
     demo_excel.register(subparsers)
     validate_boot.register(subparsers)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -115,3 +115,20 @@ class TestNewConnector:
         assert (connector_dir / "mcp_tools.py").exists()
         assert (connector_dir / "README.md").exists()
         assert (tests_dir / "test_sample_api_connector.py").exists()
+
+
+class TestInitProject:
+    def test_init_project_scaffolds_quickstart_files(self, tmp_path):
+        from deepsigma.cli.main import main
+
+        rc = main(["init", "my-project", "--out-dir", str(tmp_path)])
+        assert rc == 0
+
+        project_dir = tmp_path / "my-project"
+        assert (project_dir / "README.md").exists()
+        assert (project_dir / "Makefile").exists()
+        assert (project_dir / "data" / "sample_episodes.json").exists()
+        assert (project_dir / "data" / "sample_drift.json").exists()
+        assert (project_dir / "data" / "sample_claims.json").exists()
+        assert (project_dir / "scenarios" / "drift_scenario.md").exists()
+        assert (project_dir / "queries" / "iris_queries.md").exists()


### PR DESCRIPTION
## Summary
- add `deepsigma init <name>` to scaffold a starter project with sample claims, drift scenario, IRIS query docs, and trust scorecard input
- add `docs/QUICKSTART.md` with copy/paste flow: fresh venv -> install -> init -> make demo
- add CLI docs + README references for the new quickstart path
- add CLI smoke test coverage for `deepsigma init`

## Validation
- `ruff check src/deepsigma/cli/init_project.py src/deepsigma/cli/main.py tests/test_cli_smoke.py`
- `PYTHONPATH=src pytest -q tests/test_cli_smoke.py -k "init_project or new_connector or no_args_prints_help"`
- `PYTHONPATH=src python -m deepsigma.cli.main init my-project --out-dir <tmp>`
- `make -C <tmp>/my-project demo`

Closes #138
