### PR TITLE
feat(helm): API HPA + production scaling overlay (#189)

### DIFF
--- a/charts/deepsigma/README.md
+++ b/charts/deepsigma/README.md
@@ -23,6 +23,29 @@ helm test deepsigma
 - Base defaults: `values.yaml` (1 replica each, ingress disabled)
 - Production overlay: `values-production.yaml` (3 replicas each, ingress enabled)
 
+### Production Overlay
+
+`values-production.yaml` enables:
+- API autoscaling (`api.autoscaling.enabled=true`)
+- ConfigMap + Secret env wiring for API/dashboard
+- Fuseki and ServiceMonitor toggles
+- Resource requests/limits for API and dashboard
+
+### Resource Defaults (Production)
+
+- API:
+  - requests: `cpu=250m`, `memory=256Mi`
+  - limits: `cpu=1`, `memory=512Mi`
+- Dashboard:
+  - requests: `cpu=150m`, `memory=192Mi`
+  - limits: `cpu=500m`, `memory=512Mi`
+
+### Replica Strategy (Persistence-backed mode)
+
+- For local JSONL persistence (node-local storage), keep API single-writer semantics (`api.replicaCount=1`, HPA disabled).
+- For shared/external persistence, use API HPA in production overlay (`min=3`, `max=10`).
+- Fuseki remains optional and stateful with a PVC; scale API/dashboard independently from Fuseki data state.
+
 ### Optional Toggles
 
 - `configMap.enabled`: creates `<release>-config` from `configMap.data`

--- a/charts/deepsigma/templates/api-hpa.yaml
+++ b/charts/deepsigma/templates/api-hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "deepsigma.componentName" (dict "component" "api" "Chart" .Chart "Release" .Release "Values" .Values) }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "deepsigma.componentName" (dict "component" "api" "Chart" .Chart "Release" .Release "Values" .Values) }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/deepsigma/values-production.yaml
+++ b/charts/deepsigma/values-production.yaml
@@ -15,6 +15,12 @@ api:
   envFrom:
     configMapRef: true
     secretRef: true
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 65
+    targetMemoryUtilizationPercentage: 75
 
 dashboard:
   replicaCount: 3

--- a/charts/deepsigma/values.yaml
+++ b/charts/deepsigma/values.yaml
@@ -41,6 +41,12 @@ api:
     httpGet:
       path: /api/ready
       port: http
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
 
 dashboard:
   replicaCount: 1


### PR DESCRIPTION
## Summary
- add API HorizontalPodAutoscaler template (autoscaling/v2)
- add `api.autoscaling` values in base and production overlays
- document production resource defaults and replica strategy
- clarify persistence-backed mode scaling guidance

Closes #189
