### PR TITLE
DISR-210: optional cloud KMS provider stubs (AWS/GCP/Azure)

### DIFF
--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -26,3 +26,15 @@ visible, reversible, and measurable under pilot conditions.
 - Default provider is `local-keystore` (file-backed) with deterministic storage at `local_keystore.json`.
 - Envelope v1 metadata includes `key_id`, `key_version`, `provider`, `alg`, `nonce`, `aad`, `created_at`, and `expires_at`.
 - Expiry and disable transitions are represented as status changes, not silent mutation.
+
+## Optional cloud provider stubs
+
+Cloud KMS providers are registered as stubs only:
+
+- `aws-kms`
+- `gcp-kms`
+- `azure-kv`
+
+These stubs intentionally fail closed until you implement deployment-specific adapters.
+Do not commit credentials or cloud client configs in repo. Inject runtime auth through your
+deployment environment and replace stub internals in private integration layers.

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -11,6 +11,9 @@ from .providers import (
     resolve_provider_name,
 )
 from .providers.base import CryptoProvider
+from .providers.aws_kms import AWSKMSProvider
+from .providers.azure_kv import AzureKeyVaultProvider
+from .providers.gcp_kms import GCPKMSProvider
 from .providers.local_keystore import LocalKeyStoreProvider
 from .providers.local_keyring import LocalKeyringProvider
 
@@ -22,7 +25,10 @@ __all__ = [
     "available_providers",
     "append_security_event",
     "append_authority_rotation_entry",
+    "AWSKMSProvider",
+    "AzureKeyVaultProvider",
     "create_provider",
+    "GCPKMSProvider",
     "LocalKeyStoreProvider",
     "LocalKeyringProvider",
     "provider_from_policy",

--- a/src/deepsigma/security/providers/__init__.py
+++ b/src/deepsigma/security/providers/__init__.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 from typing import Any, Callable
 
+from .aws_kms import AWSKMSProvider
+from .azure_kv import AzureKeyVaultProvider
 from .base import CryptoProvider
+from .gcp_kms import GCPKMSProvider
 from .local_keystore import LocalKeyStoreProvider
 from .local_keyring import LocalKeyringProvider
 
@@ -83,3 +86,6 @@ def _normalize_name(name: str) -> str:
 
 register_provider("local-keystore", LocalKeyStoreProvider)
 register_provider("local-keyring", LocalKeyringProvider)
+register_provider("aws-kms", AWSKMSProvider)
+register_provider("gcp-kms", GCPKMSProvider)
+register_provider("azure-kv", AzureKeyVaultProvider)

--- a/src/deepsigma/security/providers/aws_kms.py
+++ b/src/deepsigma/security/providers/aws_kms.py
@@ -1,0 +1,38 @@
+"""AWS KMS provider stub (optional dependency, not enabled by default)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from deepsigma.security.keyring import KeyVersionRecord
+
+from .base import CryptoProvider
+
+
+class AWSKMSProvider(CryptoProvider):
+    """Stub provider for future AWS KMS integration."""
+
+    @property
+    def name(self) -> str:
+        return "aws-kms"
+
+    def create_key_version(self, key_id: str, expires_at: str | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def list_key_versions(self, key_id: str | None = None) -> list[KeyVersionRecord]:
+        self._not_configured()
+
+    def current_key_version(self, key_id: str) -> KeyVersionRecord | None:
+        self._not_configured()
+
+    def disable_key_version(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def expire_keys(self, now: datetime | None = None) -> int:
+        self._not_configured()
+
+    def _not_configured(self) -> None:
+        raise NotImplementedError(
+            "aws-kms provider is a stub. Configure cloud adapter + credentials in deployment, "
+            "then replace this stub with runtime implementation."
+        )

--- a/src/deepsigma/security/providers/azure_kv.py
+++ b/src/deepsigma/security/providers/azure_kv.py
@@ -1,0 +1,38 @@
+"""Azure Key Vault provider stub (optional dependency, not enabled by default)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from deepsigma.security.keyring import KeyVersionRecord
+
+from .base import CryptoProvider
+
+
+class AzureKeyVaultProvider(CryptoProvider):
+    """Stub provider for future Azure Key Vault integration."""
+
+    @property
+    def name(self) -> str:
+        return "azure-kv"
+
+    def create_key_version(self, key_id: str, expires_at: str | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def list_key_versions(self, key_id: str | None = None) -> list[KeyVersionRecord]:
+        self._not_configured()
+
+    def current_key_version(self, key_id: str) -> KeyVersionRecord | None:
+        self._not_configured()
+
+    def disable_key_version(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def expire_keys(self, now: datetime | None = None) -> int:
+        self._not_configured()
+
+    def _not_configured(self) -> None:
+        raise NotImplementedError(
+            "azure-kv provider is a stub. Configure cloud adapter + credentials in deployment, "
+            "then replace this stub with runtime implementation."
+        )

--- a/src/deepsigma/security/providers/gcp_kms.py
+++ b/src/deepsigma/security/providers/gcp_kms.py
@@ -1,0 +1,38 @@
+"""Google Cloud KMS provider stub (optional dependency, not enabled by default)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from deepsigma.security.keyring import KeyVersionRecord
+
+from .base import CryptoProvider
+
+
+class GCPKMSProvider(CryptoProvider):
+    """Stub provider for future Google Cloud KMS integration."""
+
+    @property
+    def name(self) -> str:
+        return "gcp-kms"
+
+    def create_key_version(self, key_id: str, expires_at: str | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def list_key_versions(self, key_id: str | None = None) -> list[KeyVersionRecord]:
+        self._not_configured()
+
+    def current_key_version(self, key_id: str) -> KeyVersionRecord | None:
+        self._not_configured()
+
+    def disable_key_version(self, key_id: str, key_version: int | None = None) -> KeyVersionRecord:
+        self._not_configured()
+
+    def expire_keys(self, now: datetime | None = None) -> int:
+        self._not_configured()
+
+    def _not_configured(self) -> None:
+        raise NotImplementedError(
+            "gcp-kms provider is a stub. Configure cloud adapter + credentials in deployment, "
+            "then replace this stub with runtime implementation."
+        )

--- a/tests/test_disr_provider_registry.py
+++ b/tests/test_disr_provider_registry.py
@@ -42,6 +42,9 @@ class _DummyProvider(CryptoProvider):
 def test_default_provider_is_registered() -> None:
     assert "local-keystore" in available_providers()
     assert "local-keyring" in available_providers()
+    assert "aws-kms" in available_providers()
+    assert "gcp-kms" in available_providers()
+    assert "azure-kv" in available_providers()
 
 
 def test_create_provider_unknown_raises() -> None:
@@ -110,3 +113,10 @@ def test_local_keystore_file_format_is_deterministic(tmp_path) -> None:
     assert '"provider": "local-keystore"' in payload
     assert '"schema_version": "1.0"' in payload
     assert payload.count('"key_version"') == 2
+
+
+@pytest.mark.parametrize("provider_name", ["aws-kms", "gcp-kms", "azure-kv"])
+def test_cloud_kms_stubs_fail_closed(provider_name: str) -> None:
+    provider = create_provider(provider_name)
+    with pytest.raises(NotImplementedError, match="stub"):
+        provider.create_key_version("credibility")


### PR DESCRIPTION
## Summary
- add optional stub providers implementing `CryptoProvider`:
  - `aws-kms`
  - `gcp-kms`
  - `azure-kv`
- register stubs in provider registry without introducing cloud SDK dependencies
- keep stubs fail-closed (`NotImplementedError`) until deployment adapters are implemented
- export stub classes via `deepsigma.security`
- document no-secrets/no-runtime-dependency guidance in DISR docs
- add tests verifying registration and fail-closed behavior

## Validation
- `python -m pytest -q tests/test_disr_provider_registry.py tests/test_credibility_store_encryption.py tests/test_disr_security_ops.py`
- `python -m ruff check src/deepsigma/security/providers src/deepsigma/security/__init__.py tests/test_disr_provider_registry.py`

Closes #283
