### PR TITLE
feat(helm): add JSONL PVC support to chart (#148)

### DIFF
--- a/charts/deepsigma/README.md
+++ b/charts/deepsigma/README.md
@@ -50,9 +50,19 @@ helm test deepsigma
 
 - `configMap.enabled`: creates `<release>-config` from `configMap.data`
 - `secret.enabled`: creates `<release>-secret` from `secret.stringData`
+- `dataPersistence.enabled`: creates/uses PVC for JSONL data directories (`/app/src/data`, `/app/data`)
 - `api.envFrom.*` / `dashboard.envFrom.*`: attach ConfigMap/Secret as env sources
 - `fuseki.enabled`: deploy optional Fuseki StatefulSet + service
 - `serviceMonitor.enabled`: emit Prometheus Operator `ServiceMonitor`
+
+### Persistence Notes
+
+- By default, chart-managed JSONL PVC is disabled.
+- To enable chart-managed PVC:
+  - set `dataPersistence.enabled=true` and optionally `dataPersistence.storageClassName`.
+- To use a pre-provisioned PVC:
+  - set `dataPersistence.enabled=true` and `dataPersistence.existingClaim=<claim-name>`.
+- For multi-replica API/dashboard, prefer shared RWX storage or external persistence backend.
 
 ### Ingress Compatibility
 

--- a/charts/deepsigma/templates/_helpers.tpl
+++ b/charts/deepsigma/templates/_helpers.tpl
@@ -45,6 +45,14 @@ app.kubernetes.io/component: {{ .component }}
 {{ include "deepsigma.fullname" . }}-secret
 {{- end }}
 
+{{- define "deepsigma.dataPvcName" -}}
+{{- if .Values.dataPersistence.existingClaim }}
+{{ .Values.dataPersistence.existingClaim }}
+{{- else }}
+{{ include "deepsigma.fullname" . }}-data
+{{- end }}
+{{- end }}
+
 {{- define "deepsigma.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "deepsigma.fullname" .) .Values.serviceAccount.name }}

--- a/charts/deepsigma/templates/api-deployment.yaml
+++ b/charts/deepsigma/templates/api-deployment.yaml
@@ -58,6 +58,19 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.dataPersistence.enabled }}
+          volumeMounts:
+            {{- range .Values.dataPersistence.mountPaths }}
+            - name: deepsigma-data
+              mountPath: {{ . | quote }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.dataPersistence.enabled }}
+      volumes:
+        - name: deepsigma-data
+          persistentVolumeClaim:
+            claimName: {{ include "deepsigma.dataPvcName" . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/deepsigma/templates/data-pvc.yaml
+++ b/charts/deepsigma/templates/data-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.dataPersistence.enabled (not .Values.dataPersistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "deepsigma.dataPvcName" . }}
+  labels:
+    {{- include "deepsigma.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.dataPersistence.accessModes | nindent 4 }}
+  {{- if .Values.dataPersistence.storageClassName }}
+  storageClassName: {{ .Values.dataPersistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.dataPersistence.size | quote }}
+{{- end }}

--- a/charts/deepsigma/templates/deployment.yaml
+++ b/charts/deepsigma/templates/deployment.yaml
@@ -58,6 +58,19 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.dataPersistence.enabled }}
+          volumeMounts:
+            {{- range .Values.dataPersistence.mountPaths }}
+            - name: deepsigma-data
+              mountPath: {{ . | quote }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.dataPersistence.enabled }}
+      volumes:
+        - name: deepsigma-data
+          persistentVolumeClaim:
+            claimName: {{ include "deepsigma.dataPvcName" . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/deepsigma/values-production.yaml
+++ b/charts/deepsigma/values-production.yaml
@@ -50,6 +50,10 @@ secret:
   stringData:
     DEEPSIGMA_MASTER_KEY: "replace-me"
 
+dataPersistence:
+  enabled: false
+  existingClaim: ""
+
 fuseki:
   enabled: true
 

--- a/charts/deepsigma/values.yaml
+++ b/charts/deepsigma/values.yaml
@@ -19,6 +19,17 @@ secret:
   enabled: false
   stringData: {}
 
+dataPersistence:
+  enabled: false
+  existingClaim: ""
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  mountPaths:
+    - /app/src/data
+    - /app/data
+
 api:
   replicaCount: 1
   image:


### PR DESCRIPTION
## Summary
- add optional chart-managed PVC for JSONL data directories
- add optional API/dashboard volume mounts for /app/src/data and /app/data
- support existing claim via `dataPersistence.existingClaim`
- document persistence toggle and multi-replica storage guidance

Progresses #148
