### PR TITLE
DISR-210: benchmark regression suite with metric history + scheduled CI

### DIFF
--- a/.github/workflows/reencrypt_benchmark.yml
+++ b/.github/workflows/reencrypt_benchmark.yml
@@ -1,0 +1,34 @@
+name: DISR Reencrypt Benchmark
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 3 * * *"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run benchmark suite
+        run: |
+          make security-demo
+          make reencrypt-benchmark ARGS="--records 20000 --reset-dataset"
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: disr-benchmark
+          path: |
+            release_kpis/security_metrics.json
+            release_kpis/scalability_metrics.json
+            release_kpis/benchmark_history.json
+            artifacts/benchmarks/reencrypt/benchmark_summary.json
+            artifacts/benchmarks/reencrypt/security_events.jsonl
+            artifacts/benchmarks/reencrypt/authority_ledger.json

--- a/scripts/security_audit_pack.py
+++ b/scripts/security_audit_pack.py
@@ -66,6 +66,7 @@ def build_security_audit_pack(root: Path, out_dir: Path, *, strict: bool = False
         "release_kpis/SECURITY_GATE_REPORT.json",
         "release_kpis/security_metrics.json",
         "release_kpis/scalability_metrics.json",
+        "release_kpis/benchmark_history.json",
         "governance/security_crypto_policy.json",
         "schemas/core/security_crypto_policy.schema.json",
         "schemas/core/crypto_envelope.schema.json",


### PR DESCRIPTION
## Summary
- extend `scripts/reencrypt_benchmark.py` to emit both:
  - `release_kpis/scalability_metrics.json`
  - `release_kpis/security_metrics.json`
- add append-only benchmark history output: `release_kpis/benchmark_history.json`
- include benchmark history artifact in `scripts/security_audit_pack.py`
- add scheduled/manual benchmark workflow: `.github/workflows/reencrypt_benchmark.yml`
- add tests validating security metrics + history behavior

## Validation
- `python -m pytest tests/test_reencrypt_benchmark_metrics.py tests/test_kpi_compute_security_metrics.py tests/test_security_audit_pack.py -q`
- `python -m ruff check scripts/reencrypt_benchmark.py scripts/security_audit_pack.py tests/test_reencrypt_benchmark_metrics.py`
- `make reencrypt-benchmark ARGS="--records 1000 --reset-dataset --history-out release_kpis/benchmark_history.json --security-metrics-out release_kpis/security_metrics.json"`

Closes #289
