### PR TITLE
Docs: Wiki structure refresh and navigation cleanup

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -23,7 +23,7 @@ Transport options:
 - **MCP server** (recommended) or MCP gateway
 - Direct adapters (LangChain callbacks/tool wrappers)
 
-See also: [Runtime Flow](Runtime-Flow.md)
+See also: [Runtime Flow](Runtime-Flow)
 
 Mermaid diagrams:
 - [System Architecture](../mermaid/01-system-architecture.md)

--- a/docs/wiki/Creative-Director-Suite.md
+++ b/docs/wiki/Creative-Director-Suite.md
@@ -122,7 +122,7 @@ See [Excel-First Governance](Excel-First-Governance) for the full BOOT!A1 spec, 
 | Boot Protocol spec | `docs/excel-first/WORKBOOK_BOOT_PROTOCOL.md` |
 | Table Schemas | `docs/excel-first/TABLE_SCHEMAS.md` |
 | 6-Lens Prompting | `docs/excel-first/multi-dim-prompting-for-teams/README.md` |
-| Release Notes | `release/RELEASE_NOTES_v0.6.2.md` |
+| Release Notes | [RELEASE_NOTES_v0.6.2.md](../release/RELEASE_NOTES_v0.6.2.md) |
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -11,6 +11,7 @@ It enforces deadlines, freshness, safe actions, and verification — then seals 
 
 | Page | Purpose |
 |------|---------|
+| [Wiki Index](Wiki-Index) | Canonical wiki structure and navigation |
 | [Quickstart](Quickstart) | Get a supervised agent running in minutes |
 | [Concepts](Concepts) | The four problems RAL solves and the primitives that solve them |
 | [Architecture](Architecture) | System diagram and component map |
@@ -118,7 +119,8 @@ Captures AI interaction exhaust (prompts, completions, tool calls, metrics) and 
 | KPI composite radar | [release_kpis/radar_composite_latest.png](../../release_kpis/radar_composite_latest.png) |
 | KPI delta table | [release_kpis/radar_composite_latest.md](../../release_kpis/radar_composite_latest.md) |
 | TEC summary (C-TEC v1.0) | [release_kpis/TEC_SUMMARY.md](../../release_kpis/TEC_SUMMARY.md) |
-| C-TEC mermaid flow | [mermaid/12-c-tec-pipeline.md](../mermaid/12-c-tec-pipeline.md) |
+| Mermaid canonical index | [docs/mermaid/README.md](../mermaid/README.md) |
+| Mermaid archive index | [docs/archive/mermaid/ARCHIVE_INDEX.md](../archive/mermaid/ARCHIVE_INDEX.md) |
 
 ---
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -1,12 +1,37 @@
 # Roadmap
 
-Near-term:
-- Full MCP handshake implementation + schema validation
-- Wire policy packs into all episode emissions
-- Verifier plugins + inconclusive handling rules
-- Drift fingerprints → Patch Packets (auto-generated)
+Current roadmap is organized into four execution tracks.
 
-Mid-term:
-- Signed policy packs
-- OpenTelemetry reference exporter
-- Replay harness that invokes real adapters
+## Track A — Credibility Hardening (v2.0.7)
+
+- KPI confidence bands (score + uncertainty)
+- KPI evidence-tier gating (simulated/real/production)
+- Stale artifact kill-switch in CI
+- Security posture proof-pack hardening
+
+## Track B — Adoption Wedge (v2.0.8)
+
+- `make try` 10-minute pilot mode
+- Decision Office scaffolding templates
+- Shareable pilot distribution pack
+
+## Track C — Enterprise Integration (v2.1.0-pre)
+
+- GitHub Issues -> DLR mapping
+- SharePoint/Teams export mode
+- Jira import/export adapter
+
+## Track D — DISR Architecture Expansion (v2.1.0)
+
+- Dual-mode crypto providers (local default + optional KMS)
+- Authority-bound action contracts
+- Streaming re-encrypt with checkpoint/resume
+- Signed telemetry event chain and exportable audit pack
+
+## Release Proof Requirements
+
+- Version parity across `pyproject.toml`, release notes, and KPI artifacts
+- Reproducible KPI pipeline output (`release_kpis/`)
+- Security gate and issue-label gate passing
+- Pilot evidence pack generated and linked
+

--- a/docs/wiki/Wiki-Index.md
+++ b/docs/wiki/Wiki-Index.md
@@ -1,0 +1,73 @@
+# Wiki Index
+
+Canonical wiki structure for Sigma OVERWATCH / DeepSigma docs.
+
+## Start
+
+- [Home](Home)
+- [Quickstart](Quickstart)
+- [FAQ](FAQ)
+- [Architecture](Architecture)
+
+## Runtime + Governance Core
+
+- [Concepts](Concepts)
+- [Contracts](Contracts)
+- [Runtime Flow](Runtime-Flow)
+- [Sealing & Episodes](Sealing-and-Episodes)
+- [Drift -> Patch](Drift-to-Patch)
+- [Coherence Ops Mapping](Coherence-Ops-Mapping)
+- [IRIS](IRIS)
+
+## Data Model + Schemas
+
+- [Schemas](Schemas)
+- [Episode Schema](Episode-Schema)
+- [DTE Schema](DTE-Schema)
+- [Action Contract Schema](Action-Contract-Schema)
+- [Drift Schema](Drift-Schema)
+- [Policy Pack Schema](Policy-Pack-Schema)
+- [Unified Atomic Claims](Unified-Atomic-Claims)
+- [Canon](Canon)
+- [Retcon](Retcon)
+
+## Integrations
+
+- [Integrations](Integrations)
+- [MCP](MCP)
+- [LangChain](LangChain)
+- [OpenTelemetry](OpenTelemetry)
+- [Palantir Foundry](Palantir-Foundry)
+- [Power Platform](Power-Platform)
+- [AskSage](AskSage)
+- [Snowflake](Snowflake)
+
+## Operations + Security
+
+- [Operations](Operations)
+- [SLOs and Metrics](SLOs-and-Metrics)
+- [Replay and Testing](Replay-and-Testing)
+- [Security](Security)
+
+## Release + Evidence
+
+- [Release Notes v2.0.6](../release/RELEASE_NOTES_v2.0.6.md)
+- [Repo Radar Composite](../../release_kpis/radar_composite_latest.png)
+- [Repo Radar Delta](../../release_kpis/radar_composite_latest.md)
+- [TEC Summary](../../release_kpis/TEC_SUMMARY.md)
+- [Mermaid Canonical Index](../mermaid/README.md)
+- [Mermaid Archive Index](../archive/mermaid/ARCHIVE_INDEX.md)
+
+## Domain Packs
+
+- [Exhaust Inbox](Exhaust-Inbox)
+- [Excel-First Governance](Excel-First-Governance)
+- [Creative Director Suite](Creative-Director-Suite)
+- [LLM Data Model](LLM-Data-Model)
+
+## Meta
+
+- [Roadmap](Roadmap)
+- [Glossary](Glossary)
+- [Contributing](Contributing)
+

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,1 +1,1 @@
-Σ OVERWATCH / RAL — Reality Await Layer • Ideas spark. Persistence builds. Deep Sigma delivers.
+Σ OVERWATCH / RAL — Reality Await Layer • Current release: [v2.0.6](../release/RELEASE_NOTES_v2.0.6.md) • DeepSigma

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,5 +1,6 @@
 - **Start**
   - [Home](Home)
+  - [Wiki Index](Wiki-Index)
   - [Quickstart](Quickstart)
   - [FAQ](FAQ)
 - **Core**
@@ -38,6 +39,8 @@
   - [Operations](Operations)
   - [SLOs & Metrics](SLOs-and-Metrics)
   - [Release Notes v2.0.6](../release/RELEASE_NOTES_v2.0.6.md)
+  - [Repo Radar Composite](../../release_kpis/radar_composite_latest.png)
+  - [TEC Summary](../../release_kpis/TEC_SUMMARY.md)
   - [Replay & Testing](Replay-and-Testing)
 - **Excel-First**
   - [Creative Director Suite](Creative-Director-Suite)


### PR DESCRIPTION
## Summary\n- add canonical wiki index page\n- update Home and Sidebar navigation with release/evidence surfaces\n- fix stale release link in Creative Director Suite\n- refresh roadmap to current A-D tracks\n- update wiki footer release pointer\n\n## Validation\n- python src/tools/mermaid_audit.py (PASS)