### PR TITLE
DISR PR4: authority-gated key rotation approvals

### DIFF
--- a/docs/docs/security/KEY_LIFECYCLE.md
+++ b/docs/docs/security/KEY_LIFECYCLE.md
@@ -29,3 +29,13 @@ Every key version record must include:
 - Rotation increments `key_version` monotonically per `key_id`.
 - New writes use the current active version.
 - Expired keys are not silently reused.
+
+## Approval chain (authority modeled)
+
+- Key rotation is blocked unless an explicit approving DRI identity is provided.
+- Approval context must include:
+  - `authority_dri`
+  - `authority_role`
+  - `authority_reason`
+- Rotations emit a signed `AUTHORIZED_KEY_ROTATION` security event.
+- Every approved rotation appends a chained entry to `data/security/authority_ledger.json`.

--- a/scripts/pilot_pack.py
+++ b/scripts/pilot_pack.py
@@ -31,6 +31,7 @@ def main() -> int:
         outdir / "history.json",
         outdir / "kpi_trend.png",
         outdir / "kpi_trend.svg",
+        ROOT / "data" / "security" / "authority_ledger.json",
     ]
     for file_path in files:
         if file_path.exists():

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -1,6 +1,13 @@
 """Security primitives for DISR (Disposable Rotors)."""
 
+from .authority_ledger import append_authority_rotation_entry
 from .events import SecurityEvent, append_security_event
 from .keyring import Keyring, KeyVersionRecord
 
-__all__ = ["Keyring", "KeyVersionRecord", "SecurityEvent", "append_security_event"]
+__all__ = [
+    "Keyring",
+    "KeyVersionRecord",
+    "SecurityEvent",
+    "append_security_event",
+    "append_authority_rotation_entry",
+]

--- a/src/deepsigma/security/authority_ledger.py
+++ b/src/deepsigma/security/authority_ledger.py
@@ -1,0 +1,71 @@
+"""Authority ledger entries for signed key rotation approvals."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _entry_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _event_signature(payload: dict[str, Any], signing_key: str) -> str:
+    return hmac.new(
+        signing_key.encode("utf-8"),
+        _canonical_json(payload).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def append_authority_rotation_entry(
+    *,
+    ledger_path: str | Path,
+    rotation_event: dict[str, Any],
+    authority_dri: str,
+    authority_role: str,
+    authority_reason: str,
+    signing_key: str,
+) -> dict[str, Any]:
+    path = Path(ledger_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    entries: list[dict[str, Any]] = []
+    if path.exists():
+        raw = path.read_text(encoding="utf-8").strip()
+        if raw:
+            obj = json.loads(raw)
+            if isinstance(obj, list):
+                entries = [item for item in obj if isinstance(item, dict)]
+
+    prev_hash = entries[-1]["entry_hash"] if entries else None
+    unsigned = {
+        "entry_type": "AUTHORIZED_KEY_ROTATION",
+        "event_id": rotation_event["event_id"],
+        "event_hash": rotation_event["event_hash"],
+        "tenant_id": rotation_event["tenant_id"],
+        "key_id": rotation_event["payload"]["key_id"],
+        "key_version": rotation_event["payload"]["key_version"],
+        "authority_dri": authority_dri,
+        "authority_role": authority_role,
+        "authority_reason": authority_reason,
+        "recorded_at": rotation_event["occurred_at"],
+        "prev_entry_hash": prev_hash,
+    }
+    signature = _event_signature(unsigned, signing_key)
+    entry = dict(unsigned)
+    entry["event_signature"] = signature
+    entry["signature_alg"] = "HMAC-SHA256"
+    entry["entry_id"] = f"AUTHROT-{rotation_event['event_hash'][:12]}"
+    entry["entry_hash"] = _entry_hash({**entry, "entry_hash": ""})
+
+    entries.append(entry)
+    path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    return entry

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -135,11 +135,13 @@ class TestInitProject:
 
 
 class TestSecurityCLI:
-    def test_security_rotate_keys_json(self, tmp_path, capsys):
+    def test_security_rotate_keys_json(self, tmp_path, capsys, monkeypatch):
         from deepsigma.cli.main import main
 
         keyring_path = tmp_path / "keyring.json"
         event_path = tmp_path / "events.jsonl"
+        authority_ledger_path = tmp_path / "authority_ledger.json"
+        monkeypatch.setenv("DEEPSIGMA_AUTHORITY_SIGNING_KEY", "test-signing-key")
 
         rc = main(
             [
@@ -155,6 +157,12 @@ class TestSecurityCLI:
                 str(keyring_path),
                 "--event-log-path",
                 str(event_path),
+                "--authority-dri",
+                "dri.approver",
+                "--authority-reason",
+                "scheduled policy rotation",
+                "--authority-ledger-path",
+                str(authority_ledger_path),
                 "--json",
             ]
         )
@@ -164,6 +172,7 @@ class TestSecurityCLI:
         assert payload["key_version"] == 1
         assert keyring_path.exists()
         assert event_path.exists()
+        assert authority_ledger_path.exists()
 
     def test_security_reencrypt_dry_run_json(self, tmp_path, capsys):
         from deepsigma.cli.main import main


### PR DESCRIPTION
## Summary
- enforce authority approval context on `security rotate-keys`
- emit signed `AUTHORIZED_KEY_ROTATION` security events
- append chained entries to `data/security/authority_ledger.json`
- add authority approval chain requirements to key lifecycle docs
- include authority ledger artifact in pilot pack when present

## Validation
- `pytest -q tests/test_disr_security_ops.py tests/test_cli_smoke.py tests/test_security_events.py`
- `ruff check src scripts tests`
- `make security-gate`

Closes #254
