### PR TITLE
feat(mesh): anti-entropy + delta sync with replay safety (#193)

### DIFF
--- a/src/mesh/README.md
+++ b/src/mesh/README.md
@@ -157,6 +157,27 @@ controls for peer-to-peer replication links.
 Use `set_peer_identity`, `configure_trust_roots`, and
 `rotate_client_certificate` to manage trust and rotation configuration.
 
+## Anti-Entropy and Delta Sync
+
+Mesh anti-entropy now uses a deterministic protocol implemented in
+`mesh.anti_entropy`:
+
+- digest exchange (`digest`) to detect divergence quickly
+- cursor + known-id delta offers (`build_delta_offer`)
+- replay-safe apply (`apply_delta_replay_safe`) to skip duplicate IDs
+- reconciliation report (`reconcile_sets`) for correctness checks
+
+### Bandwidth Profile (reference)
+
+Using the built-in estimator (`estimate_bandwidth_profile`) with
+`avg_record_bytes=256`:
+
+| Full log records | Delta records | Full bytes | Delta bytes | Saved |
+|---:|---:|---:|---:|---:|
+| 1000 | 80 | 256000 | 20480 | 92.00% |
+
+This profile documents the target behavior for avoiding full-log replication.
+
 ## Guardrails
 
 - Abstract institutional credibility model

--- a/src/mesh/anti_entropy.py
+++ b/src/mesh/anti_entropy.py
@@ -1,0 +1,152 @@
+"""Mesh anti-entropy and delta synchronization helpers.
+
+Protocol selected for this repo:
+- Digest exchange for quick divergence checks
+- Cursor + ID-based delta sync (no full-log replay)
+- Replay-safe apply using seen record IDs
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _record_id(record: dict[str, Any]) -> str:
+    rid = str(record.get("id") or record.get("envelope_id") or record.get("record_id") or "")
+    if rid:
+        return rid
+    payload = _stable_json(record)
+    return "anon:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _record_ts(record: dict[str, Any]) -> str:
+    return str(record.get("timestamp") or record.get("ts") or "")
+
+
+def record_hash(record: dict[str, Any]) -> str:
+    """Hash record content deterministically."""
+    return hashlib.sha256(_stable_json(record).encode("utf-8")).hexdigest()
+
+
+def digest(records: list[dict[str, Any]]) -> str:
+    """Compute deterministic digest for a record set."""
+    tuples = sorted((_record_id(r), record_hash(r)) for r in records)
+    blob = _stable_json(tuples).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+@dataclass
+class DeltaCursor:
+    """Cursor state for replay-safe delta synchronization."""
+
+    last_timestamp: str = ""
+    seen_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
+class ApplyResult:
+    applied: list[dict[str, Any]]
+    skipped_replay: list[dict[str, Any]]
+    cursor: DeltaCursor
+
+
+def build_delta_offer(
+    local_records: list[dict[str, Any]],
+    remote_known_ids: set[str],
+    since_timestamp: str = "",
+) -> list[dict[str, Any]]:
+    """Return only records remote does not already know and newer than cursor."""
+    out: list[dict[str, Any]] = []
+    for rec in local_records:
+        rid = _record_id(rec)
+        rts = _record_ts(rec)
+        if rid in remote_known_ids:
+            continue
+        if since_timestamp and rts and rts <= since_timestamp:
+            continue
+        out.append(rec)
+    out.sort(key=lambda r: (_record_ts(r), _record_id(r)))
+    return out
+
+
+def apply_delta_replay_safe(
+    incoming_delta: list[dict[str, Any]],
+    cursor: DeltaCursor,
+) -> ApplyResult:
+    """Apply delta with replay safety.
+
+    Any record with an ID already present in cursor.seen_ids is skipped.
+    """
+    applied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    last_ts = cursor.last_timestamp
+    seen = set(cursor.seen_ids)
+
+    for rec in incoming_delta:
+        rid = _record_id(rec)
+        rts = _record_ts(rec)
+        if rid in seen:
+            skipped.append(rec)
+            continue
+        seen.add(rid)
+        applied.append(rec)
+        if rts and rts > last_ts:
+            last_ts = rts
+
+    return ApplyResult(
+        applied=applied,
+        skipped_replay=skipped,
+        cursor=DeltaCursor(last_timestamp=last_ts, seen_ids=seen),
+    )
+
+
+def reconcile_sets(
+    local_records: list[dict[str, Any]],
+    remote_records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Reconcile local and remote record sets by ID and content hash."""
+    local_map = {_record_id(r): record_hash(r) for r in local_records}
+    remote_map = {_record_id(r): record_hash(r) for r in remote_records}
+
+    local_ids = set(local_map)
+    remote_ids = set(remote_map)
+
+    missing_on_local = sorted(remote_ids - local_ids)
+    missing_on_remote = sorted(local_ids - remote_ids)
+    shared = local_ids & remote_ids
+    mismatched = sorted(rid for rid in shared if local_map[rid] != remote_map[rid])
+
+    return {
+        "local_digest": digest(local_records),
+        "remote_digest": digest(remote_records),
+        "in_sync": not missing_on_local and not missing_on_remote and not mismatched,
+        "missing_on_local": missing_on_local,
+        "missing_on_remote": missing_on_remote,
+        "mismatched_records": mismatched,
+    }
+
+
+def estimate_bandwidth_profile(
+    full_records: int,
+    delta_records: int,
+    avg_record_bytes: int = 512,
+) -> dict[str, float]:
+    """Estimate transfer bytes for full-log replication vs delta sync."""
+    full_bytes = max(full_records, 0) * max(avg_record_bytes, 1)
+    delta_bytes = max(delta_records, 0) * max(avg_record_bytes, 1)
+    if full_bytes == 0:
+        saved = 0.0
+    else:
+        saved = max(0.0, 100.0 * (1.0 - (delta_bytes / full_bytes)))
+    return {
+        "full_bytes": float(full_bytes),
+        "delta_bytes": float(delta_bytes),
+        "saved_percent": round(saved, 2),
+    }

--- a/tests/test_mesh_anti_entropy.py
+++ b/tests/test_mesh_anti_entropy.py
@@ -1,0 +1,71 @@
+"""Tests for mesh anti-entropy + delta sync helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mesh.anti_entropy import (  # noqa: E402
+    DeltaCursor,
+    apply_delta_replay_safe,
+    build_delta_offer,
+    digest,
+    estimate_bandwidth_profile,
+    reconcile_sets,
+)
+
+
+def _rec(rid: str, ts: str, value: int) -> dict:
+    return {"id": rid, "timestamp": ts, "payload": {"value": value}}
+
+
+def test_digest_is_deterministic_for_order_variants():
+    a = [_rec("r1", "2026-02-23T00:00:00Z", 1), _rec("r2", "2026-02-23T00:00:01Z", 2)]
+    b = [a[1], a[0]]
+    assert digest(a) == digest(b)
+
+
+def test_build_delta_offer_filters_known_and_old_records():
+    local = [
+        _rec("r1", "2026-02-23T00:00:00Z", 1),
+        _rec("r2", "2026-02-23T00:00:01Z", 2),
+        _rec("r3", "2026-02-23T00:00:02Z", 3),
+    ]
+    out = build_delta_offer(
+        local_records=local,
+        remote_known_ids={"r1"},
+        since_timestamp="2026-02-23T00:00:00Z",
+    )
+    assert [r["id"] for r in out] == ["r2", "r3"]
+
+
+def test_apply_delta_replay_safe_skips_duplicates():
+    cursor = DeltaCursor(last_timestamp="2026-02-23T00:00:00Z", seen_ids={"r1"})
+    incoming = [
+        _rec("r1", "2026-02-23T00:00:01Z", 10),  # replay
+        _rec("r2", "2026-02-23T00:00:02Z", 20),  # new
+    ]
+    result = apply_delta_replay_safe(incoming, cursor)
+    assert [r["id"] for r in result.applied] == ["r2"]
+    assert [r["id"] for r in result.skipped_replay] == ["r1"]
+    assert result.cursor.last_timestamp == "2026-02-23T00:00:02Z"
+    assert "r2" in result.cursor.seen_ids
+
+
+def test_reconcile_sets_detects_missing_and_mismatch():
+    local = [_rec("r1", "2026-02-23T00:00:00Z", 1), _rec("r2", "2026-02-23T00:00:01Z", 2)]
+    remote = [_rec("r1", "2026-02-23T00:00:00Z", 1), _rec("r2", "2026-02-23T00:00:01Z", 9), _rec("r3", "2026-02-23T00:00:02Z", 3)]
+    recon = reconcile_sets(local, remote)
+    assert recon["in_sync"] is False
+    assert recon["missing_on_local"] == ["r3"]
+    assert recon["missing_on_remote"] == []
+    assert recon["mismatched_records"] == ["r2"]
+
+
+def test_bandwidth_profile_shows_savings():
+    profile = estimate_bandwidth_profile(full_records=1000, delta_records=80, avg_record_bytes=256)
+    assert profile["full_bytes"] == 256000.0
+    assert profile["delta_bytes"] == 20480.0
+    assert profile["saved_percent"] > 90.0


### PR DESCRIPTION
Summary
- add deterministic anti-entropy protocol helpers in src/mesh/anti_entropy.py
- implement digest exchange, cursor/id delta offers, replay-safe delta apply, and reconciliation reports
- add reconciliation correctness and replay-safety tests in tests/test_mesh_anti_entropy.py
- document selected anti-entropy protocol and bandwidth profile in src/mesh/README.md

Validation
- python -m pytest -q tests/test_mesh_anti_entropy.py
- python -m pytest -q tests/test_mesh_transport.py

Closes #193
