### PR TITLE
feat(mesh): DNS SRV discovery + topology dashboard panel (part of #149)

### DIFF
--- a/src/mesh/README.md
+++ b/src/mesh/README.md
@@ -74,6 +74,16 @@ seal-A
 
 7 nodes, 3 regions. All nodes peer with each other for replication.
 
+## Peer Discovery
+
+Peer discovery supports:
+
+- static config (`StaticRegistry(peers=...)` or YAML file)
+- DNS SRV records (`StaticRegistry(dns_srv_records=[...])`)
+
+DNS SRV discovery resolves peers into node URLs and tags each entry with
+`discovered_via: dns-srv`.
+
 ## Verification
 
 ```bash


### PR DESCRIPTION
Summary
- add DNS SRV peer discovery support to `mesh.discovery.StaticRegistry`
- keep static config discovery behavior and allow merging static + DNS discovered peers
- add a mesh topology panel to dashboard overview using `/mesh/tenant-alpha/topology` with replication lag visibility
- document discovery modes in mesh README
- add tests for DNS SRV discovery behavior

Validation
- python -m pytest -q tests/test_mesh_transport.py tests/test_openapi_docs.py
- cd dashboard && npm run build

Part of #149
