### PR TITLE
Build 87: enforce v2.1.0 milestone gate + layer coverage KPI wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Enforce version sync (pyproject vs release_kpis/VERSION.txt)
         run: make version-sync-check
 
+      - name: Milestone Gate (v2.1.0 hardening)
+        run: make milestone-gate
+
       - name: Validate examples against schemas
         run: |
           python src/tools/validate_examples.py

--- a/.github/workflows/kpi.yml
+++ b/.github/workflows/kpi.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Run KPI issue deltas
         run: |
+          make milestone-gate
           make issue-label-gate
           make kpi-issues
           make roadmap-gate

--- a/.github/workflows/kpi_gate.yml
+++ b/.github/workflows/kpi_gate.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Run KPI issue deltas
         run: |
+          make milestone-gate
           make issue-label-gate
           make kpi-issues
           make roadmap-gate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review tec lock-update build docker release-check release-check-strict version-sync-check pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack authority-ledger-export roadmap-forecast roadmap-badge roadmap-timeline roadmap-gate roadmap-refresh stability kpi-confidence
+.PHONY: ci demo pilot-in-a-box why-60s no-dupes kpi kpi-render kpi-composite kpi-badge kpi-gate kpi-issues issue-label-gate issues-review tec lock-update build docker release-check release-check-strict version-sync-check milestone-gate pilot-pack scale-benchmark reencrypt-benchmark openapi-docs openapi-check security-gate security-demo security-audit-pack authority-ledger-export roadmap-forecast roadmap-badge roadmap-timeline roadmap-gate roadmap-refresh stability kpi-confidence
 
 ci:
 	python scripts/compute_ci.py
@@ -63,6 +63,9 @@ release-check-strict:
 
 version-sync-check:
 	python scripts/check_release_version_sync.py
+
+milestone-gate:
+	python scripts/validate_v2_1_0_milestone.py
 
 pilot-pack:
 	python scripts/pilot_pack.py

--- a/governance/decision_invariants.md
+++ b/governance/decision_invariants.md
@@ -1,0 +1,7 @@
+# Decision Invariants (v2.1.0)
+
+- Claim -> Evidence -> Source required
+- Authority precedence enforced
+- No overwrite: seal -> version -> patch
+- Assumptions expire via TTL / half-life
+

--- a/release_kpis/PR_COMMENT.md
+++ b/release_kpis/PR_COMMENT.md
@@ -36,12 +36,18 @@
 - KPI bands: `release_kpis/kpi_bands_v2.0.6.json`
 
 **TEC (ROM):**
-- Internal: 3071.3 hrs | $460,695
-- Executive: 3071.3 hrs | $691,042
-- DoD: 3071.3 hrs | $844,608
+- Internal: 3087.5 hrs | $463,125
+- Executive: 3087.5 hrs | $694,688
+- DoD: 3087.5 hrs | $849,062
 - Full detail: `release_kpis/TEC_SUMMARY.md`
 
 **Notes:**
 - Some KPIs are auto-derived from repo telemetry (tests, docs, workflows, pilot drills).
 - Economic and Scalability are auto-derived from DISR metrics and capped by evidence eligibility (`kpi_eligible` / `evidence_level`).
 - Authority Modeling remains manual/judgment-based until authority telemetry scoring is wired.
+
+**Layer Coverage (Decision Infrastructure):**
+- Layer_0_Intent: authority_modeling, operational_maturity
+- Layer_1_AuditLogic: technical_completeness, enterprise_readiness
+- Layer_2_PreExecution: automation_depth, authority_modeling
+- Layer_3_RuntimeSafety: operational_maturity

--- a/release_kpis/TEC_SUMMARY.md
+++ b/release_kpis/TEC_SUMMARY.md
@@ -1,25 +1,25 @@
 # TEC Summary (ROM)
 
 ## Counts
-- issues_total: **166**
-- prs_merged: **182**
+- issues_total: **167**
+- prs_merged: **184**
 - workflows: **29**
 - test_files: **99**
-- doc_files: **323**
+- doc_files: **325**
 - security_issues_tagged: **4**
 - committee_cycles_est: **0**
-- issues_with_pr_link_est: **89**
+- issues_with_pr_link_est: **90**
 
 ## Effort (Base hours breakdown)
-- issues_weighted: **1566.8**
-- issues_complexity_weighted: **1970.8**
-- pr_overhead: **273.0**
+- issues_weighted: **1574.8**
+- issues_complexity_weighted: **1981.0**
+- pr_overhead: **276.0**
 - workflows: **145.0**
 - tests: **198.0**
-- docs: **484.5**
+- docs: **487.5**
 - committee: **0.0**
-- total_base: **2667.2**
-- total_ctec: **3071.3**
+- total_base: **2681.2**
+- total_ctec: **3087.5**
 
 ## Complexity (C-TEC v1.0)
 - avg_index: **1.244**
@@ -28,16 +28,16 @@
 
 ## Tiers (Low / Base / High)
 ### Internal @ $150/hr
-- Low:  2457.0 hrs | $368556.0
-- Base: 3071.3 hrs | $460695.0
-- High: 4146.3 hrs | $621938.0
+- Low:  2470.0 hrs | $370500.0
+- Base: 3087.5 hrs | $463125.0
+- High: 4168.1 hrs | $625219.0
 
 ### Executive @ $225/hr
-- Low:  2457.0 hrs | $552834.0
-- Base: 3071.3 hrs | $691042.0
-- High: 4146.3 hrs | $932907.0
+- Low:  2470.0 hrs | $555750.0
+- Base: 3087.5 hrs | $694688.0
+- High: 4168.1 hrs | $937828.0
 
 ### DoD Fully Burdened @ $275/hr
-- Low:  2457.0 hrs | $675686.0
-- Base: 3071.3 hrs | $844608.0
-- High: 4146.3 hrs | $1140220.0
+- Low:  2470.0 hrs | $679250.0
+- Base: 3087.5 hrs | $849062.0
+- High: 4168.1 hrs | $1146234.0

--- a/release_kpis/kpi_trend.svg
+++ b/release_kpis/kpi_trend.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-02-23T11:34:12.696318</dc:date>
+    <dc:date>2026-02-23T11:53:26.406909</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 65.966761 244.078125 
 L 65.966761 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9a6e150c53" d="M 0 0 
+       <path id="me40ce39f5d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9a6e150c53" x="65.966761" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me40ce39f5d" x="65.966761" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -134,11 +134,11 @@ z
      <g id="line2d_3">
       <path d="M 192.784943 244.078125 
 L 192.784943 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9a6e150c53" x="192.784943" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me40ce39f5d" x="192.784943" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -191,11 +191,11 @@ z
      <g id="line2d_5">
       <path d="M 319.603125 244.078125 
 L 319.603125 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9a6e150c53" x="319.603125" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me40ce39f5d" x="319.603125" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -235,11 +235,11 @@ z
      <g id="line2d_7">
       <path d="M 446.421307 244.078125 
 L 446.421307 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9a6e150c53" x="446.421307" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me40ce39f5d" x="446.421307" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -285,11 +285,11 @@ z
      <g id="line2d_9">
       <path d="M 573.239489 244.078125 
 L 573.239489 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9a6e150c53" x="573.239489" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me40ce39f5d" x="573.239489" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -480,16 +480,16 @@ z
      <g id="line2d_11">
       <path d="M 40.603125 244.078125 
 L 598.603125 244.078125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <defs>
-       <path id="m3a73b6b7b7" d="M 0 0 
+       <path id="me013e63bbe" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="244.078125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -503,11 +503,11 @@ L -3.5 0
      <g id="line2d_13">
       <path d="M 40.603125 199.726125 
 L 598.603125 199.726125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="199.726125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="199.726125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -521,11 +521,11 @@ L 598.603125 199.726125
      <g id="line2d_15">
       <path d="M 40.603125 155.374125 
 L 598.603125 155.374125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="155.374125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="155.374125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -539,11 +539,11 @@ L 598.603125 155.374125
      <g id="line2d_17">
       <path d="M 40.603125 111.022125 
 L 598.603125 111.022125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="111.022125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="111.022125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -557,11 +557,11 @@ L 598.603125 111.022125
      <g id="line2d_19">
       <path d="M 40.603125 66.670125 
 L 598.603125 66.670125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="66.670125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="66.670125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -616,11 +616,11 @@ z
      <g id="line2d_21">
       <path d="M 40.603125 22.318125 
 L 598.603125 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3a73b6b7b7" x="40.603125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me013e63bbe" x="40.603125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -797,7 +797,7 @@ L 192.784943 86.074125
 L 319.603125 69.857925 
 L 446.421307 67.085925 
 L 573.239489 67.085925 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_24">
     <path d="M 65.966761 44.494125 
@@ -805,7 +805,7 @@ L 192.784943 22.318125
 L 319.603125 22.318125 
 L 446.421307 22.318125 
 L 573.239489 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_25">
     <path d="M 65.966761 88.846125 
@@ -813,7 +813,7 @@ L 192.784943 111.022125
 L 319.603125 22.318125 
 L 446.421307 22.318125 
 L 573.239489 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_26">
     <path d="M 65.966761 111.022125 
@@ -821,7 +821,7 @@ L 192.784943 111.022125
 L 319.603125 107.695725 
 L 446.421307 107.695725 
 L 573.239489 107.695725 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #d62728; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #d62728; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_27">
     <path d="M 65.966761 155.374125 
@@ -829,7 +829,7 @@ L 192.784943 22.318125
 L 319.603125 22.318125 
 L 446.421307 22.318125 
 L 573.239489 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_28">
     <path d="M 65.966761 155.374125 
@@ -837,7 +837,7 @@ L 192.784943 155.374125
 L 319.603125 131.424045 
 L 446.421307 131.424045 
 L 573.239489 131.424045 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
     <path d="M 65.966761 133.198125 
@@ -845,7 +845,7 @@ L 192.784943 66.670125
 L 319.603125 58.243245 
 L 446.421307 58.243245 
 L 573.239489 58.243245 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
     <path d="M 65.966761 177.550125 
@@ -853,7 +853,7 @@ L 192.784943 177.550125
 L 319.603125 172.227885 
 L 446.421307 150.051885 
 L 573.239489 150.051885 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #7f7f7f; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #7f7f7f; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="line2d_31">
     <path d="M 65.966761 88.846125 
@@ -861,7 +861,7 @@ L 192.784943 22.318125
 L 319.603125 22.318125 
 L 446.421307 22.318125 
 L 573.239489 22.318125 
-" clip-path="url(#p084626a5be)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.65; stroke-linecap: square"/>
+" clip-path="url(#pa970118d68)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.65; stroke-linecap: square"/>
    </g>
    <g id="patch_3">
     <path d="M 40.603125 244.078125 
@@ -1135,7 +1135,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p084626a5be">
+  <clipPath id="pa970118d68">
    <rect x="40.603125" y="22.318125" width="558" height="221.76"/>
   </clipPath>
  </defs>

--- a/release_kpis/radar_composite_latest.svg
+++ b/release_kpis/radar_composite_latest.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-02-23T11:34:13.814733</dc:date>
+    <dc:date>2026-02-23T11:53:27.394037</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -77,7 +77,7 @@ L 153.722644 391.069278
 L 205.833149 276.089812 
 L 131.49511 138.882813 
 z
-" clip-path="url(#p10f4ef6e2e)" style="fill: #1f77b4; opacity: 0.12; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p937da5c6ba)" style="fill: #1f77b4; opacity: 0.12; stroke: #1f77b4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 268.702109 82.049812 
@@ -89,7 +89,7 @@ L 153.722644 391.069278
 L 186.429149 276.089812 
 L 131.49511 138.882813 
 z
-" clip-path="url(#p10f4ef6e2e)" style="fill: #2ca02c; opacity: 0.2; stroke: #2ca02c; stroke-linejoin: miter"/>
+" clip-path="url(#p937da5c6ba)" style="fill: #2ca02c; opacity: 0.2; stroke: #2ca02c; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 268.702109 82.049812 
@@ -101,14 +101,14 @@ L 153.722644 391.069278
 L 186.429149 276.089812 
 L 131.49511 138.882813 
 z
-" clip-path="url(#p10f4ef6e2e)" style="fill: #d62728; opacity: 0.28; stroke: #d62728; stroke-linejoin: miter"/>
+" clip-path="url(#p937da5c6ba)" style="fill: #d62728; opacity: 0.28; stroke: #d62728; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <path d="M 268.702109 276.089812 
 L 268.702109 82.049812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_1">
       <!-- Technical Completeness -->
@@ -443,7 +443,7 @@ z
      <g id="line2d_2">
       <path d="M 268.702109 276.089812 
 L 405.909109 138.882813 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_2">
       <!-- Automation Depth -->
@@ -530,7 +530,7 @@ z
      <g id="line2d_3">
       <path d="M 268.702109 276.089812 
 L 462.742109 276.089812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_3">
       <!-- Authority Modeling -->
@@ -672,7 +672,7 @@ z
      <g id="line2d_4">
       <path d="M 268.702109 276.089812 
 L 405.909109 413.296812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_4">
       <!-- Enterprise Readiness -->
@@ -749,7 +749,7 @@ z
      <g id="line2d_5">
       <path d="M 268.702109 276.089812 
 L 268.702109 470.129812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_5">
       <!-- Scalability -->
@@ -831,7 +831,7 @@ z
      <g id="line2d_6">
       <path d="M 268.702109 276.089812 
 L 131.49511 413.296812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_6">
       <!-- Data Integration -->
@@ -868,7 +868,7 @@ z
      <g id="line2d_7">
       <path d="M 268.702109 276.089812 
 L 74.662109 276.089812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_7">
       <!-- Economic Measurability -->
@@ -902,7 +902,7 @@ L 74.662109 276.089812
      <g id="line2d_8">
       <path d="M 268.702109 276.089812 
 L 131.49511 138.882813 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_8">
       <!-- Operational Maturity -->
@@ -974,7 +974,7 @@ C 229.894109 270.993593 230.897954 265.946927 232.848192 261.238634
 C 234.798431 256.530341 237.657138 252.251984 241.260709 248.648413 
 C 244.864281 245.044841 249.142638 242.186135 253.850931 240.235896 
 C 258.559224 238.285657 263.60589 237.281812 268.702109 237.281812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_9">
       <!-- 2 -->
@@ -1028,7 +1028,7 @@ C 191.086109 265.897373 193.093798 255.804042 196.994276 246.387455
 C 200.894753 236.970869 206.612166 228.414156 213.819309 221.207013 
 C 221.026453 213.999869 229.583166 208.282457 238.999752 204.381979 
 C 248.416339 200.481501 258.50967 198.473812 268.702109 198.473812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_10">
       <!-- 4 -->
@@ -1077,7 +1077,7 @@ C 152.278109 260.801153 155.289642 245.661156 161.140359 231.536277
 C 166.991075 217.411397 175.567195 204.576327 186.377909 193.765613 
 C 197.188624 182.954898 210.023694 174.378779 224.148573 168.528062 
 C 238.273453 162.677345 253.41345 159.665812 268.702109 159.665812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_11">
       <!-- 6 -->
@@ -1137,7 +1137,7 @@ C 113.470109 255.704933 117.485486 235.518271 125.286442 216.685098
 C 133.087397 197.851925 144.522223 180.738499 158.93651 166.324213 
 C 173.350796 151.909926 190.464222 140.475101 209.297395 132.674145 
 C 228.130568 124.873189 248.31723 120.857812 268.702109 120.857812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_12">
       <!-- 8 -->
@@ -1206,7 +1206,7 @@ C 74.662109 250.608713 79.68133 225.375385 89.432525 201.833919
 C 99.183719 178.292453 113.477251 156.900671 131.49511 138.882813 
 C 149.512968 120.864955 170.90475 106.571423 194.446216 96.820228 
 C 217.987682 87.069033 243.22101 82.049812 268.702109 82.049812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_13">
       <!-- 10 -->
@@ -1264,7 +1264,7 @@ L 153.722644 391.069278
 L 205.833149 276.089812 
 L 131.49511 138.882813 
 L 268.702109 82.049812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_15">
     <path d="M 268.702109 82.049812 
@@ -1276,7 +1276,7 @@ L 153.722644 391.069278
 L 186.429149 276.089812 
 L 131.49511 138.882813 
 L 268.702109 82.049812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_16">
     <path d="M 268.702109 82.049812 
@@ -1288,7 +1288,7 @@ L 153.722644 391.069278
 L 186.429149 276.089812 
 L 131.49511 138.882813 
 L 268.702109 82.049812 
-" clip-path="url(#p10f4ef6e2e)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p937da5c6ba)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
     <path d="M 268.702109 82.049812 
@@ -1856,7 +1856,7 @@ L 532.714509 77.205562
   </g>
  </g>
  <defs>
-  <clipPath id="p10f4ef6e2e">
+  <clipPath id="p937da5c6ba">
    <path d="M 462.742109 276.089812 
 C 462.742109 250.608713 457.722888 225.375385 447.971694 201.833919 
 C 438.220499 178.292453 423.926967 156.900671 405.909109 138.882813 

--- a/release_kpis/radar_v2.0.6.svg
+++ b/release_kpis/radar_v2.0.6.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-02-23T11:34:10.951381</dc:date>
+    <dc:date>2026-02-23T11:53:25.134773</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -77,14 +77,14 @@ L 142.428282 335.28124
 L 170.462429 236.727412 
 L 123.37611 119.121413 
 z
-" clip-path="url(#p512c67facf)" style="fill: #1f77b4; opacity: 0.2"/>
+" clip-path="url(#p50984107a3)" style="fill: #1f77b4; opacity: 0.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <path d="M 240.982109 236.727412 
 L 240.982109 70.407412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_1">
       <!-- Technical Completeness -->
@@ -419,7 +419,7 @@ z
      <g id="line2d_2">
       <path d="M 240.982109 236.727412 
 L 358.588109 119.121413 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_2">
       <!-- Automation Depth -->
@@ -506,7 +506,7 @@ z
      <g id="line2d_3">
       <path d="M 240.982109 236.727412 
 L 407.302109 236.727412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_3">
       <!-- Authority Modeling -->
@@ -648,7 +648,7 @@ z
      <g id="line2d_4">
       <path d="M 240.982109 236.727412 
 L 358.588109 354.333412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_4">
       <!-- Enterprise Readiness -->
@@ -725,7 +725,7 @@ z
      <g id="line2d_5">
       <path d="M 240.982109 236.727412 
 L 240.982109 403.047412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_5">
       <!-- Scalability -->
@@ -807,7 +807,7 @@ z
      <g id="line2d_6">
       <path d="M 240.982109 236.727412 
 L 123.37611 354.333412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_6">
       <!-- Data Integration -->
@@ -844,7 +844,7 @@ z
      <g id="line2d_7">
       <path d="M 240.982109 236.727412 
 L 74.662109 236.727412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_7">
       <!-- Economic Measurability -->
@@ -878,7 +878,7 @@ L 74.662109 236.727412
      <g id="line2d_8">
       <path d="M 240.982109 236.727412 
 L 123.37611 119.121413 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_8">
       <!-- Operational Maturity -->
@@ -950,7 +950,7 @@ C 207.718109 232.359224 208.578547 228.033511 210.250181 223.997831
 C 211.921814 219.962151 214.372134 216.294988 217.460909 213.206213 
 C 220.549685 210.117437 224.216848 207.667117 228.252528 205.995484 
 C 232.288208 204.32385 236.613921 203.463412 240.982109 203.463412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_9">
       <!-- 2 -->
@@ -1004,7 +1004,7 @@ C 174.454109 227.991036 176.174985 219.339609 179.518252 211.268249
 C 182.861519 203.196889 187.762158 195.862564 193.939709 189.685013 
 C 200.117261 183.507461 207.451586 178.606822 215.522946 175.263555 
 C 223.594306 171.920288 232.245732 170.199412 240.982109 170.199412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_10">
       <!-- 4 -->
@@ -1053,7 +1053,7 @@ C 141.190109 223.622847 143.771423 210.645707 148.786323 198.538667
 C 153.801223 186.431628 161.152182 175.43014 170.418509 166.163813 
 C 179.684837 156.897486 190.686325 149.546526 202.793364 144.531626 
 C 214.900404 139.516726 227.877544 136.935412 240.982109 136.935412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_11">
       <!-- 6 -->
@@ -1113,7 +1113,7 @@ C 107.926109 219.254659 111.367861 201.951805 118.054394 185.809086
 C 124.740928 169.666366 134.542207 154.997715 146.897309 142.642613 
 C 159.252412 130.28751 173.921063 120.486231 190.063783 113.799697 
 C 206.206502 107.113164 223.509356 103.671412 240.982109 103.671412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_12">
       <!-- 8 -->
@@ -1182,7 +1182,7 @@ C 74.662109 214.88647 78.964299 193.257904 87.322466 173.079504
 C 95.680632 152.901104 107.932231 134.565291 123.37611 119.121413 
 C 138.819988 103.677534 157.155801 91.425935 177.334201 83.067769 
 C 197.5126 74.709602 219.141167 70.407412 240.982109 70.407412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="text_13">
       <!-- 10 -->
@@ -1240,7 +1240,7 @@ L 142.428282 335.28124
 L 170.462429 236.727412 
 L 123.37611 119.121413 
 L 240.982109 70.407412 
-" clip-path="url(#p512c67facf)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p50984107a3)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
     <path d="M 240.982109 70.407412 
@@ -1704,7 +1704,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p512c67facf">
+  <clipPath id="p50984107a3">
    <path d="M 407.302109 236.727412 
 C 407.302109 214.88647 402.99992 193.257904 394.641753 173.079504 
 C 386.283586 152.901104 374.031988 134.565291 358.588109 119.121413 

--- a/release_kpis/tec_dod.json
+++ b/release_kpis/tec_dod.json
@@ -1,25 +1,25 @@
 {
   "tier": "dod",
   "counts": {
-    "issues_total": 166,
-    "prs_merged": 182,
+    "issues_total": 167,
+    "prs_merged": 184,
     "workflows": 29,
     "test_files": 99,
-    "doc_files": 323,
+    "doc_files": 325,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
-    "issues_with_pr_link_est": 89
+    "issues_with_pr_link_est": 90
   },
   "hours": {
-    "issues_weighted": 1566.8,
-    "issues_complexity_weighted": 1970.8,
-    "pr_overhead": 273.0,
+    "issues_weighted": 1574.8,
+    "issues_complexity_weighted": 1981.0,
+    "pr_overhead": 276.0,
     "workflows": 145.0,
     "tests": 198.0,
-    "docs": 484.5,
+    "docs": 487.5,
     "committee": 0.0,
-    "total_base": 2667.2,
-    "total_ctec": 3071.3
+    "total_base": 2681.2,
+    "total_ctec": 3087.5
   },
   "complexity": {
     "avg_index": 1.244,
@@ -42,15 +42,15 @@
   },
   "rate_hourly": 275.0,
   "low": {
-    "hours": 2457.0,
-    "cost": 675686.0
+    "hours": 2470.0,
+    "cost": 679250.0
   },
   "base": {
-    "hours": 3071.3,
-    "cost": 844608.0
+    "hours": 3087.5,
+    "cost": 849062.0
   },
   "high": {
-    "hours": 4146.3,
-    "cost": 1140220.0
+    "hours": 4168.1,
+    "cost": 1146234.0
   }
 }

--- a/release_kpis/tec_executive.json
+++ b/release_kpis/tec_executive.json
@@ -1,25 +1,25 @@
 {
   "tier": "executive",
   "counts": {
-    "issues_total": 166,
-    "prs_merged": 182,
+    "issues_total": 167,
+    "prs_merged": 184,
     "workflows": 29,
     "test_files": 99,
-    "doc_files": 323,
+    "doc_files": 325,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
-    "issues_with_pr_link_est": 89
+    "issues_with_pr_link_est": 90
   },
   "hours": {
-    "issues_weighted": 1566.8,
-    "issues_complexity_weighted": 1970.8,
-    "pr_overhead": 273.0,
+    "issues_weighted": 1574.8,
+    "issues_complexity_weighted": 1981.0,
+    "pr_overhead": 276.0,
     "workflows": 145.0,
     "tests": 198.0,
-    "docs": 484.5,
+    "docs": 487.5,
     "committee": 0.0,
-    "total_base": 2667.2,
-    "total_ctec": 3071.3
+    "total_base": 2681.2,
+    "total_ctec": 3087.5
   },
   "complexity": {
     "avg_index": 1.244,
@@ -42,15 +42,15 @@
   },
   "rate_hourly": 225.0,
   "low": {
-    "hours": 2457.0,
-    "cost": 552834.0
+    "hours": 2470.0,
+    "cost": 555750.0
   },
   "base": {
-    "hours": 3071.3,
-    "cost": 691042.0
+    "hours": 3087.5,
+    "cost": 694688.0
   },
   "high": {
-    "hours": 4146.3,
-    "cost": 932907.0
+    "hours": 4168.1,
+    "cost": 937828.0
   }
 }

--- a/release_kpis/tec_internal.json
+++ b/release_kpis/tec_internal.json
@@ -1,25 +1,25 @@
 {
   "tier": "internal",
   "counts": {
-    "issues_total": 166,
-    "prs_merged": 182,
+    "issues_total": 167,
+    "prs_merged": 184,
     "workflows": 29,
     "test_files": 99,
-    "doc_files": 323,
+    "doc_files": 325,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
-    "issues_with_pr_link_est": 89
+    "issues_with_pr_link_est": 90
   },
   "hours": {
-    "issues_weighted": 1566.8,
-    "issues_complexity_weighted": 1970.8,
-    "pr_overhead": 273.0,
+    "issues_weighted": 1574.8,
+    "issues_complexity_weighted": 1981.0,
+    "pr_overhead": 276.0,
     "workflows": 145.0,
     "tests": 198.0,
-    "docs": 484.5,
+    "docs": 487.5,
     "committee": 0.0,
-    "total_base": 2667.2,
-    "total_ctec": 3071.3
+    "total_base": 2681.2,
+    "total_ctec": 3087.5
   },
   "complexity": {
     "avg_index": 1.244,
@@ -42,15 +42,15 @@
   },
   "rate_hourly": 150.0,
   "low": {
-    "hours": 2457.0,
-    "cost": 368556.0
+    "hours": 2470.0,
+    "cost": 370500.0
   },
   "base": {
-    "hours": 3071.3,
-    "cost": 460695.0
+    "hours": 3087.5,
+    "cost": 463125.0
   },
   "high": {
-    "hours": 4146.3,
-    "cost": 621938.0
+    "hours": 4168.1,
+    "cost": 625219.0
   }
 }

--- a/schemas/intent_packet.schema.json
+++ b/schemas/intent_packet.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IntentPacket",
+  "type": "object",
+  "required": ["intent_statement", "scope", "success_criteria", "ttl_expires_at", "author", "authority"],
+  "properties": {
+    "intent_statement": {"type": "string"},
+    "scope": {"type": "string"},
+    "success_criteria": {"type": "string"},
+    "risk_flags": {"type": "array", "items": {"type": "string"}},
+    "ttl_expires_at": {"type": "string"},
+    "author": {"type": "object"},
+    "authority": {"type": "object"},
+    "intent_hash": {"type": "string"}
+  }
+}

--- a/scripts/capture_run_snapshot.py
+++ b/scripts/capture_run_snapshot.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Run snapshot stub.
+Captures sealed input snapshot + provenance + env fingerprint.
+"""
+
+print("TODO: implement run snapshot")
+

--- a/scripts/export_audit_neutral_pack.py
+++ b/scripts/export_audit_neutral_pack.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Audit-neutral export stub.
+Exports sealed facts + reasoning chain + authority + hashes.
+"""
+
+print("TODO: implement audit-neutral pack export")
+

--- a/scripts/idempotency_guard.py
+++ b/scripts/idempotency_guard.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Idempotency/replay guard stub.
+Prevents repeated execution without idempotency key.
+"""
+
+print("TODO: implement idempotency guard")
+

--- a/scripts/kpi_run.py
+++ b/scripts/kpi_run.py
@@ -8,6 +8,22 @@ import subprocess
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def format_layer_coverage() -> str:
+    mapping_path = ROOT / "release_kpis" / "layer_kpi_mapping.json"
+    if not mapping_path.exists():
+        return ""
+
+    mapping = json.loads(mapping_path.read_text(encoding="utf-8"))
+    lines = ["", "**Layer Coverage (Decision Infrastructure):**"]
+    for layer, kpis in mapping.items():
+        if isinstance(kpis, list):
+            kpi_str = ", ".join(kpis)
+        else:
+            kpi_str = str(kpis)
+        lines.append(f"- {layer}: {kpi_str}")
+    return "\n".join(lines)
+
+
 def main() -> int:
     outdir = ROOT / "release_kpis"
     outdir.mkdir(parents=True, exist_ok=True)
@@ -63,6 +79,7 @@ def main() -> int:
     tec_internal_data = json.loads(tec_internal.read_text(encoding="utf-8"))
     tec_executive_data = json.loads(tec_executive.read_text(encoding="utf-8"))
     tec_dod_data = json.loads(tec_dod.read_text(encoding="utf-8"))
+    layer_coverage = format_layer_coverage()
 
     comment = f"""## Repo Radar KPI — {version}
 
@@ -111,6 +128,7 @@ def main() -> int:
 - Some KPIs are auto-derived from repo telemetry (tests, docs, workflows, pilot drills).
 - Economic and Scalability are auto-derived from DISR metrics and capped by evidence eligibility (`kpi_eligible` / `evidence_level`).
 - Authority Modeling remains manual/judgment-based until authority telemetry scoring is wired.
+{layer_coverage}
 """
     (outdir / "PR_COMMENT.md").write_text(comment, encoding="utf-8")
     print("Wrote: release_kpis/PR_COMMENT.md")

--- a/scripts/pre_exec_gate.py
+++ b/scripts/pre_exec_gate.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Pre-execution gate stub.
+Blocks execution unless Intent + Authority + Policy + Snapshot are valid.
+"""
+
+print("TODO: implement pre-exec gate")
+

--- a/scripts/replay_run.py
+++ b/scripts/replay_run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Replay runner stub.
+Replays a run from sealed artifacts.
+"""
+
+print("TODO: implement replay runner")
+

--- a/scripts/validate_claim_evidence_authority.py
+++ b/scripts/validate_claim_evidence_authority.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Validator stub.
+Ensures DecisionRecords bind Claim -> Evidence -> Authority.
+"""
+
+print("TODO: implement claim/evidence/authority validation")
+

--- a/scripts/validate_v2_1_0_milestone.py
+++ b/scripts/validate_v2_1_0_milestone.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = [
+    "specs/decision_infrastructure_model.md",
+    "release_kpis/layer_kpi_mapping.json",
+]
+
+REQUIRED_PROOFS = [
+    "schemas/intent_packet.schema.json",
+    "scripts/pre_exec_gate.py",
+    "governance/decision_invariants.md",
+    "scripts/validate_claim_evidence_authority.py",
+    "scripts/verify_authority_signature.py",
+    "scripts/idempotency_guard.py",
+    "scripts/capture_run_snapshot.py",
+    "scripts/replay_run.py",
+    "scripts/export_audit_neutral_pack.py",
+]
+
+REQUIRED_LAYERS = [
+    "Layer_0_Intent",
+    "Layer_1_AuditLogic",
+    "Layer_2_PreExecution",
+    "Layer_3_RuntimeSafety",
+]
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def main() -> int:
+    missing_baseline = [p for p in REQUIRED_FILES if not (ROOT / p).exists()]
+    if missing_baseline:
+        fail("Missing required baseline files:\n- " + "\n- ".join(missing_baseline))
+
+    mapping_path = ROOT / "release_kpis/layer_kpi_mapping.json"
+    try:
+        mapping = json.loads(mapping_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"layer_kpi_mapping.json is not valid JSON: {exc}")
+
+    for layer in REQUIRED_LAYERS:
+        if layer not in mapping:
+            fail(f"layer_kpi_mapping.json missing layer: {layer}")
+        if not isinstance(mapping[layer], list) or not mapping[layer]:
+            fail(f"layer_kpi_mapping.json layer has empty KPI list: {layer}")
+
+    missing_proofs = [p for p in REQUIRED_PROOFS if not (ROOT / p).exists()]
+    if missing_proofs:
+        fail("Missing v2.1.0 proof-point files (create stubs if needed):\n- " + "\n- ".join(missing_proofs))
+
+    print("PASS: v2.1.0 milestone gate satisfied (baseline proof points present).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_authority_signature.py
+++ b/scripts/verify_authority_signature.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Authority signature verification stub.
+Replace placeholder signing with real verification.
+"""
+
+print("TODO: implement signature verification")
+


### PR DESCRIPTION
## What this implements
- Adds `scripts/validate_v2_1_0_milestone.py` and `make milestone-gate`
- Enforces milestone gate in CI (`.github/workflows/ci.yml`) and KPI pipelines (`.github/workflows/kpi.yml`, `.github/workflows/kpi_gate.yml`)
- Adds required v2.1.0 proof-point stubs (intent schema, pre-exec/accountability scripts, invariants doc)
- Wires layer-to-KPI mapping into `scripts/kpi_run.py` and appends Layer Coverage to `release_kpis/PR_COMMENT.md`

## Validation run
- `make milestone-gate`
- `make kpi`
- `ruff check` on changed Python files

## Notes
- Stubs are intentionally minimal to make milestone criteria mechanically enforceable while implementation iterates.
