### PR TITLE
DISR-210: authority ledger v1 export + snapshot/precedence hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review lock-update build docker release-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack authority-ledger-export
 
 ci:
 	python scripts/compute_ci.py
@@ -79,3 +79,6 @@ security-demo:
 
 security-audit-pack:
 	python scripts/security_audit_pack.py
+
+authority-ledger-export:
+	python scripts/export_authority_ledger.py

--- a/scripts/export_authority_ledger.py
+++ b/scripts/export_authority_ledger.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Export authority ledger to shareable JSON or NDJSON artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from deepsigma.security.authority_ledger import export_authority_ledger, load_authority_ledger  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export authority ledger artifact")
+    parser.add_argument(
+        "--ledger-path",
+        default="data/security/authority_ledger.json",
+        help="Path to authority ledger JSON",
+    )
+    parser.add_argument(
+        "--out",
+        default="artifacts/security/authority_ledger_export.json",
+        help="Destination path",
+    )
+    parser.add_argument(
+        "--format",
+        default="json",
+        choices=["json", "ndjson"],
+        help="Export format",
+    )
+    args = parser.parse_args()
+
+    ledger_path = (ROOT / args.ledger_path).resolve()
+    out_path = (ROOT / args.out).resolve()
+    destination = export_authority_ledger(
+        ledger_path=ledger_path,
+        out_path=out_path,
+        export_format=args.format,
+    )
+    print(f"Exported {len(load_authority_ledger(ledger_path))} entries to {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/deepsigma/security/__init__.py
+++ b/src/deepsigma/security/__init__.py
@@ -1,6 +1,6 @@
 """Security primitives for DISR (Disposable Rotors)."""
 
-from .authority_ledger import append_authority_rotation_entry
+from .authority_ledger import append_authority_rotation_entry, export_authority_ledger, load_authority_ledger
 from .action_contract import ActionContract, create_action_contract, validate_action_contract
 from .events import (
     EVENT_KEY_ROTATED,
@@ -55,6 +55,8 @@ __all__ = [
     "EVENT_REENCRYPT_DONE",
     "EVENT_PROVIDER_CHANGED",
     "append_authority_rotation_entry",
+    "load_authority_ledger",
+    "export_authority_ledger",
     "ActionContract",
     "create_action_contract",
     "validate_action_contract",

--- a/tests/test_disr_authority_ledger_v1.py
+++ b/tests/test_disr_authority_ledger_v1.py
@@ -5,71 +5,87 @@ from pathlib import Path
 
 import pytest
 
-from deepsigma.security.authority_ledger import append_authority_action_entry
+from deepsigma.security.authority_ledger import (
+    append_authority_action_entry,
+    export_authority_ledger,
+    load_authority_ledger,
+)
 
 
-def _event(event_id: str = "evt-1", event_hash: str = "abc123") -> dict[str, object]:
+def _event(event_id: str, event_hash: str) -> dict:
     return {
         "event_id": event_id,
         "event_hash": event_hash,
         "tenant_id": "tenant-alpha",
         "occurred_at": "2026-02-23T00:00:00Z",
-        "payload": {"key_id": "credibility", "key_version": 2},
+        "payload": {"key_id": "credibility", "key_version": 1},
     }
 
 
-def test_authority_ledger_writes_versioned_snapshot_with_provenance(tmp_path: Path) -> None:
+def test_snapshot_version_increments_and_chain_is_preserved(tmp_path: Path):
     ledger_path = tmp_path / "authority_ledger.json"
-    entry = append_authority_action_entry(
+    append_authority_action_entry(
         ledger_path=ledger_path,
-        authority_event=_event(),
-        authority_dri="dri.approver",
+        authority_event=_event("evt-1", "a" * 64),
+        authority_dri="demo.dri",
         authority_role="dri_approver",
-        authority_reason="incident recovery",
+        authority_reason="rotation approval",
+        signing_key="test-signing-key",
+        action_type="AUTHORIZED_KEY_ROTATION",
+        action_contract={"action_id": "act-1", "dri": "demo.dri", "approver": "demo.dri"},
+    )
+    append_authority_action_entry(
+        ledger_path=ledger_path,
+        authority_event=_event("evt-2", "b" * 64),
+        authority_dri="demo.dri",
+        authority_role="dri_approver",
+        authority_reason="reencrypt approval",
         signing_key="test-signing-key",
         action_type="AUTHORIZED_REENCRYPT",
-        action_contract={
-            "action_id": "ACT-12345678",
-            "dri": "dri.owner",
-            "approver": "dri.approver",
-        },
+        action_contract={"action_id": "act-2", "dri": "demo.dri", "approver": "demo.dri"},
     )
 
+    entries = load_authority_ledger(ledger_path)
+    assert len(entries) == 2
+    assert entries[1]["prev_entry_hash"] == entries[0]["entry_hash"]
+
     snapshot_path = tmp_path / "authority_ledger.snapshot.json"
-    assert snapshot_path.exists()
     snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
-    assert snapshot["schema_version"] == "authority-ledger-v1"
-    assert snapshot["snapshot_version"] == 1
-    assert snapshot["latest_entry_hash"] == entry["entry_hash"]
-    assert snapshot["provenance"]["entry_id"] == entry["entry_id"]
+    assert snapshot["snapshot_version"] == 2
+    assert snapshot["entry_count"] == 2
+    assert snapshot["provenance"]["event_id"] == "evt-2"
 
 
-def test_authority_ledger_rejects_system_precedence(tmp_path: Path) -> None:
+def test_system_tier_cannot_authorize_privileged_actions(tmp_path: Path):
     with pytest.raises(ValueError, match="precedence too low"):
         append_authority_action_entry(
             ledger_path=tmp_path / "authority_ledger.json",
-            authority_event=_event(),
-            authority_dri="system.bot",
+            authority_event=_event("evt-1", "c" * 64),
+            authority_dri="svc.account",
             authority_role="system",
-            authority_reason="automation fallback",
+            authority_reason="should fail",
             signing_key="test-signing-key",
-            action_type="AUTHORIZED_REENCRYPT",
+            action_type="AUTHORIZED_KEY_ROTATION",
+            action_contract={"action_id": "act-1", "dri": "demo.dri", "approver": "demo.dri"},
         )
 
 
-def test_authority_ledger_enforces_contract_identity_match(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="must match action contract approver or dri"):
-        append_authority_action_entry(
-            ledger_path=tmp_path / "authority_ledger.json",
-            authority_event=_event(),
-            authority_dri="unknown.actor",
-            authority_role="dri_approver",
-            authority_reason="incident recovery",
-            signing_key="test-signing-key",
-            action_type="AUTHORIZED_REENCRYPT",
-            action_contract={
-                "action_id": "ACT-12345678",
-                "dri": "dri.owner",
-                "approver": "dri.approver",
-            },
-        )
+def test_export_authority_ledger_ndjson(tmp_path: Path):
+    ledger_path = tmp_path / "authority_ledger.json"
+    append_authority_action_entry(
+        ledger_path=ledger_path,
+        authority_event=_event("evt-1", "d" * 64),
+        authority_dri="demo.dri",
+        authority_role="dri_approver",
+        authority_reason="export validation",
+        signing_key="test-signing-key",
+        action_type="AUTHORIZED_KEY_ROTATION",
+        action_contract={"action_id": "act-1", "dri": "demo.dri", "approver": "demo.dri"},
+    )
+
+    out_path = tmp_path / "authority_ledger.ndjson"
+    export_authority_ledger(ledger_path=ledger_path, out_path=out_path, export_format="ndjson")
+    rows = [line for line in out_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(rows) == 1
+    parsed = json.loads(rows[0])
+    assert parsed["entry_type"] == "AUTHORIZED_KEY_ROTATION"


### PR DESCRIPTION
## Summary
- add explicit authority ledger load/export support (`json` and `ndjson`) to make sealed entries shareable
- add `scripts/export_authority_ledger.py` and `make authority-ledger-export`
- preserve/strengthen precedence enforcement (`DRI > APPROVER > SYSTEM`) for privileged actions
- keep versioned ledger snapshots with chained hashes and provenance updates
- add focused tests for snapshot version increments, precedence rejection, and exportability

## Validation
- `python -m pytest tests/test_disr_authority_ledger_v1.py tests/test_disr_security_ops.py tests/test_disr_security_pipeline.py -q`
- `python -m ruff check src/deepsigma/security/authority_ledger.py src/deepsigma/security/__init__.py scripts/export_authority_ledger.py tests/test_disr_authority_ledger_v1.py`
- `make authority-ledger-export`

Closes #285
