### PR TITLE
Docs: fix GHCR badge link target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/8ryanWh1t3/DeepSigma/actions/workflows/ci.yml/badge.svg)](https://github.com/8ryanWh1t3/DeepSigma/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/deepsigma)](https://pypi.org/project/deepsigma/)
-[![GHCR Pulls](https://img.shields.io/docker/pulls/ghcr.io/8ryanwh1t3/deepsigma)](https://github.com/8ryanWh1t3/DeepSigma/pkgs/container/deepsigma)
+[![GHCR Pulls](https://img.shields.io/docker/pulls/ghcr.io/8ryanwh1t3/deepsigma)](https://github.com/users/8ryanWh1t3/packages?repo_name=DeepSigma)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Release](https://img.shields.io/github/v/release/8ryanWh1t3/DeepSigma)](https://github.com/8ryanWh1t3/DeepSigma/releases/latest)


### PR DESCRIPTION
Fix README GHCR badge click target that returned 404 by pointing to the account package listing for this repo.