### PR TITLE
feat(mesh): peer identity and mTLS controls for replication links (#191)

### DIFF
--- a/src/mesh/README.md
+++ b/src/mesh/README.md
@@ -140,6 +140,23 @@ State thresholds and transport retry behavior are configurable:
 `health()` output includes `peer_states` and `partition_metrics` for
 partition/recovery visibility.
 
+## Peer Identity and mTLS
+
+`HTTPTransport` supports a node identity model (`NodeIdentity`) and mTLS policy
+controls for peer-to-peer replication links.
+
+- Identity uses a SPIFFE-style ID format:
+  `spiffe://{trust_domain}/node/{node_id}`
+- Optional peer certificate fingerprint checks can be configured per peer.
+- mTLS policy can enforce:
+  - HTTPS-only peer URLs
+  - configured trust roots
+  - client certificate and key paths
+  - certificate rotation path metadata
+
+Use `set_peer_identity`, `configure_trust_roots`, and
+`rotate_client_certificate` to manage trust and rotation configuration.
+
 ## Guardrails
 
 - Abstract institutional credibility model


### PR DESCRIPTION
Summary
- define a mesh node identity model via NodeIdentity with SPIFFE-style IDs
- add mTLS policy controls to HTTPTransport (HTTPS enforcement, trust roots, client cert/key, rotation path)
- add peer identity verification through expected certificate fingerprint matching
- expose trust/identity configuration via health output and management methods
- add tests covering mTLS enforcement, trust root/rotation config, and rejected untrusted peer behavior

Validation
- python -m pytest -q tests/test_mesh_transport.py

Closes #191
