### PR TITLE
DISR-210: LocalKeyStoreProvider default + crypto envelope v1

### DIFF
--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -23,5 +23,6 @@ visible, reversible, and measurable under pilot conditions.
 ## Pilot implementation notes
 
 - Key versions are modeled explicitly (`key_id`, `key_version`, `expires_at`, `status`).
-- Envelope metadata must include `key_id`, `key_version`, `alg`, `nonce`, and `aad`.
+- Default provider is `local-keystore` (file-backed) with deterministic storage at `local_keystore.json`.
+- Envelope v1 metadata includes `key_id`, `key_version`, `provider`, `alg`, `nonce`, `aad`, `created_at`, and `expires_at`.
 - Expiry and disable transitions are represented as status changes, not silent mutation.

--- a/schemas/core/crypto_envelope.schema.json
+++ b/schemas/core/crypto_envelope.schema.json
@@ -8,9 +8,12 @@
     "envelope_version",
     "key_id",
     "key_version",
+    "provider",
     "alg",
     "nonce",
-    "aad"
+    "aad",
+    "created_at",
+    "expires_at"
   ],
   "properties": {
     "envelope_version": {
@@ -33,6 +36,11 @@
       "enum": ["AES-256-GCM"],
       "description": "Encryption algorithm used for this payload."
     },
+    "provider": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Crypto provider used to source the key version."
+    },
     "nonce": {
       "type": "string",
       "minLength": 16,
@@ -42,6 +50,15 @@
       "type": "string",
       "minLength": 1,
       "description": "Associated authenticated data context string."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the crypto envelope was generated."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "description": "Key version expiry timestamp (RFC3339) or null."
     },
     "encrypted_payload": {
       "type": "string",

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -11,6 +11,8 @@ from .providers import (
     resolve_provider_name,
 )
 from .providers.base import CryptoProvider
+from .providers.local_keystore import LocalKeyStoreProvider
+from .providers.local_keyring import LocalKeyringProvider
 
 __all__ = [
     "CryptoProvider",
@@ -21,6 +23,8 @@ __all__ = [
     "append_security_event",
     "append_authority_rotation_entry",
     "create_provider",
+    "LocalKeyStoreProvider",
+    "LocalKeyringProvider",
     "provider_from_policy",
     "register_provider",
     "resolve_provider_name",

--- a/src/deepsigma/security/providers/__init__.py
+++ b/src/deepsigma/security/providers/__init__.py
@@ -6,6 +6,7 @@ import os
 from typing import Any, Callable
 
 from .base import CryptoProvider
+from .local_keystore import LocalKeyStoreProvider
 from .local_keyring import LocalKeyringProvider
 
 ProviderFactory = Callable[..., CryptoProvider]
@@ -36,7 +37,7 @@ def create_provider(name: str, **kwargs: Any) -> CryptoProvider:
     return factory(**kwargs)
 
 
-def resolve_provider_name(policy: dict[str, Any] | None = None, *, default: str = "local-keyring") -> str:
+def resolve_provider_name(policy: dict[str, Any] | None = None, *, default: str = "local-keystore") -> str:
     """Resolve provider name from env first, then policy, then default."""
     env_name = os.getenv("DEEPSIGMA_CRYPTO_PROVIDER")
     if env_name:
@@ -61,7 +62,7 @@ def resolve_provider_name(policy: dict[str, Any] | None = None, *, default: str 
 def provider_from_policy(
     policy: dict[str, Any] | None = None,
     *,
-    default: str = "local-keyring",
+    default: str = "local-keystore",
     provider_overrides: dict[str, Any] | None = None,
 ) -> CryptoProvider:
     """Create provider selected by policy name, with optional per-provider kwargs."""
@@ -80,4 +81,5 @@ def _normalize_name(name: str) -> str:
     return normalized
 
 
+register_provider("local-keystore", LocalKeyStoreProvider)
 register_provider("local-keyring", LocalKeyringProvider)

--- a/src/deepsigma/security/providers/local_keyring.py
+++ b/src/deepsigma/security/providers/local_keyring.py
@@ -1,46 +1,13 @@
-"""Local file-backed crypto provider built on the DISR keyring."""
+"""Backward-compatible local-keyring provider alias."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Callable
-
-from deepsigma.security.keyring import Keyring, KeyVersionRecord
-
-from .base import CryptoProvider
+from .local_keystore import LocalKeyStoreProvider
 
 
-class LocalKeyringProvider(CryptoProvider):
-    """Default provider using the existing JSON keyring implementation."""
-
-    def __init__(
-        self,
-        *,
-        keyring_path: str | Path = "data/security/keyring.json",
-        now_fn: Callable[[], datetime] | None = None,
-    ) -> None:
-        self._keyring = Keyring(path=keyring_path, now_fn=now_fn or _utc_now)
+class LocalKeyringProvider(LocalKeyStoreProvider):
+    """Compatibility alias for older policy values."""
 
     @property
     def name(self) -> str:
         return "local-keyring"
-
-    def create_key_version(self, key_id: str, expires_at: str | None = None) -> KeyVersionRecord:
-        return self._keyring.create(key_id=key_id, expires_at=expires_at)
-
-    def list_key_versions(self, key_id: str | None = None) -> list[KeyVersionRecord]:
-        return self._keyring.list(key_id=key_id)
-
-    def current_key_version(self, key_id: str) -> KeyVersionRecord | None:
-        return self._keyring.current(key_id=key_id)
-
-    def disable_key_version(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
-        return self._keyring.disable(key_id=key_id, key_version=key_version)
-
-    def expire_keys(self, now: datetime | None = None) -> int:
-        return self._keyring.expire(now=now)
-
-
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)

--- a/src/deepsigma/security/providers/local_keystore.py
+++ b/src/deepsigma/security/providers/local_keystore.py
@@ -1,0 +1,186 @@
+"""Deterministic local keystore provider for DISR key lifecycle operations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Callable
+
+from deepsigma.security.keyring import KeyVersionRecord
+
+from .base import CryptoProvider
+
+_STORE_SCHEMA_VERSION = "1.0"
+_STORE_PROVIDER_NAME = "local-keystore"
+_VALID_STATUSES = {"active", "disabled", "expired"}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+class LocalKeyStoreProvider(CryptoProvider):
+    """File-backed key provider with deterministic canonical storage."""
+
+    def __init__(
+        self,
+        *,
+        path: str | Path = "data/security/local_keystore.json",
+        now_fn: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self.path = Path(path)
+        self._now_fn = now_fn
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self._write_store([])
+        else:
+            # Validate/normalize existing file on startup for deterministic shape.
+            self._write_store(self._read_records())
+
+    @property
+    def name(self) -> str:
+        return _STORE_PROVIDER_NAME
+
+    def create_key_version(self, key_id: str, expires_at: str | None = None) -> KeyVersionRecord:
+        if not key_id or not key_id.strip():
+            raise ValueError("key_id is required")
+        if expires_at:
+            _parse_iso(expires_at)
+        key_id = key_id.strip()
+
+        records = self._read_records()
+        current_versions = [r.key_version for r in records if r.key_id == key_id]
+        next_version = (max(current_versions) + 1) if current_versions else 1
+
+        created = _to_iso(self._now_fn())
+        record = KeyVersionRecord(
+            key_id=key_id,
+            key_version=next_version,
+            created_at=created,
+            expires_at=expires_at,
+            status="active",
+        )
+        records.append(record)
+        self._write_store(records)
+        return record
+
+    def list_key_versions(self, key_id: str | None = None) -> list[KeyVersionRecord]:
+        records = self._read_records()
+        if key_id is None:
+            return records
+        return [record for record in records if record.key_id == key_id]
+
+    def current_key_version(self, key_id: str) -> KeyVersionRecord | None:
+        records = self.list_key_versions(key_id=key_id)
+        if not records:
+            return None
+        ordered = sorted(records, key=lambda r: r.key_version, reverse=True)
+        now = self._now_fn()
+        for record in ordered:
+            if record.status != "active":
+                continue
+            if record.expires_at and _parse_iso(record.expires_at) <= now:
+                continue
+            return record
+        return None
+
+    def disable_key_version(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
+        records = self._read_records()
+        candidates = [record for record in records if record.key_id == key_id]
+        if not candidates:
+            raise ValueError(f"Unknown key_id: {key_id}")
+
+        target = None
+        if key_version is None:
+            target = sorted(candidates, key=lambda r: r.key_version)[-1]
+        else:
+            for candidate in candidates:
+                if candidate.key_version == key_version:
+                    target = candidate
+                    break
+            if target is None:
+                raise ValueError(f"Unknown key version: {key_id}@v{key_version}")
+
+        updated: list[KeyVersionRecord] = []
+        for record in records:
+            if record.key_id == target.key_id and record.key_version == target.key_version:
+                updated.append(
+                    KeyVersionRecord(
+                        key_id=record.key_id,
+                        key_version=record.key_version,
+                        created_at=record.created_at,
+                        expires_at=record.expires_at,
+                        status="disabled",
+                    )
+                )
+            else:
+                updated.append(record)
+        self._write_store(updated)
+        return [r for r in updated if r.key_id == target.key_id and r.key_version == target.key_version][0]
+
+    def expire_keys(self, now: datetime | None = None) -> int:
+        current_time = now or self._now_fn()
+        records = self._read_records()
+        updated: list[KeyVersionRecord] = []
+        changed = 0
+        for record in records:
+            if (
+                record.status == "active"
+                and record.expires_at
+                and _parse_iso(record.expires_at) <= current_time
+            ):
+                updated.append(
+                    KeyVersionRecord(
+                        key_id=record.key_id,
+                        key_version=record.key_version,
+                        created_at=record.created_at,
+                        expires_at=record.expires_at,
+                        status="expired",
+                    )
+                )
+                changed += 1
+            else:
+                updated.append(record)
+        if changed:
+            self._write_store(updated)
+        return changed
+
+    def _read_records(self) -> list[KeyVersionRecord]:
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+
+        # Backward compatibility: old keyring format was a flat list.
+        if isinstance(raw, list):
+            payload = raw
+        else:
+            payload = raw.get("keys", [])
+            provider = raw.get("provider")
+            if provider and str(provider) not in {_STORE_PROVIDER_NAME, "local-keyring"}:
+                raise ValueError(f"Unexpected keystore provider: {provider}")
+
+        if not isinstance(payload, list):
+            raise ValueError("Keystore keys payload must be a list")
+
+        records = [KeyVersionRecord.from_dict(item) for item in payload]
+        return sorted(records, key=lambda r: (r.key_id, r.key_version))
+
+    def _write_store(self, records: list[KeyVersionRecord]) -> None:
+        for record in records:
+            if record.status not in _VALID_STATUSES:
+                raise ValueError(f"Invalid key status: {record.status}")
+
+        payload = {
+            "schema_version": _STORE_SCHEMA_VERSION,
+            "provider": _STORE_PROVIDER_NAME,
+            "keys": [asdict(record) for record in sorted(records, key=lambda r: (r.key_id, r.key_version))],
+        }
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_credibility_store_encryption.py
+++ b/tests/test_credibility_store_encryption.py
@@ -18,9 +18,18 @@ def test_encrypt_at_rest_jsonl_roundtrip(tmp_path, monkeypatch):
     )
     store.append_claim({"claim_id": "C-1", "score": 0.9})
 
-    raw = (tmp_path / "claims.jsonl").read_text(encoding="utf-8").strip()
-    assert "encrypted_payload" in raw
-    assert "claim_id" not in raw
+    raw_text = (tmp_path / "claims.jsonl").read_text(encoding="utf-8").strip()
+    assert "encrypted_payload" in raw_text
+    assert "claim_id" not in raw_text
+    raw = json.loads(raw_text)
+    assert raw["envelope_version"] == "1.0"
+    assert raw["provider"] in {"local-keystore", "local-keyring"}
+    assert raw["key_id"] == "credibility"
+    assert raw["key_version"] >= 1
+    assert raw["alg"] == "AES-256-GCM"
+    assert raw["aad"] == "alpha"
+    assert "created_at" in raw
+    assert "expires_at" in raw
 
     records = store.latest_claims()
     assert len(records) == 1


### PR DESCRIPTION
## Summary
- add `LocalKeyStoreProvider` with deterministic keystore format (`schema_version`, `provider`, sorted `keys`)
- keep `LocalKeyringProvider` as compatibility alias, while making `local-keystore` the default provider selection
- wire `CredibilityStore` encryption to provider-managed key metadata
- emit crypto envelope v1 fields on encrypted records: `key_id`, `key_version`, `provider`, `alg`, `nonce`, `aad`, `created_at`, `expires_at`
- extend crypto envelope schema and DISR docs to reflect v1 field contract
- add/adjust tests for provider registry defaults and encrypted envelope metadata

## Validation
- `python -m pytest -q tests/test_disr_provider_registry.py tests/test_credibility_store_encryption.py tests/test_disr_security_ops.py tests/test_disr_keyring.py`
- `python -m pytest -q tests/test_crypto_misuse_scan.py`
- `python -m ruff check src/deepsigma/security/providers src/credibility_engine/store.py tests/test_disr_provider_registry.py tests/test_credibility_store_encryption.py`

Closes #282
