### PR TITLE
Fix CodeQL: explicit permissions in benchmark workflow

### DIFF
--- a/.github/workflows/reencrypt_benchmark.yml
+++ b/.github/workflows/reencrypt_benchmark.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "30 3 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit least-privilege workflow permissions to \.github/workflows/reencrypt_benchmark.yml
- Resolves CodeQL alert for missing workflow permissions

## Change
- Added:\n  permissions:\n    contents: read

## Validation
- Workflow-only metadata change; no runtime logic modified.