### PR TITLE
DISR-210: Authority Ledger v1 snapshots and precedence

### DIFF
--- a/docs/docs/security/KEY_LIFECYCLE.md
+++ b/docs/docs/security/KEY_LIFECYCLE.md
@@ -39,3 +39,5 @@ Every key version record must include:
   - `authority_reason`
 - Rotations emit a signed `AUTHORIZED_KEY_ROTATION` security event.
 - Every approved rotation appends a chained entry to `data/security/authority_ledger.json`.
+- Each append also updates `data/security/authority_ledger.snapshot.json` with snapshot hash and provenance.
+- Authority precedence is enforced as `DRI > Approver > System`; system-tier actors cannot approve privileged actions.

--- a/src/deepsigma/security/authority_ledger.py
+++ b/src/deepsigma/security/authority_ledger.py
@@ -8,6 +8,16 @@ import json
 from pathlib import Path
 from typing import Any
 
+LEDGER_SCHEMA_VERSION = "authority-ledger-v1"
+TIER_SYSTEM = "SYSTEM"
+TIER_APPROVER = "APPROVER"
+TIER_DRI = "DRI"
+_TIER_RANK = {
+    TIER_SYSTEM: 1,
+    TIER_APPROVER: 2,
+    TIER_DRI: 3,
+}
+
 
 def _canonical_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
@@ -23,6 +33,52 @@ def _event_signature(payload: dict[str, Any], signing_key: str) -> str:
         _canonical_json(payload).encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
+
+
+def _authority_tier(authority_role: str) -> str:
+    role = authority_role.strip().lower()
+    if role in {"system", "automation", "service", "bot"}:
+        return TIER_SYSTEM
+    if role in {"approver", "dri_approver", "reviewer", "coherence_steward"} or "approver" in role:
+        return TIER_APPROVER
+    if role in {"dri", "decision_dri", "program_dri"} or role.endswith("_dri") or "dri" in role:
+        return TIER_DRI
+    return TIER_APPROVER
+
+
+def _snapshot_path(ledger_path: Path) -> Path:
+    if ledger_path.suffix:
+        return ledger_path.with_name(f"{ledger_path.stem}.snapshot{ledger_path.suffix}")
+    return ledger_path.with_name(f"{ledger_path.name}.snapshot.json")
+
+
+def _write_snapshot(
+    *,
+    ledger_path: Path,
+    entries: list[dict[str, Any]],
+    provenance: dict[str, Any],
+) -> dict[str, Any]:
+    snapshot_path = _snapshot_path(ledger_path)
+    version = 1
+    if snapshot_path.exists():
+        try:
+            previous = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            version = int(previous.get("snapshot_version", 0)) + 1
+        except (json.JSONDecodeError, TypeError, ValueError):
+            version = 1
+    digest = _entry_hash({"entries": entries})
+    snapshot = {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "snapshot_version": version,
+        "snapshot_id": f"AUTHSNAP-{digest[:12]}",
+        "source_ledger_path": str(ledger_path),
+        "entry_count": len(entries),
+        "latest_entry_hash": entries[-1]["entry_hash"] if entries else None,
+        "ledger_hash": digest,
+        "provenance": provenance,
+    }
+    snapshot_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+    return snapshot
 
 
 def append_authority_rotation_entry(
@@ -67,9 +123,23 @@ def append_authority_action_entry(
             if isinstance(obj, list):
                 entries = [item for item in obj if isinstance(item, dict)]
 
+    tier = _authority_tier(authority_role)
+    if tier == TIER_SYSTEM:
+        raise ValueError("authority_role precedence too low: system cannot authorize privileged actions")
+    if action_contract:
+        contract_dri = action_contract.get("dri")
+        contract_approver = action_contract.get("approver")
+        if authority_dri == contract_dri and authority_dri != contract_approver and tier != TIER_DRI:
+            raise ValueError("authority_role must be DRI when signer is contract.dri")
+        if authority_dri == contract_approver and _TIER_RANK[tier] < _TIER_RANK[TIER_APPROVER]:
+            raise ValueError("authority_role must be APPROVER or higher when signer is contract.approver")
+        if authority_dri not in {contract_dri, contract_approver}:
+            raise ValueError("authority_dri must match action contract approver or dri")
+
     prev_hash = entries[-1]["entry_hash"] if entries else None
     payload = authority_event.get("payload", {})
     unsigned = {
+        "schema_version": LEDGER_SCHEMA_VERSION,
         "entry_type": action_type,
         "event_id": authority_event["event_id"],
         "event_hash": authority_event["event_hash"],
@@ -78,6 +148,8 @@ def append_authority_action_entry(
         "key_version": payload.get("key_version"),
         "authority_dri": authority_dri,
         "authority_role": authority_role,
+        "authority_tier": tier,
+        "authority_precedence": _TIER_RANK[tier],
         "authority_reason": authority_reason,
         "recorded_at": authority_event["occurred_at"],
         "prev_entry_hash": prev_hash,
@@ -95,4 +167,16 @@ def append_authority_action_entry(
 
     entries.append(entry)
     path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    _write_snapshot(
+        ledger_path=path,
+        entries=entries,
+        provenance={
+            "action_type": action_type,
+            "event_id": authority_event.get("event_id"),
+            "event_hash": authority_event.get("event_hash"),
+            "authority_dri": authority_dri,
+            "authority_role": authority_role,
+            "entry_id": entry["entry_id"],
+        },
+    )
     return entry

--- a/tests/test_disr_authority_ledger_v1.py
+++ b/tests/test_disr_authority_ledger_v1.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepsigma.security.authority_ledger import append_authority_action_entry
+
+
+def _event(event_id: str = "evt-1", event_hash: str = "abc123") -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "event_hash": event_hash,
+        "tenant_id": "tenant-alpha",
+        "occurred_at": "2026-02-23T00:00:00Z",
+        "payload": {"key_id": "credibility", "key_version": 2},
+    }
+
+
+def test_authority_ledger_writes_versioned_snapshot_with_provenance(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "authority_ledger.json"
+    entry = append_authority_action_entry(
+        ledger_path=ledger_path,
+        authority_event=_event(),
+        authority_dri="dri.approver",
+        authority_role="dri_approver",
+        authority_reason="incident recovery",
+        signing_key="test-signing-key",
+        action_type="AUTHORIZED_REENCRYPT",
+        action_contract={
+            "action_id": "ACT-12345678",
+            "dri": "dri.owner",
+            "approver": "dri.approver",
+        },
+    )
+
+    snapshot_path = tmp_path / "authority_ledger.snapshot.json"
+    assert snapshot_path.exists()
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert snapshot["schema_version"] == "authority-ledger-v1"
+    assert snapshot["snapshot_version"] == 1
+    assert snapshot["latest_entry_hash"] == entry["entry_hash"]
+    assert snapshot["provenance"]["entry_id"] == entry["entry_id"]
+
+
+def test_authority_ledger_rejects_system_precedence(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="precedence too low"):
+        append_authority_action_entry(
+            ledger_path=tmp_path / "authority_ledger.json",
+            authority_event=_event(),
+            authority_dri="system.bot",
+            authority_role="system",
+            authority_reason="automation fallback",
+            signing_key="test-signing-key",
+            action_type="AUTHORIZED_REENCRYPT",
+        )
+
+
+def test_authority_ledger_enforces_contract_identity_match(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must match action contract approver or dri"):
+        append_authority_action_entry(
+            ledger_path=tmp_path / "authority_ledger.json",
+            authority_event=_event(),
+            authority_dri="unknown.actor",
+            authority_role="dri_approver",
+            authority_reason="incident recovery",
+            signing_key="test-signing-key",
+            action_type="AUTHORIZED_REENCRYPT",
+            action_contract={
+                "action_id": "ACT-12345678",
+                "dri": "dri.owner",
+                "approver": "dri.approver",
+            },
+        )


### PR DESCRIPTION
## Summary\n- add Authority Ledger v1 schema/version metadata per entry\n- enforce authority precedence (DRI > Approver > System) for privileged authorization\n- emit versioned snapshot file with ledger hash + provenance on each append\n- document snapshot + precedence behavior in key lifecycle docs\n- add tests for snapshot/provenance and precedence enforcement\n\n## Validation\n- ........................                                                 [100%]
=============================== warnings summary ===============================
tests/test_disr_security_ops.py::test_reencrypt_dry_run_writes_checkpoint
tests/test_disr_security_pipeline.py::test_reencrypt_dry_run_then_resume_completed
tests/test_cli_smoke.py::TestSecurityCLI::test_security_reencrypt_dry_run_json
  /Users/bryanwhite/Documents/DeepSigma-v0.3.0/src/credibility_engine/store.py:103: RuntimeWarning: encrypt_at_rest=True but DEEPSIGMA_MASTER_KEY is unset; falling back to plaintext persistence
    self._initialize_encryption()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
24 passed, 3 warnings in 1.18s\n- All checks passed!\n\nCloses #285