### PR TITLE
DISR PR8: add reencrypt scalability benchmark telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark openapi-docs openapi-check security-gate security-demo
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo
 
 ci:
 	python scripts/compute_ci.py
@@ -59,6 +59,9 @@ pilot-pack:
 
 scale-benchmark:
 	bash scripts/run_scale_stack.sh
+
+reencrypt-benchmark:
+	python scripts/reencrypt_benchmark.py
 
 openapi-docs:
 	python scripts/export_openapi.py

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ All connectors conform to the [Connector Contract v1.0](schemas/core/connector_c
 - [Key Lifecycle](docs/docs/security/KEY_LIFECYCLE.md) — key versioning, TTL, and rotation cadence.
 - [Recovery Runbook](docs/docs/security/RECOVERY_RUNBOOK.md) — compromise response and re-encryption recovery sequence.
 - [10-Minute Security Demo](docs/docs/security/DEMO_10_MIN.md) — reproducible DISR drill (`make security-gate` + `make security-demo`).
+- [DISR Re-encrypt Benchmark](docs/docs/security/DEMO_10_MIN.md) — pilot-scale telemetry (`make reencrypt-benchmark`) with output in `release_kpis/scalability_metrics.json`.
 
 ## Monitoring
 

--- a/docs/docs/security/DEMO_10_MIN.md
+++ b/docs/docs/security/DEMO_10_MIN.md
@@ -17,6 +17,7 @@ This demo proves the DISR loop in one pass:
 ```bash
 make security-gate
 make security-demo
+make reencrypt-benchmark
 ```
 
 ## Expected outputs
@@ -35,6 +36,12 @@ make security-demo
 - `artifacts/disr_demo/disr_demo_summary.json`
 - `release_kpis/security_metrics.json`
 
+`make reencrypt-benchmark` writes:
+
+- `release_kpis/scalability_metrics.json`
+- `artifacts/benchmarks/reencrypt/benchmark_summary.json`
+- `artifacts/benchmarks/reencrypt/claims.jsonl` (100k-record deterministic fixture by default)
+
 ## What to verify
 
 - Rotation event exists with `event_type = KEY_ROTATED`.
@@ -50,3 +57,11 @@ make security-demo
 - `mttr_seconds`
 - `reencrypt_records_per_second`
 - `reencrypt_mb_per_minute`
+
+`release_kpis/scalability_metrics.json` captures:
+
+- `wall_clock_seconds`
+- `cpu_seconds`
+- `rss_peak_bytes`
+- `throughput_records_per_second`
+- `throughput_mb_per_minute`

--- a/scripts/kpi_compute.py
+++ b/scripts/kpi_compute.py
@@ -47,6 +47,19 @@ def parse_security_metrics() -> dict | None:
     return obj
 
 
+def parse_scalability_metrics() -> dict | None:
+    path = ROOT / "release_kpis" / "scalability_metrics.json"
+    if not path.exists():
+        return None
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
 def score_economic_measurability(metrics: dict) -> float:
     score = 3.0  # metrics present and parseable
     mttr = float(metrics.get("mttr_seconds", 0))
@@ -70,6 +83,28 @@ def score_economic_measurability(metrics: dict) -> float:
     elif mbm >= 0.001:
         score += 1
 
+    return clamp(score)
+
+
+def score_scalability(metrics: dict) -> float:
+    raw = metrics.get("scalability_score")
+    if isinstance(raw, (int, float)):
+        return clamp(float(raw))
+    throughput = float(metrics.get("throughput_records_per_second", 0))
+    mbm = float(metrics.get("throughput_mb_per_minute", 0))
+    score = 2.0
+    if throughput >= 5000:
+        score += 5
+    elif throughput >= 1000:
+        score += 4
+    elif throughput >= 100:
+        score += 2
+    if mbm >= 500:
+        score += 3
+    elif mbm >= 100:
+        score += 2
+    elif mbm >= 10:
+        score += 1
     return clamp(score)
 
 
@@ -135,6 +170,7 @@ def score_operational_maturity() -> float:
 def main() -> int:
     docs_root = ROOT / "docs" / "docs"
     metrics = parse_security_metrics()
+    scalability_metrics = parse_scalability_metrics()
     out = {
         "technical_completeness": round(score_technical_completeness(), 2),
         "automation_depth": round(score_automation_depth(), 2),
@@ -146,10 +182,13 @@ def main() -> int:
             "workflows": count_files(".github/workflows/*.yml") + count_files(".github/workflows/*.yaml"),
             "docs_md": len(list(docs_root.glob("**/*.md"))) if docs_root.exists() else 0,
             "security_metrics_present": metrics is not None,
+            "scalability_metrics_present": scalability_metrics is not None,
         },
     }
     if metrics is not None:
         out["economic_measurability"] = round(score_economic_measurability(metrics), 2)
+    if scalability_metrics is not None:
+        out["scalability"] = round(score_scalability(scalability_metrics), 2)
     print(json.dumps(out, indent=2))
     return 0
 

--- a/scripts/pilot_pack.py
+++ b/scripts/pilot_pack.py
@@ -33,9 +33,11 @@ def main() -> int:
         outdir / "kpi_trend.svg",
         outdir / "SECURITY_GATE_REPORT.md",
         outdir / "SECURITY_GATE_REPORT.json",
+        outdir / "scalability_metrics.json",
         ROOT / "data" / "security" / "authority_ledger.json",
         ROOT / "artifacts" / "disr_demo" / "authority_ledger.json",
         ROOT / "artifacts" / "disr_demo" / "disr_demo_summary.json",
+        ROOT / "artifacts" / "benchmarks" / "reencrypt" / "benchmark_summary.json",
     ]
     for file_path in files:
         if file_path.exists():
@@ -64,6 +66,7 @@ def main() -> int:
         ROOT / "scripts" / "why_60s_challenge.py",
         ROOT / "scripts" / "compute_ci.py",
         ROOT / "scripts" / "reencrypt_demo.py",
+        ROOT / "scripts" / "reencrypt_benchmark.py",
     ]
     for drill in drills:
         if drill.exists():

--- a/scripts/reencrypt_benchmark.py
+++ b/scripts/reencrypt_benchmark.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Deterministic DISR re-encrypt benchmark with resource telemetry."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import resource
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from deepsigma.security.reencrypt import reencrypt_summary_to_dict, run_reencrypt_job  # noqa: E402
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _rss_bytes(ru_maxrss: int) -> int:
+    # Linux reports KB, macOS reports bytes.
+    if sys.platform == "darwin":
+        return int(ru_maxrss)
+    return int(ru_maxrss * 1024)
+
+
+def _write_dataset(path: Path, records: int, reset: bool) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if reset or not path.exists():
+        with path.open("w", encoding="utf-8") as handle:
+            for i in range(records):
+                row = (
+                    '{"tenant_id":"tenant-alpha","claim_id":"C-%06d","nonce":"NONCE-%06d",'
+                    '"encrypted_payload":"PAYLOAD-%06d","key_id":"credibility","key_version":1,'
+                    '"alg":"AES-256-GCM","aad":"tenant-alpha"}\n'
+                ) % (i, i, i)
+                handle.write(row)
+    lines = sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+    return lines, path.stat().st_size
+
+
+def _scalability_score(mttr_seconds: float, records_per_second: float, mb_per_minute: float) -> float:
+    score = 2.0  # baseline: benchmark evidence exists
+    if mttr_seconds <= 300:
+        score += 3
+    elif mttr_seconds <= 600:
+        score += 2
+    elif mttr_seconds <= 1200:
+        score += 1
+
+    if records_per_second >= 5000:
+        score += 3
+    elif records_per_second >= 1000:
+        score += 2
+    elif records_per_second >= 100:
+        score += 1
+
+    if mb_per_minute >= 500:
+        score += 2
+    elif mb_per_minute >= 100:
+        score += 1
+    return max(0.0, min(10.0, score))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark DISR re-encrypt dry-run with telemetry")
+    parser.add_argument("--records", type=int, default=100000, help="Number of records to benchmark")
+    parser.add_argument(
+        "--dataset-dir",
+        default="artifacts/benchmarks/reencrypt",
+        help="Directory for generated benchmark dataset",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="artifacts/benchmarks/reencrypt/reencrypt_checkpoint.json",
+        help="Checkpoint path for the benchmark run",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        default="release_kpis/scalability_metrics.json",
+        help="Path to write benchmark metrics JSON",
+    )
+    parser.add_argument(
+        "--summary-out",
+        default="artifacts/benchmarks/reencrypt/benchmark_summary.json",
+        help="Path to write benchmark summary JSON",
+    )
+    parser.add_argument("--reset-dataset", action="store_true", help="Regenerate dataset from scratch")
+    args = parser.parse_args()
+
+    dataset_dir = (ROOT / args.dataset_dir).resolve()
+    claims_path = dataset_dir / "claims.jsonl"
+    records_targeted, bytes_targeted = _write_dataset(claims_path, args.records, args.reset_dataset)
+
+    started_at = _utc_now_iso()
+    wall_start = time.perf_counter()
+    cpu_start = time.process_time()
+    ru_start = resource.getrusage(resource.RUSAGE_SELF)
+
+    summary = run_reencrypt_job(
+        tenant_id="tenant-alpha",
+        dry_run=True,
+        resume=False,
+        data_dir=dataset_dir,
+        checkpoint_path=(ROOT / args.checkpoint).resolve(),
+        actor_user="benchmark-runner",
+        actor_role="coherence_steward",
+    )
+
+    wall_elapsed = max(time.perf_counter() - wall_start, 0.001)
+    cpu_elapsed = max(time.process_time() - cpu_start, 0.0)
+    ru_end = resource.getrusage(resource.RUSAGE_SELF)
+    rss_peak_bytes = max(_rss_bytes(ru_start.ru_maxrss), _rss_bytes(ru_end.ru_maxrss))
+    ended_at = _utc_now_iso()
+
+    records_per_second = records_targeted / wall_elapsed
+    mb_per_minute = (bytes_targeted / (1024 * 1024)) / (wall_elapsed / 60.0)
+    score = _scalability_score(wall_elapsed, records_per_second, mb_per_minute)
+
+    metrics = {
+        "schema_version": "1.0",
+        "metric_family": "disr_scalability",
+        "run_started_at": started_at,
+        "run_completed_at": ended_at,
+        "records_targeted": records_targeted,
+        "bytes_targeted": bytes_targeted,
+        "wall_clock_seconds": round(wall_elapsed, 6),
+        "cpu_seconds": round(cpu_elapsed, 6),
+        "rss_peak_bytes": rss_peak_bytes,
+        "throughput_records_per_second": round(records_per_second, 3),
+        "throughput_mb_per_minute": round(mb_per_minute, 6),
+        "scalability_score": round(score, 2),
+        "dataset_sha256": hashlib.sha256(claims_path.read_bytes()).hexdigest(),
+        "deterministic_seed": "DISR-BENCH-2026",
+    }
+
+    metrics_out = (ROOT / args.metrics_out).resolve()
+    metrics_out.parent.mkdir(parents=True, exist_ok=True)
+    metrics_out.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
+
+    output = {
+        "metrics": metrics,
+        "reencrypt_summary": reencrypt_summary_to_dict(summary),
+        "dataset_path": str(claims_path),
+    }
+    summary_out = (ROOT / args.summary_out).resolve()
+    summary_out.parent.mkdir(parents=True, exist_ok=True)
+    summary_out.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(output, indent=2))
+    print(f"Wrote: {metrics_out}")
+    print(f"Wrote: {summary_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reencrypt_benchmark_metrics.py
+++ b/tests/test_reencrypt_benchmark_metrics.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+
+def _load_kpi_compute(repo_root: Path):
+    mod_path = repo_root / "scripts" / "kpi_compute.py"
+    spec = importlib.util.spec_from_file_location("kpi_compute", mod_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_reencrypt_benchmark_writes_scalability_metrics(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+    out_dir = tmp_path / "bench"
+    metrics_path = tmp_path / "scalability_metrics.json"
+    summary_path = tmp_path / "summary.json"
+
+    cmd = [
+        "python",
+        str(repo_root / "scripts" / "reencrypt_benchmark.py"),
+        "--records",
+        "1000",
+        "--dataset-dir",
+        str(out_dir),
+        "--checkpoint",
+        str(tmp_path / "checkpoint.json"),
+        "--metrics-out",
+        str(metrics_path),
+        "--summary-out",
+        str(summary_path),
+        "--reset-dataset",
+    ]
+    subprocess.check_call(cmd, cwd=repo_root)
+
+    assert metrics_path.exists()
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["records_targeted"] == 1000
+    assert metrics["throughput_records_per_second"] > 0
+    assert metrics["rss_peak_bytes"] > 0
+
+
+def test_kpi_compute_supports_scalability_metrics(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parents[1] / "scripts" / "kpi_compute.py"
+    (repo / "scripts" / "kpi_compute.py").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / "release_kpis").mkdir(parents=True, exist_ok=True)
+    (repo / "release_kpis" / "scalability_metrics.json").write_text(
+        json.dumps({"scalability_score": 7.4}),
+        encoding="utf-8",
+    )
+
+    module = _load_kpi_compute(repo)
+    module.ROOT = repo
+    metrics = module.parse_scalability_metrics()
+    assert metrics is not None
+    assert module.score_scalability(metrics) == 7.4


### PR DESCRIPTION
## Summary
- add deterministic DISR benchmark script: `scripts/reencrypt_benchmark.py`
- benchmark runs against a generated 100k-record fixture by default
- log wall-clock, CPU, RSS peak, throughput, and dataset hash
- write outputs to:
  - `release_kpis/scalability_metrics.json`
  - `artifacts/benchmarks/reencrypt/benchmark_summary.json`
- wire benchmark command into `make reencrypt-benchmark`
- include scalability metrics/artifacts in pilot pack when present
- surface benchmark path in security demo docs and README
- add tests for benchmark metrics + KPI parser support

## Validation
- `ruff check src scripts tests`
- `pytest -q tests/test_reencrypt_benchmark_metrics.py tests/test_kpi_compute_security_metrics.py`
- `make reencrypt-benchmark`
- `make security-gate`

Closes #255
