### PR TITLE
DISR-210: add one-command Security Audit Pack export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack
 
 ci:
 	python scripts/compute_ci.py
@@ -76,3 +76,6 @@ security-gate:
 
 security-demo:
 	python scripts/reencrypt_demo.py
+
+security-audit-pack:
+	python scripts/security_audit_pack.py

--- a/docs/docs/security/DISR.md
+++ b/docs/docs/security/DISR.md
@@ -17,6 +17,7 @@ visible, reversible, and measurable under pilot conditions.
 - Key lifecycle policy: `docs/docs/security/KEY_LIFECYCLE.md`
 - Recovery runbook: `docs/docs/security/RECOVERY_RUNBOOK.md`
 - 10-minute demo: `docs/docs/security/DEMO_10_MIN.md`
+- Security audit export: `scripts/security_audit_pack.py` (`make security-audit-pack`)
 - Envelope migration plan: `docs/docs/security/ENVELOPE_VERSIONING.md`
 - Crypto envelope schema: `schemas/core/crypto_envelope.schema.json`
 - Crypto policy: `governance/security_crypto_policy.json`

--- a/scripts/pilot_pack.py
+++ b/scripts/pilot_pack.py
@@ -14,6 +14,7 @@ def main() -> int:
         shutil.rmtree(pack)
     pack.mkdir(parents=True, exist_ok=True)
 
+    subprocess.check_call(["make", "security-audit-pack"])
     subprocess.check_call(["make", "issue-label-gate"])
     subprocess.check_call(["make", "kpi-issues"])
     subprocess.check_call(["make", "kpi"])
@@ -74,6 +75,10 @@ def main() -> int:
         if drill.exists():
             shutil.copy2(drill, pack / drill.name)
 
+    audit_pack = ROOT / "security_audit_pack"
+    if audit_pack.exists():
+        shutil.copytree(audit_pack, pack / "security_audit_pack")
+
     (pack / "README.md").write_text(
         f"""# Pilot Pack - {version}
 
@@ -84,6 +89,7 @@ This folder is a shareable bundle for pilot evaluation.
 - KPI gate report + Issue label gate report
 - Pilot docs (scope, DRI, branch protection, contract)
 - Drill scripts (pilot_in_a_box, why_60s)
+- Security audit proof bundle (`security_audit_pack/`)
 
 ## Run locally
 ```bash

--- a/scripts/security_audit_pack.py
+++ b/scripts/security_audit_pack.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Build a shareable DISR security audit pack from repository artifacts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _git_commit(root: Path) -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except Exception:
+        return "unknown"
+
+
+def _release_version(root: Path) -> str:
+    version_file = root / "release_kpis" / "VERSION.txt"
+    if version_file.exists():
+        return version_file.read_text(encoding="utf-8").strip()
+    return "unknown"
+
+
+def _copy_source(root: Path, out_dir: Path, rel_path: str) -> dict[str, Any]:
+    src = root / rel_path
+    if not src.exists():
+        return {
+            "source": rel_path,
+            "status": "missing",
+        }
+    dest = out_dir / rel_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    return {
+        "source": rel_path,
+        "status": "included",
+        "output": str(dest.relative_to(out_dir)),
+        "size_bytes": src.stat().st_size,
+    }
+
+
+def build_security_audit_pack(root: Path, out_dir: Path, *, strict: bool = False) -> dict[str, Any]:
+    sources = [
+        "data/security/security_events.jsonl",
+        "data/security/authority_ledger.json",
+        "artifacts/disr_demo/security_events.jsonl",
+        "artifacts/disr_demo/authority_ledger.json",
+        "artifacts/disr_demo/disr_demo_summary.json",
+        "release_kpis/SECURITY_GATE_REPORT.md",
+        "release_kpis/SECURITY_GATE_REPORT.json",
+        "release_kpis/security_metrics.json",
+        "release_kpis/scalability_metrics.json",
+        "governance/security_crypto_policy.json",
+        "schemas/core/security_crypto_policy.schema.json",
+        "schemas/core/crypto_envelope.schema.json",
+        "docs/docs/security/DISR.md",
+        "docs/docs/security/KEY_LIFECYCLE.md",
+        "docs/docs/security/RECOVERY_RUNBOOK.md",
+        "docs/docs/security/ENVELOPE_VERSIONING.md",
+    ]
+
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    items = [_copy_source(root, out_dir, rel_path) for rel_path in sources]
+    missing = [item for item in items if item["status"] == "missing"]
+    included = [item for item in items if item["status"] == "included"]
+
+    versions = {
+        "generated_at": _utc_now_iso(),
+        "git_commit": _git_commit(root),
+        "release_version": _release_version(root),
+    }
+    (out_dir / "versions.json").write_text(json.dumps(versions, indent=2) + "\n", encoding="utf-8")
+
+    manifest = {
+        "schema_version": "1.0",
+        "artifact": "security_audit_pack",
+        "created_at": versions["generated_at"],
+        "root": str(root),
+        "counts": {
+            "included": len(included),
+            "missing": len(missing),
+        },
+        "files": items,
+        "versions": versions,
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    if strict and missing:
+        missing_paths = ", ".join(item["source"] for item in missing)
+        raise RuntimeError(f"Missing required audit pack sources: {missing_paths}")
+
+    return manifest
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build security_audit_pack from DISR artifacts")
+    parser.add_argument("--out-dir", default="security_audit_pack", help="Output directory")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if any expected source artifact is missing",
+    )
+    args = parser.parse_args()
+
+    out_dir = (ROOT / args.out_dir).resolve()
+    manifest = build_security_audit_pack(ROOT, out_dir, strict=args.strict)
+    print(json.dumps(manifest["counts"], indent=2))
+    print(f"Wrote: {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_security_audit_pack.py
+++ b/tests/test_security_audit_pack.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module(repo_root: Path):
+    mod_path = repo_root / "scripts" / "security_audit_pack.py"
+    spec = importlib.util.spec_from_file_location("security_audit_pack", mod_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_security_audit_pack_collects_expected_files(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "release_kpis").mkdir(parents=True, exist_ok=True)
+    (repo / "governance").mkdir(parents=True, exist_ok=True)
+    (repo / "schemas" / "core").mkdir(parents=True, exist_ok=True)
+    (repo / "docs" / "docs" / "security").mkdir(parents=True, exist_ok=True)
+    (repo / "data" / "security").mkdir(parents=True, exist_ok=True)
+
+    (repo / "release_kpis" / "VERSION.txt").write_text("v2.0.5\n", encoding="utf-8")
+    (repo / "release_kpis" / "security_metrics.json").write_text('{"ok":true}\n', encoding="utf-8")
+    (repo / "release_kpis" / "SECURITY_GATE_REPORT.md").write_text("# ok\n", encoding="utf-8")
+    (repo / "governance" / "security_crypto_policy.json").write_text("{}", encoding="utf-8")
+    (repo / "schemas" / "core" / "security_crypto_policy.schema.json").write_text("{}", encoding="utf-8")
+    (repo / "schemas" / "core" / "crypto_envelope.schema.json").write_text("{}", encoding="utf-8")
+    (repo / "docs" / "docs" / "security" / "DISR.md").write_text("# DISR\n", encoding="utf-8")
+    (repo / "docs" / "docs" / "security" / "KEY_LIFECYCLE.md").write_text("# KEY\n", encoding="utf-8")
+    (repo / "docs" / "docs" / "security" / "RECOVERY_RUNBOOK.md").write_text("# REC\n", encoding="utf-8")
+    (repo / "docs" / "docs" / "security" / "ENVELOPE_VERSIONING.md").write_text("# ENV\n", encoding="utf-8")
+    (repo / "data" / "security" / "security_events.jsonl").write_text('{"event":"x"}\n', encoding="utf-8")
+    (repo / "data" / "security" / "authority_ledger.json").write_text("[]\n", encoding="utf-8")
+
+    module = _load_module(Path(__file__).resolve().parents[1])
+    out_dir = repo / "security_audit_pack"
+    manifest = module.build_security_audit_pack(repo, out_dir, strict=False)
+
+    assert (out_dir / "manifest.json").exists()
+    assert (out_dir / "versions.json").exists()
+    assert (out_dir / "governance" / "security_crypto_policy.json").exists()
+    assert manifest["counts"]["included"] > 0
+
+
+def test_build_security_audit_pack_strict_raises_on_missing(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    module = _load_module(Path(__file__).resolve().parents[1])
+    out_dir = repo / "security_audit_pack"
+    try:
+        module.build_security_audit_pack(repo, out_dir, strict=True)
+        assert False, "expected strict mode to fail on missing files"
+    except RuntimeError as exc:
+        assert "Missing required audit pack sources" in str(exc)
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["counts"]["missing"] >= 1


### PR DESCRIPTION
## Summary
- add `scripts/security_audit_pack.py` to generate a shareable `security_audit_pack/` bundle
- export events, authority ledger, security/scalability metrics, policy/config artifacts, and security docs
- emit `manifest.json` and `versions.json` for reconstructable audit evidence
- wire `make security-audit-pack` target into `Makefile`
- integrate audit pack into `scripts/pilot_pack.py` so `pilot_pack/security_audit_pack/` is included
- add tests for audit pack generation and strict-mode behavior

## Validation
- `python -m pytest tests/test_security_audit_pack.py -q`
- `python -m ruff check scripts/security_audit_pack.py scripts/pilot_pack.py tests/test_security_audit_pack.py`
- `make security-audit-pack`

Closes #291
