### PR TITLE
DISR PR1: docs + envelope schema + keyring TTL model

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ All connectors conform to the [Connector Contract v1.0](schemas/core/connector_c
 
 - [Data Boundaries](docs/DATA_BOUNDARIES.md) — data at rest, storage locations, retention, redaction, tenancy isolation, connector flow, secrets policy, and network boundaries.
 - [Connector SDK](docs/CONNECTOR_SDK.md) — ConnectorV1 contract and safety expectations for custom adapters.
+- [DISR Security Model](docs/docs/security/DISR.md) — Breakable -> Detectable -> Rotatable -> Recoverable posture for pilot security credibility.
+- [Key Lifecycle](docs/docs/security/KEY_LIFECYCLE.md) — key versioning, TTL, and rotation cadence.
+- [Recovery Runbook](docs/docs/security/RECOVERY_RUNBOOK.md) — compromise response and re-encryption recovery sequence.
 
 ## Monitoring
 

--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -1,0 +1,26 @@
+# DISR Security Model
+
+DISR stands for **Breakable -> Detectable -> Rotatable -> Recoverable**.
+
+The intent is practical: assume keys can be compromised, then make compromise
+visible, reversible, and measurable under pilot conditions.
+
+## Core controls
+
+- **Breakable:** Keys are treated as disposable. No key is permanent.
+- **Detectable:** Misuse signals are machine-detectable and gateable in CI.
+- **Rotatable:** Rotation is a first-class operation, not an emergency-only script.
+- **Recoverable:** Re-encryption and rollback are rehearsed with deterministic drills.
+
+## Artifacts
+
+- Key lifecycle policy: `docs/docs/security/KEY_LIFECYCLE.md`
+- Recovery runbook: `docs/docs/security/RECOVERY_RUNBOOK.md`
+- Crypto envelope schema: `schemas/core/crypto_envelope.schema.json`
+- Keyring model: `src/deepsigma/security/keyring.py`
+
+## Pilot implementation notes
+
+- Key versions are modeled explicitly (`key_id`, `key_version`, `expires_at`, `status`).
+- Envelope metadata must include `key_id`, `key_version`, `alg`, `nonce`, and `aad`.
+- Expiry and disable transitions are represented as status changes, not silent mutation.

--- a/docs/docs/security/KEY_LIFECYCLE.md
+++ b/docs/docs/security/KEY_LIFECYCLE.md
@@ -1,0 +1,31 @@
+# Key Lifecycle
+
+This document defines pilot-safe key lifecycle behavior for DISR.
+
+## States
+
+- `active`: usable for new encryption operations
+- `disabled`: administratively disabled; no new encryption
+- `expired`: TTL exceeded; no new encryption
+
+## Required fields
+
+Every key version record must include:
+
+- `key_id`
+- `key_version`
+- `created_at`
+- `expires_at` (nullable)
+- `status`
+
+## Rotation cadence (pilot)
+
+- Normal cadence: rotate every 14 days.
+- Emergency cadence: rotate immediately upon compromise signal.
+- Re-encryption follows rotation when historical data must remain decryptable.
+
+## Operational expectations
+
+- Rotation increments `key_version` monotonically per `key_id`.
+- New writes use the current active version.
+- Expired keys are not silently reused.

--- a/docs/docs/security/RECOVERY_RUNBOOK.md
+++ b/docs/docs/security/RECOVERY_RUNBOOK.md
@@ -1,0 +1,30 @@
+# Recovery Runbook (Pilot)
+
+This runbook describes recovery steps after key compromise in a DISR posture.
+
+## Objective
+
+Recover encrypted evidence integrity with auditable steps and bounded downtime.
+
+## Procedure
+
+1. Freeze writes for affected scope.
+2. Disable compromised key version.
+3. Create and activate a new key version.
+4. Re-encrypt evidence from old key -> new key (dry-run first).
+5. Validate readability and integrity.
+6. Resume writes.
+
+## Outputs
+
+- Rotation event with key lineage
+- Re-encryption summary (records processed, failures, retries)
+- Recovery timestamp and owner attribution
+
+## Rollback
+
+If re-encryption validation fails:
+
+1. Halt processing.
+2. Restore from the latest verified checkpoint.
+3. Re-run with reduced batch size and diagnostics enabled.

--- a/schemas/core/crypto_envelope.schema.json
+++ b/schemas/core/crypto_envelope.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deepsigma.dev/schemas/crypto_envelope/v1.0",
+  "title": "Crypto Envelope v1.0",
+  "description": "Canonical cryptographic envelope metadata for encrypted at-rest artifacts.",
+  "type": "object",
+  "required": [
+    "envelope_version",
+    "key_id",
+    "key_version",
+    "alg",
+    "nonce",
+    "aad"
+  ],
+  "properties": {
+    "envelope_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Schema version identifier."
+    },
+    "key_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Logical key identifier from the keyring."
+    },
+    "key_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic key version from the keyring."
+    },
+    "alg": {
+      "type": "string",
+      "enum": ["AES-256-GCM"],
+      "description": "Encryption algorithm used for this payload."
+    },
+    "nonce": {
+      "type": "string",
+      "minLength": 16,
+      "description": "Nonce/IV encoded as base64."
+    },
+    "aad": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Associated authenticated data context string."
+    },
+    "encrypted_payload": {
+      "type": "string",
+      "description": "Ciphertext payload encoded as base64."
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -1,0 +1,5 @@
+"""Security primitives for DISR (Disposable Rotors)."""
+
+from .keyring import Keyring, KeyVersionRecord
+
+__all__ = ["Keyring", "KeyVersionRecord"]

--- a/src/deepsigma/security/keyring.py
+++ b/src/deepsigma/security/keyring.py
@@ -1,0 +1,192 @@
+"""File-backed keyring model for rotatable keys.
+
+Provides a lightweight JSON persistence layer with key version records and
+TTL/status lifecycle controls suitable for pilot workflows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Callable, Iterable
+
+VALID_STATUSES = {"active", "disabled", "expired"}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+@dataclass(frozen=True)
+class KeyVersionRecord:
+    key_id: str
+    key_version: int
+    created_at: str
+    expires_at: str | None
+    status: str
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "KeyVersionRecord":
+        status = str(payload.get("status", "")).lower()
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid key status: {status}")
+        return cls(
+            key_id=str(payload["key_id"]),
+            key_version=int(payload["key_version"]),
+            created_at=str(payload["created_at"]),
+            expires_at=(str(payload["expires_at"]) if payload.get("expires_at") else None),
+            status=status,
+        )
+
+
+class Keyring:
+    """Manage key versions and lifecycle state in a JSON keyring file."""
+
+    def __init__(
+        self,
+        path: str | Path = "data/security/keyring.json",
+        now_fn: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self.path = Path(path)
+        self._now_fn = now_fn
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self._write([])
+
+    def list(self, key_id: str | None = None) -> list[KeyVersionRecord]:
+        records = self._read()
+        if key_id is None:
+            return records
+        return [record for record in records if record.key_id == key_id]
+
+    def create(
+        self,
+        key_id: str,
+        expires_at: str | None = None,
+    ) -> KeyVersionRecord:
+        if not key_id or not key_id.strip():
+            raise ValueError("key_id is required")
+        if expires_at:
+            _parse_iso(expires_at)
+
+        records = self._read()
+        current_versions = [r.key_version for r in records if r.key_id == key_id]
+        next_version = (max(current_versions) + 1) if current_versions else 1
+        created = _to_iso(self._now_fn())
+
+        new_record = KeyVersionRecord(
+            key_id=key_id.strip(),
+            key_version=next_version,
+            created_at=created,
+            expires_at=expires_at,
+            status="active",
+        )
+        records.append(new_record)
+        self._write(records)
+        return new_record
+
+    def disable(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
+        records = self._read()
+        target = self._find_target(records, key_id, key_version)
+        updated = self._replace_status(records, target, "disabled")
+        self._write(updated)
+        return self._find_target(updated, key_id, target.key_version)
+
+    def expire(self, now: datetime | None = None) -> int:
+        current_time = now or self._now_fn()
+        records = self._read()
+        changed = 0
+        updated: list[KeyVersionRecord] = []
+        for record in records:
+            if (
+                record.status == "active"
+                and record.expires_at
+                and _parse_iso(record.expires_at) <= current_time
+            ):
+                updated.append(
+                    KeyVersionRecord(
+                        key_id=record.key_id,
+                        key_version=record.key_version,
+                        created_at=record.created_at,
+                        expires_at=record.expires_at,
+                        status="expired",
+                    )
+                )
+                changed += 1
+            else:
+                updated.append(record)
+        if changed:
+            self._write(updated)
+        return changed
+
+    def current(self, key_id: str) -> KeyVersionRecord | None:
+        records = self.list(key_id)
+        if not records:
+            return None
+        ordered = sorted(records, key=lambda r: r.key_version, reverse=True)
+        for record in ordered:
+            if record.status == "active":
+                if record.expires_at and _parse_iso(record.expires_at) <= self._now_fn():
+                    continue
+                return record
+        return None
+
+    def _find_target(
+        self,
+        records: Iterable[KeyVersionRecord],
+        key_id: str,
+        key_version: int | None,
+    ) -> KeyVersionRecord:
+        candidates = [r for r in records if r.key_id == key_id]
+        if not candidates:
+            raise ValueError(f"Unknown key_id: {key_id}")
+        if key_version is not None:
+            for record in candidates:
+                if record.key_version == key_version:
+                    return record
+            raise ValueError(f"Unknown key version: {key_id}@v{key_version}")
+        return sorted(candidates, key=lambda r: r.key_version)[-1]
+
+    def _replace_status(
+        self,
+        records: list[KeyVersionRecord],
+        target: KeyVersionRecord,
+        status: str,
+    ) -> list[KeyVersionRecord]:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid key status: {status}")
+        output: list[KeyVersionRecord] = []
+        for record in records:
+            if record.key_id == target.key_id and record.key_version == target.key_version:
+                output.append(
+                    KeyVersionRecord(
+                        key_id=record.key_id,
+                        key_version=record.key_version,
+                        created_at=record.created_at,
+                        expires_at=record.expires_at,
+                        status=status,
+                    )
+                )
+            else:
+                output.append(record)
+        return output
+
+    def _read(self) -> list[KeyVersionRecord]:
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            raise ValueError("Keyring file must contain a JSON array")
+        return [KeyVersionRecord.from_dict(item) for item in raw]
+
+    def _write(self, records: list[KeyVersionRecord]) -> None:
+        payload = [asdict(record) for record in records]
+        self.path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_disr_keyring.py
+++ b/tests/test_disr_keyring.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from deepsigma.security.keyring import Keyring
+
+
+def _now() -> datetime:
+    return datetime(2026, 2, 23, 0, 0, tzinfo=timezone.utc)
+
+
+def test_create_increments_version(tmp_path):
+    path = tmp_path / "keyring.json"
+    keyring = Keyring(path=path, now_fn=_now)
+
+    first = keyring.create("credibility")
+    second = keyring.create("credibility")
+
+    assert first.key_version == 1
+    assert second.key_version == 2
+    assert second.status == "active"
+
+
+def test_disable_latest_when_version_unspecified(tmp_path):
+    path = tmp_path / "keyring.json"
+    keyring = Keyring(path=path, now_fn=_now)
+    keyring.create("credibility")
+    keyring.create("credibility")
+
+    disabled = keyring.disable("credibility")
+
+    assert disabled.key_version == 2
+    assert disabled.status == "disabled"
+
+
+def test_expire_marks_active_records(tmp_path):
+    path = tmp_path / "keyring.json"
+    keyring = Keyring(path=path, now_fn=_now)
+
+    expired_at = (_now() - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    active_at = (_now() + timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    keyring.create("credibility", expires_at=expired_at)
+    keyring.create("credibility", expires_at=active_at)
+
+    changed = keyring.expire(now=_now())
+    records = keyring.list("credibility")
+
+    assert changed == 1
+    assert records[0].status == "expired"
+    assert records[1].status == "active"
+
+
+def test_current_ignores_expired_entries(tmp_path):
+    path = tmp_path / "keyring.json"
+    keyring = Keyring(path=path, now_fn=_now)
+
+    expired_at = (_now() - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    keyring.create("credibility", expires_at=expired_at)
+    keyring.create("credibility")
+
+    current = keyring.current("credibility")
+
+    assert current is not None
+    assert current.key_version == 2
+    assert current.status == "active"
+
+
+def test_disable_unknown_key_raises(tmp_path):
+    keyring = Keyring(path=tmp_path / "keyring.json", now_fn=_now)
+
+    with pytest.raises(ValueError):
+        keyring.disable("missing")


### PR DESCRIPTION
## Scope\nImplements the DISR foundation slice:\n- #257 Security spec + key lifecycle docs\n- #260 Canonical crypto envelope metadata schema\n- #261 Keyring + TTL model\n\n## Changes\n- Added docs:\n  - docs/docs/security/DISR.md\n  - docs/docs/security/KEY_LIFECYCLE.md\n  - docs/docs/security/RECOVERY_RUNBOOK.md\n- Added schema:\n  - schemas/core/crypto_envelope.schema.json\n- Added keyring module:\n  - src/deepsigma/security/keyring.py\n  - src/deepsigma/security/__init__.py\n- Added tests:\n  - tests/test_disr_keyring.py\n- Linked DISR docs in README security section.\n\n## Validation\n- pytest -q tests/test_disr_keyring.py tests/test_credibility_store_encryption.py\n- ruff check src/deepsigma/security/keyring.py tests/test_disr_keyring.py\n