### PR TITLE
DISR-210: streaming batched reencrypt with idempotent checkpoint/resume

### DIFF
--- a/src/deepsigma/cli/security.py
+++ b/src/deepsigma/cli/security.py
@@ -94,6 +94,8 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Optional JSON file with signed authority action contract",
     )
+    reenc.add_argument("--batch-size", type=int, default=1000, help="Records per checkpointed batch")
+    reenc.add_argument("--idempotency-key", default=None, help="Stable idempotency key for resume safety")
     reenc.add_argument("--json", action="store_true", help="Output JSON")
     reenc.set_defaults(func=run_reencrypt)
 
@@ -179,6 +181,8 @@ def run_reencrypt(args: argparse.Namespace) -> int:
         action_contract=action_contract,
         authority_ledger_path=Path(args.authority_ledger_path),
         security_events_path=Path(args.security_events_path),
+        batch_size=args.batch_size,
+        idempotency_key=args.idempotency_key,
     )
     payload = reencrypt_summary_to_dict(summary)
     if args.json:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -195,6 +195,10 @@ class TestSecurityCLI:
                 "--checkpoint",
                 str(checkpoint),
                 "--dry-run",
+                "--batch-size",
+                "50",
+                "--idempotency-key",
+                "ik-cli-001",
                 "--authority-dri",
                 "dri.approver",
                 "--authority-reason",
@@ -209,6 +213,9 @@ class TestSecurityCLI:
         assert payload["status"] == "dry_run"
         assert payload["records_targeted"] == 1
         assert checkpoint.exists()
+        cp = json.loads(checkpoint.read_text(encoding="utf-8"))
+        assert cp["batch_size"] == 50
+        assert cp["idempotency_key"] == "ik-cli-001"
 
     def test_security_provider_changed_and_query(self, tmp_path, capsys, monkeypatch):
         from deepsigma.cli.main import main


### PR DESCRIPTION
## Summary
- rework reencrypt pipeline to stream records in bounded batches instead of loading full files in memory
- add batch checkpointing during execution so resume can continue from persisted `line_offset` per file
- add idempotency key handling to prevent accidental mismatched resumes
- add CLI flags for `--batch-size` and `--idempotency-key`
- keep dry-run + completed-checkpoint shortcuts intact

## Validation
- `python -m pytest tests/test_disr_security_ops.py tests/test_disr_security_pipeline.py tests/test_cli_smoke.py -q`
- `python -m ruff check src/deepsigma/security/reencrypt.py src/deepsigma/cli/security.py tests/test_disr_security_ops.py tests/test_cli_smoke.py`

Closes #288
