### PR TITLE
CI: fix kind-install-test chart install rollout check

### DIFF
--- a/.github/workflows/helm_chart_validate.yml
+++ b/.github/workflows/helm_chart_validate.yml
@@ -39,9 +39,18 @@ jobs:
         uses: helm/kind-action@v1
         with:
           cluster_name: deepsigma
+      - name: Build and load local API image for kind
+        run: |
+          docker build -f docker/scale/Dockerfile.api -t deepsigma-api:ci .
+          kind load docker-image deepsigma-api:ci --name deepsigma
       - name: Install chart
         run: |
-          helm upgrade --install deepsigma charts/deepsigma --namespace deepsigma --create-namespace
+          helm upgrade --install deepsigma charts/deepsigma \
+            --namespace deepsigma \
+            --create-namespace \
+            --set api.image.repository=deepsigma-api \
+            --set api.image.tag=ci \
+            --set api.image.pullPolicy=IfNotPresent
           kubectl -n deepsigma wait \
             --for=condition=available \
             deployment \


### PR DESCRIPTION
## Fix
- replace hardcoded rollout target `deploy/deepsigma` with a label-based wait for all release deployments
- chart creates component deployments (api/dashboard), so hardcoded deployment name does not exist

## Why
`kind-install-test` failed in the install step with:
`Error from server (NotFound): deployments.apps "deepsigma" not found`

## Validation
- workflow syntax preserved
- install step now waits for deployments labeled `app.kubernetes.io/instance=deepsigma`
