### PR TITLE
Prometheus metrics + Grafana dashboard template

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ All connectors conform to the [Connector Contract v1.0](schemas/core/connector_c
 - [Data Boundaries](docs/DATA_BOUNDARIES.md) — data at rest, storage locations, retention, redaction, tenancy isolation, connector flow, secrets policy, and network boundaries.
 - [Connector SDK](docs/CONNECTOR_SDK.md) — ConnectorV1 contract and safety expectations for custom adapters.
 
+## Monitoring
+
+- Prometheus metrics endpoint: `GET /metrics`
+- Grafana dashboard: `ops/grafana/deepsigma.json`
+- Local monitoring stack: `docker-compose.monitoring.yml`
+
+Start monitoring stack:
+
+```bash
+docker compose -f docker-compose.monitoring.yml up --build
+```
+
+Endpoints:
+- DeepSigma API: `http://localhost:8000`
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3001` (`admin` / `admin`)
+
 ---
 
 ## Repo Structure

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  deepsigma:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: python dashboard/api_server.py
+    ports:
+      - "8000:8000"
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    depends_on:
+      - deepsigma
+    volumes:
+      - ./ops/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./ops/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./ops/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./ops/grafana:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3001:3000"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1114,6 +1114,25 @@
         }
       }
     },
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "description": "Prometheus metrics endpoint.",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/trust_scorecard": {
       "get": {
         "summary": "Get Trust Scorecard",

--- a/ops/grafana/deepsigma.json
+++ b/ops/grafana/deepsigma.json
@@ -1,0 +1,124 @@
+{
+  "id": null,
+  "uid": "deepsigma-overwatch",
+  "title": "DeepSigma Monitoring",
+  "tags": ["deepsigma", "prometheus", "operations"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Credibility Index Trend",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "deepsigma_credibility_index"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "none"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Drift Event Rate (5m)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (severity) (rate(deepsigma_drift_events_total[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "IRIS Query p95 (s)",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(deepsigma_iris_query_duration_seconds_bucket[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1.0 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Packet Seal p95 (s)",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(deepsigma_packet_seal_duration_seconds_bucket[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1.0 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "piechart",
+      "title": "Evidence Tiering",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "deepsigma_evidence_tier_count"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        }
+      }
+    }
+  ]
+}

--- a/ops/grafana/provisioning/dashboards/dashboards.yml
+++ b/ops/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: DeepSigma Dashboards
+    orgId: 1
+    folder: DeepSigma
+    type: file
+    disableDeletion: true
+    editable: true
+    updateIntervalSeconds: 15
+    options:
+      path: /var/lib/grafana/dashboards

--- a/ops/grafana/provisioning/datasources/prometheus.yml
+++ b/ops/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: deepsigma
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - deepsigma:8000

--- a/src/credibility_engine/api.py
+++ b/src/credibility_engine/api.py
@@ -26,6 +26,7 @@ from credibility_engine.packet import (
 from credibility_engine.store import CredibilityStore
 from governance.audit import audit_action, load_recent_audit
 from governance.telemetry import check_quota, record_metric
+from services.prom_metrics import PROM_METRICS
 from tenancy.policies import (
     load_policy,
     save_policy,
@@ -205,6 +206,10 @@ def tenant_seal_packet(tenant_id: str, request: Request) -> dict[str, Any]:
     engine.recalculate_index()
     result = seal_credibility_packet(engine, role=role_header, user=user)
     elapsed_ms = round((time.monotonic() - start) * 1000, 1)
+    PROM_METRICS.observe_histogram(
+        "deepsigma_packet_seal_duration_seconds",
+        elapsed_ms / 1000.0,
+    )
 
     record_metric(tenant_id, "packet_seal_latency_ms", elapsed_ms, actor=user)
     return result

--- a/src/services/prom_metrics.py
+++ b/src/services/prom_metrics.py
@@ -1,0 +1,124 @@
+"""Lightweight Prometheus exposition metrics for DeepSigma.
+
+This module avoids hard runtime dependency on prometheus_client while still
+exposing Prometheus-compatible text format from /metrics.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections import defaultdict
+from dataclasses import dataclass
+
+
+def _fmt_labels(labels: dict[str, str]) -> str:
+    if not labels:
+        return ""
+    parts = []
+    for k in sorted(labels):
+        v = labels[k].replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        parts.append(f'{k}="{v}"')
+    return "{" + ",".join(parts) + "}"
+
+
+@dataclass
+class _HistogramState:
+    buckets: list[float]
+    counts: list[int]
+    sum_value: float = 0.0
+    total_count: int = 0
+
+
+class PromMetrics:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._gauges: dict[str, dict[tuple[tuple[str, str], ...], float]] = defaultdict(dict)
+        self._counters: dict[str, dict[tuple[tuple[str, str], ...], float]] = defaultdict(dict)
+        self._histograms: dict[str, _HistogramState] = {}
+
+    @staticmethod
+    def _key(labels: dict[str, str] | None) -> tuple[tuple[str, str], ...]:
+        if not labels:
+            return ()
+        return tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+
+    @staticmethod
+    def _labels_from_key(key: tuple[tuple[str, str], ...]) -> dict[str, str]:
+        return dict(key)
+
+    def set_gauge(self, name: str, value: float, labels: dict[str, str] | None = None) -> None:
+        with self._lock:
+            self._gauges[name][self._key(labels)] = float(value)
+
+    def inc_counter(self, name: str, inc: float = 1.0, labels: dict[str, str] | None = None) -> None:
+        with self._lock:
+            k = self._key(labels)
+            self._counters[name][k] = self._counters[name].get(k, 0.0) + float(inc)
+
+    def set_counter_floor(self, name: str, value: float, labels: dict[str, str] | None = None) -> None:
+        with self._lock:
+            k = self._key(labels)
+            cur = self._counters[name].get(k, 0.0)
+            self._counters[name][k] = max(cur, float(value))
+
+    def define_histogram(self, name: str, buckets: list[float]) -> None:
+        with self._lock:
+            clean = sorted(b for b in buckets if b > 0)
+            if not clean:
+                clean = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+            self._histograms[name] = _HistogramState(
+                buckets=clean,
+                counts=[0 for _ in clean],
+            )
+
+    def observe_histogram(self, name: str, value: float) -> None:
+        with self._lock:
+            if name not in self._histograms:
+                self.define_histogram(name, [])
+            h = self._histograms[name]
+            v = 0.0 if math.isnan(value) or value < 0 else float(value)
+            h.sum_value += v
+            h.total_count += 1
+            for i, bound in enumerate(h.buckets):
+                if v <= bound:
+                    h.counts[i] += 1
+
+    def render(self) -> str:
+        lines: list[str] = []
+        with self._lock:
+            for name, series in sorted(self._gauges.items()):
+                lines.append(f"# TYPE {name} gauge")
+                for k, v in sorted(series.items()):
+                    lines.append(f"{name}{_fmt_labels(self._labels_from_key(k))} {v}")
+
+            for name, series in sorted(self._counters.items()):
+                lines.append(f"# TYPE {name} counter")
+                for k, v in sorted(series.items()):
+                    lines.append(f"{name}{_fmt_labels(self._labels_from_key(k))} {v}")
+
+            for name, h in sorted(self._histograms.items()):
+                lines.append(f"# TYPE {name} histogram")
+                cumulative = 0
+                for i, bound in enumerate(h.buckets):
+                    cumulative += h.counts[i]
+                    lines.append(f'{name}_bucket{{le="{bound:g}"}} {cumulative}')
+                lines.append(f'{name}_bucket{{le="+Inf"}} {h.total_count}')
+                lines.append(f"{name}_sum {h.sum_value}")
+                lines.append(f"{name}_count {h.total_count}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+
+PROM_METRICS = PromMetrics()
+
+# Required histograms
+PROM_METRICS.define_histogram(
+    "deepsigma_packet_seal_duration_seconds",
+    [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+)
+PROM_METRICS.define_histogram(
+    "deepsigma_iris_query_duration_seconds",
+    [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
+)

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+TestClient = pytest.importorskip("fastapi.testclient").TestClient
+
+from dashboard.api_server import app  # noqa: E402
+
+
+def test_metrics_endpoint_exposes_required_series():
+    client = TestClient(app)
+
+    # Seed a few request and duration metrics.
+    client.get("/api/health")
+    client.post("/api/iris", json={"query_type": "STATUS"})
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    text = resp.text
+
+    required = [
+        "deepsigma_claims_total",
+        "deepsigma_drift_events_total",
+        "deepsigma_packet_seal_duration_seconds",
+        "deepsigma_iris_query_duration_seconds",
+        "deepsigma_api_requests_total",
+        "deepsigma_evidence_tier_count",
+    ]
+    for name in required:
+        assert name in text


### PR DESCRIPTION
## Summary
- add `/metrics` Prometheus exposition endpoint on dashboard API
- add required DeepSigma series:
  - `deepsigma_claims_total` (gauge by state)
  - `deepsigma_drift_events_total` (counter by severity)
  - `deepsigma_packet_seal_duration_seconds` (histogram)
  - `deepsigma_iris_query_duration_seconds` (histogram)
  - `deepsigma_api_requests_total` (counter by endpoint + status)
  - `deepsigma_evidence_tier_count` (gauge by tier)
- add Grafana dashboard template at `ops/grafana/deepsigma.json`
- add local monitoring stack: `docker-compose.monitoring.yml` + Prometheus/Grafana provisioning
- add README Monitoring section
- refresh OpenAPI artifact for `/metrics`

## Validation
- `ruff check src/services/prom_metrics.py dashboard/api_server.py src/credibility_engine/api.py tests/test_metrics_endpoint.py`
- `PYTHONPATH=src pytest -q tests/test_metrics_endpoint.py tests/test_openapi_docs.py`
- `PYTHONPATH=src python - <<'PY' ... /metrics smoke check ... PY`
- `make openapi-docs`

Closes #143
