### PR TITLE
feat(helm): optional Fuseki + ServiceMonitor + config templates (#188)

### DIFF
--- a/charts/deepsigma/README.md
+++ b/charts/deepsigma/README.md
@@ -13,6 +13,7 @@ helm test deepsigma
 
 - `api` Deployment + Service (`/api/health`, `/api/ready` probes)
 - `dashboard` Deployment + Service (`/healthz` probes)
+- Optional `fuseki` StatefulSet + Service (SPARQL endpoint on port `3030`)
 - Optional Ingress with path routing:
   - `/` -> dashboard service
   - `/api` -> api service
@@ -22,6 +23,14 @@ helm test deepsigma
 - Base defaults: `values.yaml` (1 replica each, ingress disabled)
 - Production overlay: `values-production.yaml` (3 replicas each, ingress enabled)
 
+### Optional Toggles
+
+- `configMap.enabled`: creates `<release>-config` from `configMap.data`
+- `secret.enabled`: creates `<release>-secret` from `secret.stringData`
+- `api.envFrom.*` / `dashboard.envFrom.*`: attach ConfigMap/Secret as env sources
+- `fuseki.enabled`: deploy optional Fuseki StatefulSet + service
+- `serviceMonitor.enabled`: emit Prometheus Operator `ServiceMonitor`
+
 ### Ingress Compatibility
 
 Use `ingress.className` and `ingress.annotations` for controller-specific settings.
@@ -30,4 +39,3 @@ Use `ingress.className` and `ingress.annotations` for controller-specific settin
   - `ingress.className: nginx`
 - Traefik example:
   - `ingress.className: traefik`
-

--- a/charts/deepsigma/templates/_helpers.tpl
+++ b/charts/deepsigma/templates/_helpers.tpl
@@ -37,6 +37,14 @@ app.kubernetes.io/component: {{ .component }}
 {{ include "deepsigma.fullname" . }}-{{ .component }}
 {{- end }}
 
+{{- define "deepsigma.configMapName" -}}
+{{ include "deepsigma.fullname" . }}-config
+{{- end }}
+
+{{- define "deepsigma.secretName" -}}
+{{ include "deepsigma.fullname" . }}-secret
+{{- end }}
+
 {{- define "deepsigma.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "deepsigma.fullname" .) .Values.serviceAccount.name }}

--- a/charts/deepsigma/templates/api-deployment.yaml
+++ b/charts/deepsigma/templates/api-deployment.yaml
@@ -39,6 +39,17 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or .Values.api.envFrom.configMapRef .Values.api.envFrom.secretRef }}
+          envFrom:
+            {{- if and .Values.api.envFrom.configMapRef .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "deepsigma.configMapName" . }}
+            {{- end }}
+            {{- if and .Values.api.envFrom.secretRef .Values.secret.enabled }}
+            - secretRef:
+                name: {{ include "deepsigma.secretName" . }}
+            {{- end }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/deepsigma/templates/configmap.yaml
+++ b/charts/deepsigma/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.configMap.enabled .Values.configMap.data }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "deepsigma.configMapName" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.configMap.data }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/deepsigma/templates/deployment.yaml
+++ b/charts/deepsigma/templates/deployment.yaml
@@ -39,6 +39,17 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or .Values.dashboard.envFrom.configMapRef .Values.dashboard.envFrom.secretRef }}
+          envFrom:
+            {{- if and .Values.dashboard.envFrom.configMapRef .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "deepsigma.configMapName" . }}
+            {{- end }}
+            {{- if and .Values.dashboard.envFrom.secretRef .Values.secret.enabled }}
+            - secretRef:
+                name: {{ include "deepsigma.secretName" . }}
+            {{- end }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.dashboard.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/deepsigma/templates/fuseki-service.yaml
+++ b/charts/deepsigma/templates/fuseki-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.fuseki.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deepsigma.componentName" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fuseki
+spec:
+  type: {{ .Values.fuseki.service.type }}
+  ports:
+    - port: {{ .Values.fuseki.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "deepsigma.componentLabels" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 4 }}
+{{- end }}

--- a/charts/deepsigma/templates/fuseki-statefulset.yaml
+++ b/charts/deepsigma/templates/fuseki-statefulset.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.fuseki.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "deepsigma.componentName" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fuseki
+spec:
+  serviceName: {{ include "deepsigma.componentName" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "deepsigma.componentLabels" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "deepsigma.componentLabels" (dict "component" "fuseki" "Chart" .Chart "Release" .Release "Values" .Values) | nindent 8 }}
+    spec:
+      containers:
+        - name: fuseki
+          image: "{{ .Values.fuseki.image.repository }}:{{ .Values.fuseki.image.tag }}"
+          imagePullPolicy: {{ .Values.fuseki.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3030
+              protocol: TCP
+          env:
+            - name: FUSEKI_ADMIN_PASSWORD
+              value: {{ .Values.fuseki.adminPassword | quote }}
+          livenessProbe:
+            {{- toYaml .Values.fuseki.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.fuseki.readinessProbe | nindent 12 }}
+          {{- with .Values.fuseki.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.fuseki.persistence.enabled }}
+          volumeMounts:
+            - name: fuseki-data
+              mountPath: /fuseki
+          {{- end }}
+  {{- if .Values.fuseki.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: fuseki-data
+        labels:
+          {{- include "deepsigma.labels" . | nindent 10 }}
+          app.kubernetes.io/component: fuseki
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.fuseki.persistence.storageClassName }}
+        storageClassName: {{ .Values.fuseki.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.fuseki.persistence.size | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/deepsigma/templates/secret.yaml
+++ b/charts/deepsigma/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.secret.enabled .Values.secret.stringData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deepsigma.secretName" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $k, $v := .Values.secret.stringData }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/deepsigma/templates/servicemonitor.yaml
+++ b/charts/deepsigma/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "deepsigma.fullname" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "deepsigma.componentLabels" (dict "component" .Values.serviceMonitor.endpoint.service "Chart" .Chart "Release" .Release "Values" .Values) | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.endpoint.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/deepsigma/values-production.yaml
+++ b/charts/deepsigma/values-production.yaml
@@ -12,6 +12,9 @@ api:
   env:
     - name: DEEPSIGMA_ENCRYPT_AT_REST
       value: "1"
+  envFrom:
+    configMapRef: true
+    secretRef: true
 
 dashboard:
   replicaCount: 3
@@ -24,6 +27,25 @@ dashboard:
     limits:
       cpu: 500m
       memory: 512Mi
+  envFrom:
+    configMapRef: true
+    secretRef: true
 
 ingress:
+  enabled: true
+
+configMap:
+  enabled: true
+  data:
+    DEEPSIGMA_LOG_LEVEL: info
+
+secret:
+  enabled: true
+  stringData:
+    DEEPSIGMA_MASTER_KEY: "replace-me"
+
+fuseki:
+  enabled: true
+
+serviceMonitor:
   enabled: true

--- a/charts/deepsigma/values.yaml
+++ b/charts/deepsigma/values.yaml
@@ -11,6 +11,14 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+configMap:
+  enabled: false
+  data: {}
+
+secret:
+  enabled: false
+  stringData: {}
+
 api:
   replicaCount: 1
   image:
@@ -22,6 +30,9 @@ api:
     port: 8000
   env: []
   resources: {}
+  envFrom:
+    configMapRef: false
+    secretRef: false
   livenessProbe:
     httpGet:
       path: /api/health
@@ -42,6 +53,9 @@ dashboard:
     port: 3000
   env: []
   resources: {}
+  envFrom:
+    configMapRef: false
+    secretRef: false
   livenessProbe:
     httpGet:
       path: /healthz
@@ -65,6 +79,39 @@ ingress:
           pathType: Prefix
           service: api
   tls: []
+
+fuseki:
+  enabled: false
+  image:
+    repository: stain/jena-fuseki
+    tag: "5.1.0"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3030
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClassName: ""
+  resources: {}
+  adminPassword: "admin"
+  livenessProbe:
+    httpGet:
+      path: /$/ping
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /$/ping
+      port: http
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels: {}
+  endpoint:
+    service: api
+    path: /metrics
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Summary\n- add optional Fuseki StatefulSet + Service templates\n- add optional ConfigMap and Secret templates\n- wire envFrom toggles for API/dashboard from chart-managed config/secret\n- add optional ServiceMonitor template for Prometheus Operator\n- document all toggle paths in chart README\n\nCloses #188\n