### PR TITLE
DISR: honesty hardening for demo metrics and KPI caps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ scale-benchmark:
 	bash scripts/run_scale_stack.sh
 
 reencrypt-benchmark:
-	python scripts/reencrypt_benchmark.py
+	python scripts/reencrypt_benchmark.py $(ARGS)
 
 openapi-docs:
 	python scripts/export_openapi.py

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ All connectors conform to the [Connector Contract v1.0](schemas/core/connector_c
 - [10-Minute Security Demo](docs/docs/security/DEMO_10_MIN.md) — reproducible DISR drill (`make security-gate` + `make security-demo`).
 - [DISR Re-encrypt Benchmark](docs/docs/security/DEMO_10_MIN.md) — pilot-scale telemetry (`make reencrypt-benchmark`) with output in `release_kpis/scalability_metrics.json`.
 
+Note: default demo/benchmark commands run in dry-run mode and are marked as simulated evidence; KPI uplift is capped unless real workload mode is used.
+
 ## Monitoring
 
 - Prometheus metrics endpoint: `GET /metrics`

--- a/docs/docs/security/DEMO_10_MIN.md
+++ b/docs/docs/security/DEMO_10_MIN.md
@@ -12,6 +12,13 @@ This demo proves the DISR loop in one pass:
 - Optional signing key in env:
   - `export DEEPSIGMA_AUTHORITY_SIGNING_KEY="demo-signing-key"`
 
+## Honesty flags (important)
+
+- `make security-demo` and default `make reencrypt-benchmark` are **dry-run/simulated** workflows.
+- These flows measure orchestration + IO behavior, not production-grade cryptographic throughput.
+- KPI uplift from these artifacts is capped unless metrics are marked `kpi_eligible=true` from real workload runs.
+- If `DEEPSIGMA_AUTHORITY_SIGNING_KEY` is unset, demo signing uses a placeholder default key.
+
 ## Commands
 
 ```bash
@@ -42,6 +49,12 @@ make reencrypt-benchmark
 - `artifacts/benchmarks/reencrypt/benchmark_summary.json`
 - `artifacts/benchmarks/reencrypt/claims.jsonl` (100k-record deterministic fixture by default)
 
+To run a real workload benchmark (not dry-run), use:
+
+```bash
+make reencrypt-benchmark ARGS="--real-workload"
+```
+
 ## What to verify
 
 - Rotation event exists with `event_type = KEY_ROTATED`.
@@ -57,6 +70,8 @@ make reencrypt-benchmark
 - `mttr_seconds`
 - `reencrypt_records_per_second`
 - `reencrypt_mb_per_minute`
+- `execution_mode`, `evidence_level`, `kpi_eligible`
+- `signing_key_source` and `signing_notice`
 
 `release_kpis/scalability_metrics.json` captures:
 
@@ -65,3 +80,4 @@ make reencrypt-benchmark
 - `rss_peak_bytes`
 - `throughput_records_per_second`
 - `throughput_mb_per_minute`
+- `execution_mode`, `evidence_level`, `kpi_eligible`

--- a/scripts/reencrypt_benchmark.py
+++ b/scripts/reencrypt_benchmark.py
@@ -93,6 +93,11 @@ def main() -> int:
         help="Path to write benchmark summary JSON",
     )
     parser.add_argument("--reset-dataset", action="store_true", help="Regenerate dataset from scratch")
+    parser.add_argument(
+        "--real-workload",
+        action="store_true",
+        help="Run real re-encrypt workload (requires DEEPSIGMA_MASTER_KEY and DEEPSIGMA_PREVIOUS_MASTER_KEY)",
+    )
     args = parser.parse_args()
 
     dataset_dir = (ROOT / args.dataset_dir).resolve()
@@ -106,7 +111,7 @@ def main() -> int:
 
     summary = run_reencrypt_job(
         tenant_id="tenant-alpha",
-        dry_run=True,
+        dry_run=not args.real_workload,
         resume=False,
         data_dir=dataset_dir,
         checkpoint_path=(ROOT / args.checkpoint).resolve(),
@@ -127,6 +132,9 @@ def main() -> int:
     metrics = {
         "schema_version": "1.0",
         "metric_family": "disr_scalability",
+        "execution_mode": "real_workload" if args.real_workload else "dry_run",
+        "evidence_level": "real_workload" if args.real_workload else "simulated",
+        "kpi_eligible": bool(args.real_workload),
         "run_started_at": started_at,
         "run_completed_at": ended_at,
         "records_targeted": records_targeted,

--- a/scripts/reencrypt_demo.py
+++ b/scripts/reencrypt_demo.py
@@ -47,6 +47,7 @@ def main() -> int:
     bytes_targeted = claims_path.stat().st_size
 
     signing_key = os.getenv("DEEPSIGMA_AUTHORITY_SIGNING_KEY", "demo-signing-key")
+    signing_key_source = "env" if os.getenv("DEEPSIGMA_AUTHORITY_SIGNING_KEY") else "placeholder_default"
     compromise_started_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     t0 = time.perf_counter()
     rotation = rotate_keys(
@@ -81,6 +82,9 @@ def main() -> int:
     metrics = {
         "schema_version": "1.0",
         "metric_family": "disr_security",
+        "execution_mode": "dry_run",
+        "evidence_level": "simulated",
+        "kpi_eligible": False,
         "tenant_id": args.tenant,
         "compromise_started_at": compromise_started_at,
         "rotation_completed_at": rotation_completed_at,
@@ -90,6 +94,9 @@ def main() -> int:
         "bytes_targeted": bytes_targeted,
         "reencrypt_records_per_second": round(records_per_second, 3),
         "reencrypt_mb_per_minute": round(mb_per_minute, 6),
+        "signing_mode": "hmac",
+        "signing_key_source": signing_key_source,
+        "signing_notice": "Pilot signing key may be placeholder unless DEEPSIGMA_AUTHORITY_SIGNING_KEY is set.",
     }
     kpi_metrics_path = ROOT / "release_kpis" / "security_metrics.json"
     kpi_metrics_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_kpi_compute_security_metrics.py
+++ b/tests/test_kpi_compute_security_metrics.py
@@ -26,6 +26,8 @@ def test_score_economic_measurability_from_metrics(tmp_path: Path):
                 "mttr_seconds": 120,
                 "reencrypt_records_per_second": 5,
                 "reencrypt_mb_per_minute": 0.1,
+                "kpi_eligible": True,
+                "evidence_level": "real_workload",
             }
         ),
         encoding="utf-8",
@@ -38,6 +40,32 @@ def test_score_economic_measurability_from_metrics(tmp_path: Path):
     assert metrics is not None
     score = module.score_economic_measurability(metrics)
     assert score >= 8
+
+
+def test_score_economic_measurability_is_capped_for_simulated_metrics(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parents[1] / "scripts" / "kpi_compute.py"
+    (repo / "scripts" / "kpi_compute.py").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / "release_kpis").mkdir(parents=True, exist_ok=True)
+    (repo / "release_kpis" / "security_metrics.json").write_text(
+        json.dumps(
+            {
+                "mttr_seconds": 1,
+                "reencrypt_records_per_second": 999999,
+                "reencrypt_mb_per_minute": 999999,
+                "kpi_eligible": False,
+                "evidence_level": "simulated",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    module = _load_module(repo)
+    module.ROOT = repo
+    metrics = module.parse_security_metrics()
+    assert metrics is not None
+    assert module.score_economic_measurability(metrics) <= 4.0
 
 
 def test_main_omits_economic_measurability_without_metrics(tmp_path: Path):


### PR DESCRIPTION
## Summary
- mark default demo and benchmark metrics as `dry_run`/`simulated` with `kpi_eligible=false`
- cap `economic_measurability` and `scalability` KPI scores at 4.0 unless evidence is real workload
- add explicit signing placeholder disclosure to security demo metrics/docs
- add test coverage for simulated score caps and real-workload eligibility paths

## Validation
- `ruff check src scripts tests`
- `pytest -q tests/test_kpi_compute_security_metrics.py tests/test_reencrypt_benchmark_metrics.py`
- `make security-demo && make reencrypt-benchmark && python scripts/kpi_compute.py`
