### PR TITLE
DISR-210: crypto policy engine + envelope version governance

### DIFF
--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -17,7 +17,10 @@ visible, reversible, and measurable under pilot conditions.
 - Key lifecycle policy: `docs/docs/security/KEY_LIFECYCLE.md`
 - Recovery runbook: `docs/docs/security/RECOVERY_RUNBOOK.md`
 - 10-minute demo: `docs/docs/security/DEMO_10_MIN.md`
+- Envelope migration plan: `docs/docs/security/ENVELOPE_VERSIONING.md`
 - Crypto envelope schema: `schemas/core/crypto_envelope.schema.json`
+- Crypto policy: `governance/security_crypto_policy.json`
+- Crypto policy schema: `schemas/core/security_crypto_policy.schema.json`
 - Authority action contract schema: `schemas/core/action_contract.schema.json`
 - Keyring model: `src/deepsigma/security/keyring.py`
 
@@ -25,7 +28,8 @@ visible, reversible, and measurable under pilot conditions.
 
 - Key versions are modeled explicitly (`key_id`, `key_version`, `expires_at`, `status`).
 - Default provider is `local-keystore` (file-backed) with deterministic storage at `local_keystore.json`.
-- Envelope v1 metadata includes `key_id`, `key_version`, `provider`, `alg`, `nonce`, `aad`, `created_at`, and `expires_at`.
+- Envelope metadata is policy-driven via `envelope_version_current` and `envelope_versions_supported`.
+- Runtime enforces allowed providers/algorithms/TTL bounds from `governance/security_crypto_policy.json`.
 - Expiry and disable transitions are represented as status changes, not silent mutation.
 - Privileged rotate/reencrypt actions require a signed authority action contract.
 

--- a/docs/docs/security/ENVELOPE_VERSIONING.md
+++ b/docs/docs/security/ENVELOPE_VERSIONING.md
@@ -1,0 +1,27 @@
+# Envelope Versioning Plan
+
+This document defines the migration path for cryptographic envelope schema versions.
+
+## Current state
+
+- `envelope_version_current`: `1.0`
+- `envelope_versions_supported`: `["1.0"]`
+- Source of truth: `governance/security_crypto_policy.json`
+
+## Migration strategy to v2
+
+- Strategy: **dual-read, single-write**
+- Writers must emit `envelope_version_current`.
+- Readers may accept any value in `envelope_versions_supported`.
+
+## v2 rollout sequence
+
+1. Add `2.0` to `envelope_versions_supported` while keeping current at `1.0`.
+2. Ship readers that can decode both `1.0` and `2.0`.
+3. Flip `envelope_version_current` to `2.0` for new writes.
+4. Retire `1.0` from supported versions after re-encryption and validation.
+
+## CI and runtime enforcement
+
+- `scripts/crypto_misuse_scan.py` fails on unsupported envelope versions.
+- Runtime write path rejects envelope metadata that violates provider/algorithm/version policy.

--- a/governance/security_crypto_policy.json
+++ b/governance/security_crypto_policy.json
@@ -1,0 +1,22 @@
+{
+  "policy_version": "1.0",
+  "default_provider": "local-keystore",
+  "allowed_providers": [
+    "local-keystore",
+    "local-keyring"
+  ],
+  "allowed_algorithms": [
+    "AES-256-GCM"
+  ],
+  "min_ttl_days": 1,
+  "max_ttl_days": 30,
+  "envelope_version_current": "1.0",
+  "envelope_versions_supported": [
+    "1.0"
+  ],
+  "migration": {
+    "next_version": "2.0",
+    "strategy": "dual-read single-write",
+    "notes": "Writers must emit envelope_version_current. Readers may accept envelope_versions_supported."
+  }
+}

--- a/schemas/core/security_crypto_policy.schema.json
+++ b/schemas/core/security_crypto_policy.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deepsigma.dev/schemas/security_crypto_policy/v1.0",
+  "title": "Security Crypto Policy",
+  "description": "Runtime policy constraints for provider/algorithm/TTL and envelope versions.",
+  "type": "object",
+  "required": [
+    "policy_version",
+    "default_provider",
+    "allowed_providers",
+    "allowed_algorithms",
+    "min_ttl_days",
+    "max_ttl_days",
+    "envelope_version_current",
+    "envelope_versions_supported"
+  ],
+  "properties": {
+    "policy_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "default_provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "allowed_algorithms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "min_ttl_days": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "max_ttl_days": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "envelope_version_current": {
+      "type": "string",
+      "minLength": 1
+    },
+    "envelope_versions_supported": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "migration": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -12,6 +12,15 @@ from .events import (
     query_security_events,
 )
 from .keyring import Keyring, KeyVersionRecord
+from .policy import (
+    CryptoPolicyError,
+    get_envelope_settings,
+    load_crypto_policy,
+    validate_algorithm_allowed,
+    validate_envelope_metadata,
+    validate_provider_allowed,
+    validate_rotation_ttl_days,
+)
 from .providers import (
     available_providers,
     create_provider,
@@ -34,6 +43,13 @@ __all__ = [
     "available_providers",
     "append_security_event",
     "query_security_events",
+    "load_crypto_policy",
+    "get_envelope_settings",
+    "validate_algorithm_allowed",
+    "validate_envelope_metadata",
+    "validate_provider_allowed",
+    "validate_rotation_ttl_days",
+    "CryptoPolicyError",
     "EVENT_KEY_ROTATED",
     "EVENT_NONCE_REUSE_DETECTED",
     "EVENT_REENCRYPT_DONE",

--- a/src/deepsigma/security/policy.py
+++ b/src/deepsigma/security/policy.py
@@ -1,0 +1,110 @@
+"""Runtime crypto policy loading and enforcement helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POLICY_PATH = Path("governance/security_crypto_policy.json")
+
+
+class CryptoPolicyError(ValueError):
+    """Raised when runtime crypto policy validation fails."""
+
+
+def _coerce_path(path: str | Path | None) -> Path:
+    if path is not None:
+        return Path(path)
+    from_env = os.getenv("DEEPSIGMA_CRYPTO_POLICY_PATH")
+    if from_env:
+        return Path(from_env)
+    return DEFAULT_POLICY_PATH
+
+
+def load_crypto_policy(path: str | Path | None = None) -> dict[str, Any]:
+    """Load policy JSON from explicit path, env override, or default location."""
+    policy_path = _coerce_path(path)
+    if not policy_path.exists():
+        raise CryptoPolicyError(f"Crypto policy file not found: {policy_path}")
+
+    try:
+        payload = json.loads(policy_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CryptoPolicyError(f"Invalid crypto policy JSON at {policy_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise CryptoPolicyError(f"Crypto policy must be a JSON object: {policy_path}")
+
+    required = {
+        "policy_version",
+        "default_provider",
+        "allowed_providers",
+        "allowed_algorithms",
+        "min_ttl_days",
+        "max_ttl_days",
+        "envelope_version_current",
+        "envelope_versions_supported",
+    }
+    missing = sorted(required - set(payload.keys()))
+    if missing:
+        raise CryptoPolicyError(f"Crypto policy missing required keys: {', '.join(missing)}")
+    return payload
+
+
+def get_envelope_settings(path: str | Path | None = None) -> tuple[str, set[str]]:
+    policy = load_crypto_policy(path)
+    current = str(policy["envelope_version_current"])
+    supported = {str(item) for item in policy["envelope_versions_supported"]}
+    if current not in supported:
+        raise CryptoPolicyError("envelope_version_current must be included in envelope_versions_supported")
+    return current, supported
+
+
+def validate_provider_allowed(provider_name: str, path: str | Path | None = None) -> None:
+    policy = load_crypto_policy(path)
+    allowed = {str(item) for item in policy["allowed_providers"]}
+    if provider_name not in allowed:
+        raise CryptoPolicyError(
+            f"Provider '{provider_name}' blocked by crypto policy. Allowed providers: {sorted(allowed)}"
+        )
+
+
+def validate_algorithm_allowed(algorithm: str, path: str | Path | None = None) -> None:
+    policy = load_crypto_policy(path)
+    allowed = {str(item) for item in policy["allowed_algorithms"]}
+    if algorithm not in allowed:
+        raise CryptoPolicyError(
+            f"Algorithm '{algorithm}' blocked by crypto policy. Allowed algorithms: {sorted(allowed)}"
+        )
+
+
+def validate_rotation_ttl_days(ttl_days: int, path: str | Path | None = None) -> None:
+    policy = load_crypto_policy(path)
+    min_days = int(policy["min_ttl_days"])
+    max_days = int(policy["max_ttl_days"])
+    if ttl_days < min_days or ttl_days > max_days:
+        raise CryptoPolicyError(
+            f"ttl_days={ttl_days} violates crypto policy bounds [{min_days}, {max_days}]"
+        )
+
+
+def validate_envelope_metadata(envelope: dict[str, Any], path: str | Path | None = None) -> None:
+    current, supported = get_envelope_settings(path)
+    version = str(envelope.get("envelope_version", ""))
+    if version not in supported:
+        raise CryptoPolicyError(
+            f"Envelope version '{version}' is not supported by crypto policy: {sorted(supported)}"
+        )
+    if version != current:
+        # Migration path remains backward compatible, but new writes must use current.
+        raise CryptoPolicyError(
+            f"Envelope version '{version}' is not current policy version '{current}' for new writes"
+        )
+
+    provider = str(envelope.get("provider", ""))
+    validate_provider_allowed(provider, path=path)
+
+    algorithm = str(envelope.get("alg", ""))
+    validate_algorithm_allowed(algorithm, path=path)

--- a/src/deepsigma/security/providers/__init__.py
+++ b/src/deepsigma/security/providers/__init__.py
@@ -11,6 +11,7 @@ from .base import CryptoProvider
 from .gcp_kms import GCPKMSProvider
 from .local_keystore import LocalKeyStoreProvider
 from .local_keyring import LocalKeyringProvider
+from ..policy import validate_provider_allowed
 
 ProviderFactory = Callable[..., CryptoProvider]
 
@@ -76,6 +77,7 @@ def provider_from_policy(
 ) -> CryptoProvider:
     """Create provider selected by policy name, with optional per-provider kwargs."""
     name = resolve_provider_name(policy, default=default)
+    validate_provider_allowed(name)
     overrides = provider_overrides or {}
     kwargs = overrides.get(name, {})
     if not isinstance(kwargs, dict):

--- a/src/deepsigma/security/rotate_keys.py
+++ b/src/deepsigma/security/rotate_keys.py
@@ -15,6 +15,7 @@ from .action_contract import create_action_contract, validate_action_contract
 from .authority_ledger import append_authority_action_entry
 from .events import EVENT_KEY_ROTATED, append_security_event
 from .keyring import Keyring, KeyVersionRecord
+from .policy import validate_rotation_ttl_days
 
 
 def _utc_now() -> datetime:
@@ -64,6 +65,7 @@ def rotate_keys(
 ) -> RotationResult:
     if ttl_days <= 0:
         raise ValueError("ttl_days must be > 0")
+    validate_rotation_ttl_days(ttl_days)
     if not authority_dri:
         raise ValueError("authority_dri is required for rotation approval")
     if not authority_reason:

--- a/tests/test_disr_policy.py
+++ b/tests/test_disr_policy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepsigma.security.policy import (
+    CryptoPolicyError,
+    get_envelope_settings,
+    load_crypto_policy,
+    validate_envelope_metadata,
+)
+
+
+def test_load_crypto_policy_reads_default_file() -> None:
+    policy = load_crypto_policy()
+    assert policy["policy_version"] == "1.0"
+    assert "local-keystore" in policy["allowed_providers"]
+
+
+def test_get_envelope_settings_returns_current_and_supported() -> None:
+    current, supported = get_envelope_settings()
+    assert current == "1.0"
+    assert "1.0" in supported
+
+
+def test_validate_envelope_metadata_rejects_unsupported_version(tmp_path: Path) -> None:
+    policy_path = tmp_path / "security_crypto_policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "policy_version": "1.0",
+                "default_provider": "local-keystore",
+                "allowed_providers": ["local-keystore"],
+                "allowed_algorithms": ["AES-256-GCM"],
+                "min_ttl_days": 1,
+                "max_ttl_days": 30,
+                "envelope_version_current": "1.0",
+                "envelope_versions_supported": ["1.0"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(CryptoPolicyError, match="not supported"):
+        validate_envelope_metadata(
+            {
+                "envelope_version": "2.0",
+                "provider": "local-keystore",
+                "alg": "AES-256-GCM",
+            },
+            path=policy_path,
+        )

--- a/tests/test_disr_provider_registry.py
+++ b/tests/test_disr_provider_registry.py
@@ -12,6 +12,7 @@ from deepsigma.security.providers import (
     register_provider,
     resolve_provider_name,
 )
+from deepsigma.security.policy import CryptoPolicyError
 from deepsigma.security.providers.base import CryptoProvider
 
 
@@ -85,6 +86,12 @@ def test_provider_from_policy_uses_overrides(monkeypatch: pytest.MonkeyPatch, tm
     )
     record = provider.create_key_version("credibility")
     assert record.key_version == 1
+
+
+def test_provider_from_policy_rejects_disallowed_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPSIGMA_CRYPTO_PROVIDER", "aws-kms")
+    with pytest.raises(CryptoPolicyError, match="blocked by crypto policy"):
+        provider_from_policy({"security": {"crypto_provider": "local-keystore"}})
 
 
 def test_provider_from_policy_emits_provider_changed_event(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/tests/test_disr_security_ops.py
+++ b/tests/test_disr_security_ops.py
@@ -124,6 +124,23 @@ def test_rotate_keys_rejects_invalid_ttl(tmp_path: Path):
         )
 
 
+def test_rotate_keys_rejects_ttl_above_policy_max(tmp_path: Path):
+    with pytest.raises(ValueError, match="violates crypto policy bounds"):
+        rotate_keys(
+            tenant_id="tenant-alpha",
+            key_id="credibility",
+            ttl_days=45,
+            actor_user="dri",
+            actor_role="coherence_steward",
+            authority_dri="dri.approver",
+            authority_role="dri_approver",
+            authority_reason="policy",
+            authority_signing_key="test-signing-key",
+            keyring_path=tmp_path / "keyring.json",
+            event_log_path=tmp_path / "events.jsonl",
+        )
+
+
 def test_rotate_keys_requires_authority_context(tmp_path: Path):
     with pytest.raises(ValueError, match="authority_dri is required"):
         rotate_keys(


### PR DESCRIPTION
## Summary
- add runtime crypto policy loader/enforcer for provider, algorithm, TTL bounds, and envelope version support
- add policy artifacts: `governance/security_crypto_policy.json` + `schemas/core/security_crypto_policy.schema.json`
- enforce policy at runtime in provider resolution, key rotation TTL validation, and encrypted envelope writes
- extend `scripts/crypto_misuse_scan.py` to fail CI on policy/config drift and envelope policy violations
- add envelope migration plan docs (`docs/docs/security/ENVELOPE_VERSIONING.md`) and update DISR docs
- add focused tests for policy, scanner policy violations, provider blocking, and TTL enforcement

## Validation
- `python -m pytest tests/test_disr_policy.py tests/test_disr_provider_registry.py tests/test_disr_security_ops.py tests/test_credibility_store_encryption.py tests/test_crypto_misuse_scan.py -q`
- `make security-gate`

Closes #287
