### PR TITLE
Harden release flow: strict tag preflight before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,26 @@ jobs:
           path: dashboard/dist/
           retention-days: 5
 
+  release-preflight:
+    name: Release Preflight (tag integrity)
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+      - name: Validate release metadata + tag points to main HEAD
+        run: make release-check-strict
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests, validation-gates, lint, dashboard-build]
+    needs: [unit-tests, integration-tests, validation-gates, lint, dashboard-build, release-preflight]
     if: startsWith(github.ref, 'refs/tags/v')
     environment: pypi
     permissions:
@@ -241,7 +257,7 @@ jobs:
   release-artifacts:
     name: Release Artifacts + GHCR
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests, validation-gates, lint, dashboard-build]
+    needs: [unit-tests, integration-tests, validation-gates, lint, dashboard-build, release-preflight]
     if: startsWith(github.ref, 'refs/tags/v')
     outputs:
       image_digest: ${{ steps.build-image.outputs.digest }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review tec lock-update build docker release-check version-sync-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack authority-ledger-export
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review tec lock-update build docker release-check release-check-strict version-sync-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack authority-ledger-export
 
 ci:
 	python scripts/compute_ci.py
@@ -57,6 +57,9 @@ docker:
 
 release-check:
 	python scripts/release_check.py
+
+release-check-strict:
+	RELEASE_CHECK_REQUIRE_MAIN_HEAD=1 python scripts/release_check.py
 
 version-sync-check:
 	python scripts/check_release_version_sync.py


### PR DESCRIPTION
## Summary
- Adds a dedicated `release-preflight` CI job for tag builds
- Enforces strict release checks before publish jobs start
- Requires release tag commit to match `origin/main` HEAD

## Details
- `scripts/release_check.py`: adds `--require-main-head` / `RELEASE_CHECK_REQUIRE_MAIN_HEAD=1`
- `Makefile`: adds `release-check-strict`
- `.github/workflows/ci.yml`: adds `release-preflight` and makes `publish` + `release-artifacts` depend on it

## Why
Prevents stale/mis-pointed tags from reaching PyPI/GHCR publish steps.

## Validation
- `python scripts/release_check.py --tag v2.0.6 --require-main-head`
- `python -m py_compile scripts/release_check.py`
