### PR TITLE
DISR PR5: 10-minute security demo and pilot-pack evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark openapi-docs openapi-check security-gate
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark openapi-docs openapi-check security-gate security-demo
 
 ci:
 	python scripts/compute_ci.py
@@ -70,3 +70,6 @@ openapi-check:
 
 security-gate:
 	python scripts/crypto_misuse_scan.py
+
+security-demo:
+	python scripts/reencrypt_demo.py

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ All connectors conform to the [Connector Contract v1.0](schemas/core/connector_c
 - [DISR Security Model](docs/docs/security/DISR.md) — Breakable -> Detectable -> Rotatable -> Recoverable posture for pilot security credibility.
 - [Key Lifecycle](docs/docs/security/KEY_LIFECYCLE.md) — key versioning, TTL, and rotation cadence.
 - [Recovery Runbook](docs/docs/security/RECOVERY_RUNBOOK.md) — compromise response and re-encryption recovery sequence.
+- [10-Minute Security Demo](docs/docs/security/DEMO_10_MIN.md) — reproducible DISR drill (`make security-gate` + `make security-demo`).
 
 ## Monitoring
 

--- a/docs/docs/security/DEMO_10_MIN.md
+++ b/docs/docs/security/DEMO_10_MIN.md
@@ -1,0 +1,42 @@
+# DISR 10-Minute Demo
+
+This demo proves the DISR loop in one pass:
+
+1. Detectable: run the crypto misuse gate.
+2. Rotatable: rotate keys with explicit DRI approval context.
+3. Recoverable: run a re-encrypt dry-run and checkpoint result.
+
+## Prerequisites
+
+- Python environment with DeepSigma dependencies installed.
+- Optional signing key in env:
+  - `export DEEPSIGMA_AUTHORITY_SIGNING_KEY="demo-signing-key"`
+
+## Commands
+
+```bash
+make security-gate
+make security-demo
+```
+
+## Expected outputs
+
+`make security-gate` writes:
+
+- `release_kpis/SECURITY_GATE_REPORT.md`
+- `release_kpis/SECURITY_GATE_REPORT.json`
+
+`make security-demo` writes:
+
+- `artifacts/disr_demo/keyring.json`
+- `artifacts/disr_demo/key_rotation_events.jsonl`
+- `artifacts/disr_demo/authority_ledger.json`
+- `artifacts/disr_demo/reencrypt_checkpoint.json`
+- `artifacts/disr_demo/disr_demo_summary.json`
+
+## What to verify
+
+- Rotation event exists with `event_type = KEY_ROTATED`.
+- Security event stream includes signed `AUTHORIZED_KEY_ROTATION`.
+- Authority ledger contains an `AUTHORIZED_KEY_ROTATION` entry.
+- Re-encrypt result is `dry_run` with deterministic checkpoint output.

--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -16,6 +16,7 @@ visible, reversible, and measurable under pilot conditions.
 
 - Key lifecycle policy: `docs/docs/security/KEY_LIFECYCLE.md`
 - Recovery runbook: `docs/docs/security/RECOVERY_RUNBOOK.md`
+- 10-minute demo: `docs/docs/security/DEMO_10_MIN.md`
 - Crypto envelope schema: `schemas/core/crypto_envelope.schema.json`
 - Keyring model: `src/deepsigma/security/keyring.py`
 

--- a/docs/docs/security/RECOVERY_RUNBOOK.md
+++ b/docs/docs/security/RECOVERY_RUNBOOK.md
@@ -28,3 +28,11 @@ If re-encryption validation fails:
 1. Halt processing.
 2. Restore from the latest verified checkpoint.
 3. Re-run with reduced batch size and diagnostics enabled.
+
+## Reproducible drill
+
+Use the demo drill to rehearse rotation plus re-encrypt dry-run:
+
+```bash
+make security-demo
+```

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -6,6 +6,7 @@ This folder contains the canonical pilot dataset: Decisions (DLR), Assumptions, 
 - PASS→FAIL→PASS: `make pilot-in-a-box`
 - WHY-60s: `make why-60s`
 - CI baseline: `make ci`
+- DISR security recovery drill: `make security-demo`
 
 ## Pilot Governance
 - Scope: `docs/docs/pilot/PILOT_SCOPE.md`

--- a/scripts/pilot_pack.py
+++ b/scripts/pilot_pack.py
@@ -31,7 +31,11 @@ def main() -> int:
         outdir / "history.json",
         outdir / "kpi_trend.png",
         outdir / "kpi_trend.svg",
+        outdir / "SECURITY_GATE_REPORT.md",
+        outdir / "SECURITY_GATE_REPORT.json",
         ROOT / "data" / "security" / "authority_ledger.json",
+        ROOT / "artifacts" / "disr_demo" / "authority_ledger.json",
+        ROOT / "artifacts" / "disr_demo" / "disr_demo_summary.json",
     ]
     for file_path in files:
         if file_path.exists():
@@ -44,6 +48,10 @@ def main() -> int:
         ROOT / "docs" / "docs" / "pilot" / "PILOT_CONTRACT_ONEPAGER.md",
         ROOT / "docs" / "docs" / "release" / "RELEASE_NOTES_v2.0.3.md",
         ROOT / "docs" / "docs" / "governance" / "LABEL_POLICY.md",
+        ROOT / "docs" / "docs" / "security" / "DISR.md",
+        ROOT / "docs" / "docs" / "security" / "KEY_LIFECYCLE.md",
+        ROOT / "docs" / "docs" / "security" / "RECOVERY_RUNBOOK.md",
+        ROOT / "docs" / "docs" / "security" / "DEMO_10_MIN.md",
         ROOT / "governance" / "kpi_issue_map.yaml",
         ROOT / "governance" / "kpi_spec.yaml",
     ]
@@ -55,6 +63,7 @@ def main() -> int:
         ROOT / "scripts" / "pilot_in_a_box.py",
         ROOT / "scripts" / "why_60s_challenge.py",
         ROOT / "scripts" / "compute_ci.py",
+        ROOT / "scripts" / "reencrypt_demo.py",
     ]
     for drill in drills:
         if drill.exists():

--- a/scripts/reencrypt_demo.py
+++ b/scripts/reencrypt_demo.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run a deterministic DISR rotation + reencrypt dry-run demo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from deepsigma.security.reencrypt import reencrypt_summary_to_dict, run_reencrypt_job  # noqa: E402
+from deepsigma.security.rotate_keys import rotate_keys, rotation_result_to_dict  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="DISR 10-minute demo: rotate + reencrypt dry-run")
+    parser.add_argument("--tenant", default="tenant-alpha", help="Tenant ID")
+    parser.add_argument("--key-id", default="credibility", help="Logical key id")
+    parser.add_argument("--ttl-days", type=int, default=14, help="Rotation TTL in days")
+    parser.add_argument(
+        "--out-dir",
+        default="artifacts/disr_demo",
+        help="Output directory for demo fixtures and reports",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir).resolve()
+    data_dir = out_dir / "cred"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    claims_path = data_dir / "claims.jsonl"
+    claims_path.write_text(
+        (
+            '{"tenant_id":"tenant-alpha","nonce":"AAAAAAAAAAAAAAAA","encrypted_payload":"BBBB",'
+            '"key_id":"credibility","key_version":1,"alg":"AES-256-GCM","aad":"tenant-alpha"}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    signing_key = os.getenv("DEEPSIGMA_AUTHORITY_SIGNING_KEY", "demo-signing-key")
+    rotation = rotate_keys(
+        tenant_id=args.tenant,
+        key_id=args.key_id,
+        ttl_days=args.ttl_days,
+        actor_user="demo-operator",
+        actor_role="coherence_steward",
+        authority_dri="demo.dri",
+        authority_role="dri_approver",
+        authority_reason="DISR 10-minute demo approval",
+        authority_signing_key=signing_key,
+        keyring_path=out_dir / "keyring.json",
+        event_log_path=out_dir / "key_rotation_events.jsonl",
+        authority_ledger_path=out_dir / "authority_ledger.json",
+    )
+    reencrypt = run_reencrypt_job(
+        tenant_id=args.tenant,
+        dry_run=True,
+        resume=False,
+        data_dir=data_dir,
+        checkpoint_path=out_dir / "reencrypt_checkpoint.json",
+        actor_user="demo-operator",
+        actor_role="coherence_steward",
+    )
+
+    summary = {
+        "rotation": rotation_result_to_dict(rotation),
+        "reencrypt": reencrypt_summary_to_dict(reencrypt),
+        "outputs": {
+            "keyring": str(out_dir / "keyring.json"),
+            "events": str(out_dir / "key_rotation_events.jsonl"),
+            "authority_ledger": str(out_dir / "authority_ledger.json"),
+            "checkpoint": str(out_dir / "reencrypt_checkpoint.json"),
+        },
+    }
+    report_path = out_dir / "disr_demo_summary.json"
+    report_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"Wrote: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add DISR 10-minute demo doc with reproducible commands and expected outputs
- add `scripts/reencrypt_demo.py` and `make security-demo` for rotation + reencrypt dry-run rehearsal
- wire DISR docs and security artifacts into `pilot_pack`
- add DISR drill references in README and pilot README

## Validation
- `ruff check src scripts tests`
- `pytest -q tests/test_disr_security_ops.py tests/test_cli_smoke.py tests/test_security_events.py`
- `make security-demo`
- `make security-gate`
- `make pilot-pack`

Closes #259
Closes #267
Closes #268
