### PR TITLE
Security: resolve 8 open code scanning alerts

### DIFF
--- a/.github/workflows/helm_chart_validate.yml
+++ b/.github/workflows/helm_chart_validate.yml
@@ -13,6 +13,9 @@ on:
       - "docs/deployment/HELM.md"
       - ".github/workflows/helm_chart_validate.yml"
 
+permissions:
+  contents: read
+
 jobs:
   chart-lint-template:
     runs-on: ubuntu-latest

--- a/.github/workflows/mesh_wan_integration.yml
+++ b/.github/workflows/mesh_wan_integration.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   wan-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   openapi-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/scale_benchmark.yml
+++ b/.github/workflows/scale_benchmark.yml
@@ -10,6 +10,9 @@ on:
       - "docs/scaling/STATELESS_API_SCALE_GUIDE.md"
       - "docs/examples/scale/**"
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/dashboard/api_server.py
+++ b/dashboard/api_server.py
@@ -399,7 +399,9 @@ def _persistence_probe() -> tuple[bool, str]:
         probe_path.unlink(missing_ok=True)
         return True, "ok"
     except Exception as exc:
-        return False, f"{type(exc).__name__}: {exc}"
+        # Avoid leaking internal exception data via public health endpoints.
+        logger.warning("Persistence probe failed: %s", type(exc).__name__)
+        return False, "unavailable"
 
 
 def _health_payload() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add explicit least-privilege permissions blocks to flagged workflows
- redact persistence exception details from public health/readiness responses
- keep degraded health semantics while removing stack-trace/exception leakage

## Files
- .github/workflows/mesh_wan_integration.yml
- .github/workflows/openapi_sync.yml
- .github/workflows/helm_chart_validate.yml
- .github/workflows/scale_benchmark.yml
- dashboard/api_server.py

## Validation
- pytest -q tests/test_api_health_degraded.py tests/test_openapi_docs.py
- ruff check dashboard/api_server.py
