### PR TITLE
DISR PR2: rotate-keys + reencrypt runtime commands

### DIFF
--- a/src/deepsigma/cli/main.py
+++ b/src/deepsigma/cli/main.py
@@ -12,6 +12,8 @@ Commands:
     deepsigma golden-path <source> [opts]     7-step Golden Path loop
     deepsigma compact --input <dir>           Compact JSONL evidence files
     deepsigma rekey --tenant <id>             Rekey encrypted evidence at rest
+    deepsigma security rotate-keys ...        Rotate key versions with audit events
+    deepsigma security reencrypt ...          Re-encrypt with checkpoint/resume
     deepsigma compliance export --tenant ...  Export SOC 2 evidence package
 """
 from __future__ import annotations
@@ -52,6 +54,7 @@ def main(argv: list[str] | None = None) -> int:
         golden_path,
         init_project,
         mdpt_index,
+        security,
         retention,
         rekey,
         new_connector,
@@ -67,6 +70,7 @@ def main(argv: list[str] | None = None) -> int:
     golden_path.register(subparsers)
     compact.register(subparsers)
     rekey.register(subparsers)
+    security.register(subparsers)
     compliance_export.register(subparsers)
     new_connector.register(subparsers)
 

--- a/src/deepsigma/cli/security.py
+++ b/src/deepsigma/cli/security.py
@@ -1,0 +1,93 @@
+"""deepsigma security — DISR security operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from deepsigma.security.reencrypt import reencrypt_summary_to_dict, run_reencrypt_job
+from deepsigma.security.rotate_keys import rotate_keys, rotation_result_to_dict
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("security", help="DISR security commands")
+    sp = p.add_subparsers(dest="security_command", required=True)
+
+    rotate = sp.add_parser("rotate-keys", help="Rotate key version and emit KEY_ROTATED event")
+    rotate.add_argument("--tenant", required=True, help="Tenant ID")
+    rotate.add_argument("--key-id", required=True, help="Logical key identifier")
+    rotate.add_argument("--ttl-days", type=int, default=14, help="Days before key expiry")
+    rotate.add_argument("--actor-user", default="system", help="Actor user for audit event")
+    rotate.add_argument("--actor-role", default="coherence_steward", help="Actor role for audit event")
+    rotate.add_argument("--keyring-path", default="data/security/keyring.json", help="Path to keyring JSON")
+    rotate.add_argument(
+        "--event-log-path",
+        default="data/security/key_rotation_events.jsonl",
+        help="Path to append key rotation events",
+    )
+    rotate.add_argument("--json", action="store_true", help="Output JSON")
+    rotate.set_defaults(func=run_rotate)
+
+    reenc = sp.add_parser("reencrypt", help="Re-encrypt tenant evidence using current key")
+    reenc.add_argument("--tenant", required=True, help="Tenant ID")
+    reenc.add_argument("--data-dir", default=None, help="Optional explicit credibility data directory")
+    reenc.add_argument(
+        "--checkpoint",
+        default="artifacts/checkpoints/reencrypt_checkpoint.json",
+        help="Checkpoint path",
+    )
+    reenc.add_argument("--resume", action="store_true", help="Resume from existing checkpoint")
+    reenc.add_argument("--dry-run", action="store_true", help="Plan run without rewriting records")
+    reenc.add_argument(
+        "--previous-master-key-env",
+        default="DEEPSIGMA_PREVIOUS_MASTER_KEY",
+        help="Env var containing previous master key",
+    )
+    reenc.add_argument("--actor-user", default="system", help="Actor user for audit event")
+    reenc.add_argument("--actor-role", default="coherence_steward", help="Actor role for audit event")
+    reenc.add_argument("--json", action="store_true", help="Output JSON")
+    reenc.set_defaults(func=run_reencrypt)
+
+
+def run_rotate(args: argparse.Namespace) -> int:
+    result = rotate_keys(
+        tenant_id=args.tenant,
+        key_id=args.key_id,
+        ttl_days=args.ttl_days,
+        actor_user=args.actor_user,
+        actor_role=args.actor_role,
+        keyring_path=Path(args.keyring_path),
+        event_log_path=Path(args.event_log_path),
+    )
+    payload = rotation_result_to_dict(result)
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            f"Key rotated tenant={payload['tenant_id']} key={payload['key_id']} "
+            f"version={payload['key_version']} expires_at={payload['expires_at']}"
+        )
+    return 0
+
+
+def run_reencrypt(args: argparse.Namespace) -> int:
+    summary = run_reencrypt_job(
+        tenant_id=args.tenant,
+        dry_run=bool(args.dry_run),
+        resume=bool(args.resume),
+        data_dir=Path(args.data_dir) if args.data_dir else None,
+        checkpoint_path=Path(args.checkpoint),
+        previous_master_key_env=args.previous_master_key_env,
+        actor_user=args.actor_user,
+        actor_role=args.actor_role,
+    )
+    payload = reencrypt_summary_to_dict(summary)
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            f"Reencrypt status={payload['status']} tenant={payload['tenant_id']} "
+            f"targeted={payload['records_targeted']} rewritten={payload['records_reencrypted']}"
+        )
+    return 0

--- a/src/deepsigma/security/reencrypt.py
+++ b/src/deepsigma/security/reencrypt.py
@@ -1,0 +1,163 @@
+"""Re-encryption job primitive with checkpoint and resume semantics."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from credibility_engine.store import CredibilityStore
+from governance.audit import audit_action
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class ReencryptSummary:
+    tenant_id: str
+    dry_run: bool
+    resumed: bool
+    checkpoint_path: str
+    files_targeted: int
+    records_targeted: int
+    files_rewritten: int
+    records_reencrypted: int
+    status: str
+
+
+
+def _count_records(path: Path) -> int:
+    if path.suffix == ".jsonl":
+        return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+    if path.suffix == ".json":
+        return 1
+    return 0
+
+
+def _target_files(store: CredibilityStore) -> list[Path]:
+    files = []
+    for path in sorted(store.data_dir.glob("*")):
+        if path.is_dir():
+            continue
+        if path.name == store.PACKET_FILE:
+            continue
+        if path.suffix in {".json", ".jsonl"}:
+            files.append(path)
+    return files
+
+
+def _write_checkpoint(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def run_reencrypt_job(
+    *,
+    tenant_id: str,
+    dry_run: bool,
+    resume: bool,
+    data_dir: str | Path | None = None,
+    checkpoint_path: str | Path = "artifacts/checkpoints/reencrypt_checkpoint.json",
+    previous_master_key_env: str = "DEEPSIGMA_PREVIOUS_MASTER_KEY",
+    actor_user: str = "system",
+    actor_role: str = "coherence_steward",
+) -> ReencryptSummary:
+    checkpoint = Path(checkpoint_path)
+
+    if resume and checkpoint.exists():
+        prior = json.loads(checkpoint.read_text(encoding="utf-8"))
+        if prior.get("status") == "completed":
+            return ReencryptSummary(
+                tenant_id=tenant_id,
+                dry_run=dry_run,
+                resumed=True,
+                checkpoint_path=str(checkpoint),
+                files_targeted=int(prior.get("files_targeted", 0)),
+                records_targeted=int(prior.get("records_targeted", 0)),
+                files_rewritten=int(prior.get("files_rewritten", 0)),
+                records_reencrypted=int(prior.get("records_reencrypted", 0)),
+                status="completed",
+            )
+
+    store = CredibilityStore(data_dir=data_dir, tenant_id=tenant_id, encrypt_at_rest=True)
+    targets = _target_files(store)
+    files_targeted = len(targets)
+    records_targeted = sum(_count_records(path) for path in targets)
+
+    if dry_run:
+        payload = {
+            "tenant_id": tenant_id,
+            "status": "dry_run",
+            "updated_at": _utc_now_iso(),
+            "files_targeted": files_targeted,
+            "records_targeted": records_targeted,
+            "files_rewritten": 0,
+            "records_reencrypted": 0,
+        }
+        _write_checkpoint(checkpoint, payload)
+        return ReencryptSummary(
+            tenant_id=tenant_id,
+            dry_run=True,
+            resumed=False,
+            checkpoint_path=str(checkpoint),
+            files_targeted=files_targeted,
+            records_targeted=records_targeted,
+            files_rewritten=0,
+            records_reencrypted=0,
+            status="dry_run",
+        )
+
+    previous_master_key = os.environ.get(previous_master_key_env, "")
+    if not previous_master_key:
+        raise RuntimeError(f"Missing previous key: set ${previous_master_key_env}")
+    if not os.environ.get("DEEPSIGMA_MASTER_KEY", ""):
+        raise RuntimeError("Missing current key: set $DEEPSIGMA_MASTER_KEY")
+
+    stats = store.rekey(previous_master_key=previous_master_key)
+
+    payload = {
+        "tenant_id": tenant_id,
+        "status": "completed",
+        "updated_at": _utc_now_iso(),
+        "files_targeted": files_targeted,
+        "records_targeted": records_targeted,
+        "files_rewritten": int(stats.get("files", 0)),
+        "records_reencrypted": int(stats.get("records", 0)),
+    }
+    _write_checkpoint(checkpoint, payload)
+
+    audit_action(
+        tenant_id=tenant_id,
+        actor_user=actor_user,
+        actor_role=actor_role,
+        action="REENCRYPT_COMPLETED",
+        target_type="EVIDENCE",
+        target_id=tenant_id,
+        outcome="SUCCESS",
+        metadata={
+            "files_rewritten": payload["files_rewritten"],
+            "records_reencrypted": payload["records_reencrypted"],
+            "checkpoint_path": str(checkpoint),
+        },
+    )
+
+    return ReencryptSummary(
+        tenant_id=tenant_id,
+        dry_run=False,
+        resumed=False,
+        checkpoint_path=str(checkpoint),
+        files_targeted=files_targeted,
+        records_targeted=records_targeted,
+        files_rewritten=payload["files_rewritten"],
+        records_reencrypted=payload["records_reencrypted"],
+        status="completed",
+    )
+
+
+def reencrypt_summary_to_dict(summary: ReencryptSummary) -> dict[str, Any]:
+    return asdict(summary)

--- a/src/deepsigma/security/rotate_keys.py
+++ b/src/deepsigma/security/rotate_keys.py
@@ -1,0 +1,108 @@
+"""Key rotation primitive for DISR workflows."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Callable
+
+from governance.audit import audit_action
+
+from .keyring import Keyring, KeyVersionRecord
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class RotationResult:
+    tenant_id: str
+    key_id: str
+    key_version: int
+    expires_at: str | None
+    actor_user: str
+    actor_role: str
+    event_hash: str
+
+
+
+def _event_hash(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def rotate_keys(
+    *,
+    tenant_id: str,
+    key_id: str,
+    ttl_days: int,
+    actor_user: str,
+    actor_role: str,
+    keyring_path: str | Path = "data/security/keyring.json",
+    event_log_path: str | Path = "data/security/key_rotation_events.jsonl",
+    now_fn: Callable[[], datetime] = _utc_now,
+) -> RotationResult:
+    if ttl_days <= 0:
+        raise ValueError("ttl_days must be > 0")
+
+    now = now_fn()
+    expires_at = _to_iso(now + timedelta(days=ttl_days))
+
+    keyring = Keyring(path=keyring_path, now_fn=now_fn)
+    record: KeyVersionRecord = keyring.create(key_id=key_id, expires_at=expires_at)
+
+    payload = {
+        "event_type": "KEY_ROTATED",
+        "tenant_id": tenant_id,
+        "key_id": record.key_id,
+        "key_version": record.key_version,
+        "expires_at": record.expires_at,
+        "actor_user": actor_user,
+        "actor_role": actor_role,
+        "rotated_at": _to_iso(now),
+    }
+    digest = _event_hash(payload)
+    payload["event_hash"] = digest
+
+    event_path = Path(event_log_path)
+    event_path.parent.mkdir(parents=True, exist_ok=True)
+    with event_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    audit_action(
+        tenant_id=tenant_id,
+        actor_user=actor_user,
+        actor_role=actor_role,
+        action="KEY_ROTATED",
+        target_type="KEYRING",
+        target_id=f"{record.key_id}@v{record.key_version}",
+        outcome="SUCCESS",
+        metadata={
+            "key_id": record.key_id,
+            "key_version": record.key_version,
+            "expires_at": record.expires_at,
+            "event_hash": digest,
+        },
+    )
+
+    return RotationResult(
+        tenant_id=tenant_id,
+        key_id=record.key_id,
+        key_version=record.key_version,
+        expires_at=record.expires_at,
+        actor_user=actor_user,
+        actor_role=actor_role,
+        event_hash=digest,
+    )
+
+
+def rotation_result_to_dict(result: RotationResult) -> dict:
+    return asdict(result)

--- a/tests/test_disr_security_ops.py
+++ b/tests/test_disr_security_ops.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepsigma.security.reencrypt import run_reencrypt_job
+from deepsigma.security.rotate_keys import rotate_keys
+
+
+@pytest.fixture
+def temp_store_dir(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "cred"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "claims.jsonl").write_text(
+        '{"enc":"AES-256-GCM","tenant_id":"tenant-alpha","nonce":"AAAAAAAAAAAAAAAA","encrypted_payload":"BBBB"}\n',
+        encoding="utf-8",
+    )
+    return data_dir
+
+
+def test_rotate_keys_emits_event_and_keyring(tmp_path: Path):
+    keyring_path = tmp_path / "keyring.json"
+    event_log_path = tmp_path / "events.jsonl"
+
+    result = rotate_keys(
+        tenant_id="tenant-alpha",
+        key_id="credibility",
+        ttl_days=14,
+        actor_user="dri",
+        actor_role="coherence_steward",
+        keyring_path=keyring_path,
+        event_log_path=event_log_path,
+    )
+
+    assert result.key_version == 1
+    keyring = json.loads(keyring_path.read_text(encoding="utf-8"))
+    assert keyring[0]["key_id"] == "credibility"
+    events = [json.loads(line) for line in event_log_path.read_text(encoding="utf-8").splitlines()]
+    assert events[0]["event_type"] == "KEY_ROTATED"
+    assert events[0]["event_hash"]
+
+
+def test_reencrypt_dry_run_writes_checkpoint(tmp_path: Path):
+    checkpoint = tmp_path / "checkpoint.json"
+    data_dir = tmp_path / "cred"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "claims.jsonl").write_text('{"k":"v"}\n', encoding="utf-8")
+
+    summary = run_reencrypt_job(
+        tenant_id="tenant-alpha",
+        dry_run=True,
+        resume=False,
+        data_dir=data_dir,
+        checkpoint_path=checkpoint,
+    )
+
+    assert summary.status == "dry_run"
+    assert summary.records_targeted == 1
+    cp = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert cp["status"] == "dry_run"
+
+
+def test_reencrypt_resume_completed_returns_without_changes(tmp_path: Path):
+    checkpoint = tmp_path / "checkpoint.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "tenant_id": "tenant-alpha",
+                "status": "completed",
+                "files_targeted": 3,
+                "records_targeted": 9,
+                "files_rewritten": 3,
+                "records_reencrypted": 9,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = run_reencrypt_job(
+        tenant_id="tenant-alpha",
+        dry_run=False,
+        resume=True,
+        data_dir=tmp_path / "cred",
+        checkpoint_path=checkpoint,
+    )
+
+    assert summary.resumed is True
+    assert summary.status == "completed"
+    assert summary.records_reencrypted == 9
+
+
+def test_rotate_keys_rejects_invalid_ttl(tmp_path: Path):
+    with pytest.raises(ValueError):
+        rotate_keys(
+            tenant_id="tenant-alpha",
+            key_id="credibility",
+            ttl_days=0,
+            actor_user="dri",
+            actor_role="coherence_steward",
+            keyring_path=tmp_path / "keyring.json",
+            event_log_path=tmp_path / "events.jsonl",
+        )


### PR DESCRIPTION
## Scope
Implements DISR runtime primitives:
- #262 Add rotate_keys command
- #263 Add reencrypt job with checkpointing + rollback-oriented flow

## Changes
- Added runtime modules:
  - src/deepsigma/security/rotate_keys.py
  - src/deepsigma/security/reencrypt.py
- Added CLI namespace:
  - src/deepsigma/cli/security.py
  - wired into src/deepsigma/cli/main.py
- Added tests:
  - tests/test_disr_security_ops.py
  - extended tests/test_cli_smoke.py for security commands

## Behavior
- deepsigma security rotate-keys creates a new key version and emits KEY_ROTATED event + audit entry.
- deepsigma security reencrypt supports --dry-run, --checkpoint, and --resume; actual run performs rekey and emits REENCRYPT_COMPLETED audit event.

## Validation
- pytest -q tests/test_disr_keyring.py tests/test_disr_security_ops.py tests/test_cli_smoke.py -k 'security or keyring'
- ruff check src/deepsigma/security src/deepsigma/cli/security.py tests/test_disr_security_ops.py tests/test_cli_smoke.py
