### PR TITLE
v2.1.0: decision infrastructure hardening framing (A+B+D+C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ See: [docs/release/RELEASE_NOTES_v2.0.6.md](docs/release/RELEASE_NOTES_v2.0.6.md
 - Authority-bound contract enforcement expansion
 - Integration schema finalization
 
+## Positioning Shift
+- Not AI governance tooling
+- Not compliance software
+- **Decision Infrastructure**
+- **Institutional Accountability Engine**
+- Positioning manifesto: [docs/positioning/positioning_manifesto.md](docs/positioning/positioning_manifesto.md)
+- Executive briefing: [docs/positioning/executive_briefing_one_page.md](docs/positioning/executive_briefing_one_page.md)
+- Architecture model: [specs/decision_infrastructure_model.md](specs/decision_infrastructure_model.md)
+- Layer-to-KPI map: [release_kpis/layer_kpi_mapping.json](release_kpis/layer_kpi_mapping.json)
+
 **Institutional Decision Infrastructure**
 
 *Trust layer for agentic AI: verify before act, seal what happened, detect drift, ship patches.*

--- a/docs/positioning/executive_briefing_one_page.md
+++ b/docs/positioning/executive_briefing_one_page.md
@@ -1,0 +1,44 @@
+# Executive Briefing (One Page): Decision Infrastructure
+
+## Framing
+
+DeepSigma provides **Decision Infrastructure** for AI-enabled institutions.
+It ensures decisions are accountable before execution, reconstructable after execution, and correctable over time.
+
+## Problem
+
+AI increases decision velocity while reducing natural accountability.
+Without structural controls, organizations inherit four failure modes:
+
+- non-replayable outcomes
+- missing pre-action intent
+- narrative-dependent audit logic
+- execution without provable authority
+
+## Solution
+
+DeepSigma enforces a layered accountability model:
+
+- Layer 0: Intent (explicit, signed, TTL-bound)
+- Layer 1: Audit-neutral logic (claim/evidence/authority invariants)
+- Layer 2: Pre-execution gate (fail closed)
+- Layer 3: Runtime safety (monitoring, drift, observability)
+
+## Evidence Model
+
+- KPI claims are tier-capped by artifact eligibility
+- confidence and uncertainty bands are produced per KPI
+- nonlinear stability (SSI + drift acceleration) quantifies fragility
+- TEC/C-TEC provides cost realism with variance bands
+
+## Executive Value
+
+- faster high-stakes decisions with lower governance debt
+- reduced audit risk through mechanically reconstructable evidence
+- shorter incident-to-recovery cycle via drift-to-patch discipline
+- clearer capital allocation through quantified fragility and cost variance
+
+## Adoption Requirement
+
+Treat DeepSigma as infrastructure, not a dashboard.
+Institutional value appears only when pre-execution gates and replayability are non-optional.

--- a/docs/positioning/positioning_manifesto.md
+++ b/docs/positioning/positioning_manifesto.md
@@ -1,0 +1,43 @@
+# Positioning Manifesto: Decision Infrastructure
+
+DeepSigma is not "AI governance tooling" and not "compliance software."
+
+DeepSigma is **Decision Infrastructure**: the system layer that binds institutional intent, authority, evidence, execution, and outcomes into one reconstructable chain.
+
+## Why This Category Exists
+
+Most organizations can answer one of these questions, not all three:
+
+- What did we do?
+- Why did we do it?
+- Can we prove the decision chain under adversarial review?
+
+Decision Infrastructure exists to make all three answerable from sealed artifacts, not memory.
+
+## The Operating Principle
+
+Every consequential action must satisfy this contract:
+
+- intent is explicit before execution
+- authority is verified before execution
+- logic is auditable without narrative context
+- outcomes are sealed and replayable
+
+## What We Refuse
+
+- post-hoc storytelling as governance
+- unverifiable "trust me" decisions
+- score inflation without evidence eligibility
+- runtime convenience that bypasses accountability
+
+## What We Build
+
+- intent packets and authority contracts
+- pre-execution gates that fail closed
+- claim -> evidence -> authority validators
+- deterministic replay and sealed decision episodes
+- drift-to-patch loops with measurable recovery
+
+## Category Statement
+
+DeepSigma is an **Institutional Accountability Engine** implemented as **Decision Infrastructure**.

--- a/release_kpis/layer_kpi_mapping.json
+++ b/release_kpis/layer_kpi_mapping.json
@@ -1,0 +1,6 @@
+{
+  "Layer_0_Intent": ["authority_modeling", "operational_maturity"],
+  "Layer_1_AuditLogic": ["technical_completeness", "enterprise_readiness"],
+  "Layer_2_PreExecution": ["automation_depth", "authority_modeling"],
+  "Layer_3_RuntimeSafety": ["operational_maturity"]
+}

--- a/specs/decision_infrastructure_model.md
+++ b/specs/decision_infrastructure_model.md
@@ -1,0 +1,33 @@
+# Decision Infrastructure Model
+
+## Layer 0 - Intent Layer
+
+- `intent_packet.json` required
+- TTL enforced
+- authority signature required
+- intent hash binding mandatory
+
+## Layer 1 - Audit-Neutral Logic
+
+- Claim -> Evidence -> Authority binding
+- Decision invariants ledger
+- Assumption half-life enforcement
+- Seal -> version -> patch (no overwrite)
+
+## Layer 2 - Pre-Execution Accountability Gate
+
+Execution blocked unless:
+
+- Valid intent
+- Valid authority
+- Policy satisfied
+- Environment fingerprint sealed
+- Input snapshot sealed
+- Idempotency key valid
+
+## Layer 3 - Runtime Safety (Subordinate)
+
+- Monitoring
+- Rate limiting
+- Drift detection
+- Observability


### PR DESCRIPTION
## What this ships
- Adds layered architecture spec for decision infrastructure (`specs/decision_infrastructure_model.md`)
- Adds layer-to-KPI mapping artifact (`release_kpis/layer_kpi_mapping.json`)
- Adds positioning manifesto + one-page executive briefing (`docs/positioning/positioning_manifesto.md`, `docs/positioning/executive_briefing_one_page.md`)
- Updates README with explicit positioning shift and links to the new artifacts

## External gate
- Created milestone issue: #358

## Why
This formalizes A+B+D from the hardening plan and implements C narrative framing without changing runtime behavior.
