### PR TITLE
Docs: fix README KPI badge and radar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@
 See: [docs/release/RELEASE_NOTES_v2.0.4.md](docs/release/RELEASE_NOTES_v2.0.4.md)
 
 ## Repo Radar KPI (latest)
-[![Repo KPI Badge](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/badge_latest.svg?raw=1)](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/radar_v2.0.4.png?raw=1)
+[![Repo KPI Badge](release_kpis/badge_latest.svg)](release_kpis/radar_composite_latest.png)
 
-- Current release radar: [release_kpis/radar_v2.0.4.png](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/radar_v2.0.4.png?raw=1)
-- Composite release radar: [release_kpis/radar_composite_latest.png](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/radar_composite_latest.png?raw=1)
-- Composite release delta table: [release_kpis/radar_composite_latest.md](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/radar_composite_latest.md)
-- Gate report: [release_kpis/KPI_GATE_REPORT.md](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/KPI_GATE_REPORT.md)
-- Issue label gate: [release_kpis/ISSUE_LABEL_GATE_REPORT.md](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/ISSUE_LABEL_GATE_REPORT.md)
-- KPI history: [release_kpis/history.json](https://github.com/8ryanWh1t3/DeepSigma/blob/main/release_kpis/history.json)
+- Current release radar: [release_kpis/radar_v2.0.4.png](release_kpis/radar_v2.0.4.png)
+- Composite release radar: [release_kpis/radar_composite_latest.png](release_kpis/radar_composite_latest.png)
+- Composite release delta table: [release_kpis/radar_composite_latest.md](release_kpis/radar_composite_latest.md)
+- Gate report: [release_kpis/KPI_GATE_REPORT.md](release_kpis/KPI_GATE_REPORT.md)
+- Issue label gate: [release_kpis/ISSUE_LABEL_GATE_REPORT.md](release_kpis/ISSUE_LABEL_GATE_REPORT.md)
+- KPI history: [release_kpis/history.json](release_kpis/history.json)
 
 **Institutional Decision Infrastructure**
 


### PR DESCRIPTION
## Fix
- switched KPI badge and radar links in README to repo-relative paths
- badge click target now points to `release_kpis/radar_composite_latest.png`

This avoids intermittent 404/render issues from fully-qualified blob/raw URL variants and keeps the target on the latest radar graphic.
