### PR TITLE
feat(devcontainer): Codespaces config + one-click setup (#141)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+  "name": "DeepSigma Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers-contrib/features/helm:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.vscode-pylance",
+        "dbaeumer.vscode-eslint"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.analysis.typeCheckingMode": "basic",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "forwardPorts": [
+    8000,
+    5173
+  ],
+  "portsAttributes": {
+    "8000": {
+      "label": "DeepSigma API",
+      "onAutoForward": "notify"
+    },
+    "5173": {
+      "label": "Dashboard Dev Server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[devcontainer] python: $(python --version)"
+echo "[devcontainer] node: $(node --version)"
+
+python -m pip install --upgrade pip
+pip install -c requirements/locks/dev-excel-local.txt -e ".[dev,excel,local]" pydantic
+
+if [ -f dashboard/package-lock.json ]; then
+  npm --prefix dashboard ci
+else
+  npm --prefix dashboard install
+fi
+
+echo "[devcontainer] install complete"
+echo "[devcontainer] try: make demo"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Release](https://img.shields.io/github/v/release/8ryanWh1t3/DeepSigma)](https://github.com/8ryanWh1t3/DeepSigma/releases/latest)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/8ryanWh1t3/DeepSigma)
 
 <div align="center">
 


### PR DESCRIPTION
## Summary
- add .devcontainer/devcontainer.json for Python 3.12 + Node 20
- add post-create bootstrap script using lockfile-constrained install
- auto-install dashboard npm dependencies in container setup
- preinstall VS Code extensions (Python, Ruff, Pylance, ESLint)
- configure forwarded ports for API (8000) and dashboard (5173)
- add README badge: Open in GitHub Codespaces

Closes #141
