### PR TITLE
Build 88: no-theater milestone gate (semantic enforcement)

### DIFF
--- a/scripts/capture_run_snapshot.py
+++ b/scripts/capture_run_snapshot.py
@@ -1,7 +1,91 @@
 #!/usr/bin/env python3
-"""Run snapshot stub.
-Captures sealed input snapshot + provenance + env fingerprint.
-"""
+from __future__ import annotations
 
-print("TODO: implement run snapshot")
+import argparse
+import hashlib
+import json
+import platform
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def capture(input_path: Path, output_path: Path, provenance_path: Path | None) -> None:
+    if not input_path.exists():
+        raise FileNotFoundError(str(input_path))
+
+    snapshot = {
+        "captured_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "input_path": str(input_path),
+        "input_hash": sha256_file(input_path),
+        "env_fingerprint": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        },
+    }
+
+    if provenance_path:
+        if not provenance_path.exists():
+            raise FileNotFoundError(str(provenance_path))
+        snapshot["provenance_path"] = str(provenance_path)
+        snapshot["provenance_hash"] = sha256_file(provenance_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+
+
+def run_self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        input_path = root / "input.json"
+        provenance_path = root / "prov.json"
+        out = root / "snapshot.json"
+        input_path.write_text('{"x":1}', encoding="utf-8")
+        provenance_path.write_text('{"source":"fixture"}', encoding="utf-8")
+        capture(input_path, out, provenance_path)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        if "input_hash" not in data or "env_fingerprint" not in data:
+            return fail("snapshot missing required fields")
+    print("PASS: snapshot self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture sealed run snapshot")
+    parser.add_argument("--input", default="artifacts/input.json")
+    parser.add_argument("--output", default="artifacts/run_snapshot.json")
+    parser.add_argument("--provenance", default=None)
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return run_self_check()
+
+    try:
+        provenance = Path(args.provenance) if args.provenance else None
+        capture(Path(args.input), Path(args.output), provenance)
+    except Exception as exc:
+        return fail(str(exc))
+
+    print("PASS: snapshot captured")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_audit_neutral_pack.py
+++ b/scripts/export_audit_neutral_pack.py
@@ -1,7 +1,80 @@
 #!/usr/bin/env python3
-"""Audit-neutral export stub.
-Exports sealed facts + reasoning chain + authority + hashes.
-"""
+from __future__ import annotations
 
-print("TODO: implement audit-neutral pack export")
+import argparse
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def export_pack(inputs: list[Path], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, str] = {}
+    for src in inputs:
+        if not src.exists():
+            raise FileNotFoundError(str(src))
+        dst = output_dir / src.name
+        shutil.copy2(src, dst)
+        manifest[dst.name] = sha256_file(dst)
+
+    manifest_path = output_dir / "MANIFEST.sha256.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return manifest_path
+
+
+def run_self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        src1 = root / "decision.json"
+        src2 = root / "authority.json"
+        dst = root / "pack"
+        src1.write_text('{"d":1}', encoding="utf-8")
+        src2.write_text('{"a":1}', encoding="utf-8")
+        manifest = export_pack([src1, src2], dst)
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        if set(data.keys()) != {"decision.json", "authority.json"}:
+            return fail("manifest keys mismatch")
+    print("PASS: audit-neutral pack self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export audit-neutral pack")
+    parser.add_argument("--inputs", nargs="*", default=["artifacts/decision_record.json", "artifacts/action_contract.json"])
+    parser.add_argument("--output-dir", default="artifacts/audit_neutral_pack")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return run_self_check()
+
+    try:
+        inputs = [Path(x) for x in args.inputs]
+        manifest = export_pack(inputs, Path(args.output_dir))
+    except Exception as exc:
+        return fail(str(exc))
+
+    print(f"PASS: audit-neutral pack exported ({manifest})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/idempotency_guard.py
+++ b/scripts/idempotency_guard.py
@@ -1,7 +1,72 @@
 #!/usr/bin/env python3
-"""Idempotency/replay guard stub.
-Prevents repeated execution without idempotency key.
-"""
+from __future__ import annotations
 
-print("TODO: implement idempotency guard")
+import argparse
+import json
+import tempfile
+from pathlib import Path
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def register_key(ledger_path: Path, key: str) -> bool:
+    if ledger_path.exists():
+        payload = json.loads(ledger_path.read_text(encoding="utf-8"))
+    else:
+        payload = {"keys": []}
+
+    keys = payload.get("keys", [])
+    if not isinstance(keys, list):
+        raise ValueError("ledger keys must be a list")
+
+    if key in keys:
+        return False
+
+    keys.append(key)
+    payload["keys"] = keys
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return True
+
+
+def run_self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger = Path(tmp) / "idempotency_ledger.json"
+        if not register_key(ledger, "abc"):
+            return fail("first key registration should pass")
+        if register_key(ledger, "abc"):
+            return fail("duplicate key registration should fail")
+    print("PASS: idempotency guard self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Idempotency/replay guard")
+    parser.add_argument("--ledger", default="artifacts/idempotency_ledger.json")
+    parser.add_argument("--key", default=None)
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return run_self_check()
+
+    if not args.key:
+        return fail("--key is required outside self-check")
+
+    try:
+        inserted = register_key(Path(args.ledger), args.key)
+    except Exception as exc:
+        return fail(str(exc))
+
+    if not inserted:
+        return fail(f"idempotency key already used: {args.key}")
+
+    print("PASS: idempotency key accepted")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pre_exec_gate.py
+++ b/scripts/pre_exec_gate.py
@@ -1,7 +1,136 @@
 #!/usr/bin/env python3
-"""Pre-execution gate stub.
-Blocks execution unless Intent + Authority + Policy + Snapshot are valid.
-"""
+from __future__ import annotations
 
-print("TODO: implement pre-exec gate")
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
 
+
+REQUIRED_INTENT = [
+    "intent_statement",
+    "scope",
+    "success_criteria",
+    "ttl_expires_at",
+    "author",
+    "authority",
+    "intent_hash",
+]
+REQUIRED_AUTH = ["action_type", "requested_by", "dri", "intent_hash", "signature"]
+REQUIRED_SNAPSHOT = ["input_hash", "env_fingerprint"]
+
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def parse_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"JSON object expected in {path}")
+    return data
+
+
+def require_keys(name: str, payload: dict[str, Any], keys: list[str]) -> None:
+    missing = [k for k in keys if k not in payload]
+    if missing:
+        raise ValueError(f"{name} missing keys: {', '.join(missing)}")
+
+
+def validate(intent_path: Path, authority_path: Path, policy_path: Path, snapshot_path: Path) -> None:
+    intent = parse_json(intent_path)
+    authority = parse_json(authority_path)
+    policy = parse_json(policy_path)
+    snapshot = parse_json(snapshot_path)
+
+    require_keys("intent packet", intent, REQUIRED_INTENT)
+    require_keys("authority contract", authority, REQUIRED_AUTH)
+    require_keys("snapshot", snapshot, REQUIRED_SNAPSHOT)
+
+    if not isinstance(policy.get("allowed_actions", []), list):
+        raise ValueError("policy.allowed_actions must be a list")
+
+    action = authority["action_type"]
+    allowed_actions = policy.get("allowed_actions", [])
+    if action not in allowed_actions:
+        raise ValueError(f"action '{action}' is not allowed by policy")
+
+    if authority["intent_hash"] != intent["intent_hash"]:
+        raise ValueError("authority intent_hash does not match intent packet")
+
+
+def run_self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        intent = root / "intent.json"
+        auth = root / "authority.json"
+        policy = root / "policy.json"
+        snapshot = root / "snapshot.json"
+
+        intent.write_text(
+            json.dumps(
+                {
+                    "intent_statement": "Patch drift record",
+                    "scope": "pilot",
+                    "success_criteria": "ci >= 90",
+                    "ttl_expires_at": "2026-12-31T00:00:00Z",
+                    "author": {"id": "ops"},
+                    "authority": {"id": "approver"},
+                    "intent_hash": "abc123",
+                }
+            ),
+            encoding="utf-8",
+        )
+        auth.write_text(
+            json.dumps(
+                {
+                    "action_type": "patch",
+                    "requested_by": "ops",
+                    "dri": "approver",
+                    "intent_hash": "abc123",
+                    "signature": "sig",
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy.write_text(json.dumps({"allowed_actions": ["patch", "seal"]}), encoding="utf-8")
+        snapshot.write_text(
+            json.dumps({"input_hash": "h1", "env_fingerprint": "python-3.12"}), encoding="utf-8"
+        )
+
+        validate(intent, auth, policy, snapshot)
+
+    print("PASS: pre-exec self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pre-execution gate")
+    parser.add_argument("--intent", default="artifacts/intent_packet.json")
+    parser.add_argument("--authority-contract", default="artifacts/action_contract.json")
+    parser.add_argument("--policy", default="governance/security_crypto_policy.json")
+    parser.add_argument("--snapshot", default="artifacts/run_snapshot.json")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        try:
+            return run_self_check()
+        except Exception as exc:
+            return fail(str(exc))
+
+    try:
+        validate(Path(args.intent), Path(args.authority_contract), Path(args.policy), Path(args.snapshot))
+    except Exception as exc:
+        return fail(str(exc))
+
+    print("PASS: pre-execution gate checks satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/replay_run.py
+++ b/scripts/replay_run.py
@@ -1,7 +1,79 @@
 #!/usr/bin/env python3
-"""Replay runner stub.
-Replays a run from sealed artifacts.
-"""
+from __future__ import annotations
 
-print("TODO: implement replay runner")
+import argparse
+import hashlib
+import json
+import tempfile
+from pathlib import Path
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def replay(snapshot_path: Path, output_path: Path) -> None:
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    input_path = Path(snapshot["input_path"])
+    expected = snapshot["input_hash"]
+    actual = sha256_file(input_path)
+    if actual != expected:
+        raise ValueError("snapshot input hash mismatch during replay")
+
+    result = {"replay_status": "verified", "input_hash": actual}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+
+def run_self_check() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        inp = root / "input.json"
+        snap = root / "snapshot.json"
+        out = root / "replay.json"
+        inp.write_text('{"n":1}', encoding="utf-8")
+        snap.write_text(
+            json.dumps({"input_path": str(inp), "input_hash": sha256_file(inp)}),
+            encoding="utf-8",
+        )
+        replay(snap, out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        if data.get("replay_status") != "verified":
+            return fail("replay output is not verified")
+    print("PASS: replay self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Replay run from sealed snapshot")
+    parser.add_argument("--snapshot", default="artifacts/run_snapshot.json")
+    parser.add_argument("--output", default="artifacts/replay_result.json")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return run_self_check()
+
+    try:
+        replay(Path(args.snapshot), Path(args.output))
+    except Exception as exc:
+        return fail(str(exc))
+
+    print("PASS: replay completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_claim_evidence_authority.py
+++ b/scripts/validate_claim_evidence_authority.py
@@ -1,7 +1,83 @@
 #!/usr/bin/env python3
-"""Validator stub.
-Ensures DecisionRecords bind Claim -> Evidence -> Authority.
-"""
+from __future__ import annotations
 
-print("TODO: implement claim/evidence/authority validation")
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def load_record(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("decision record must be an object")
+    return data
+
+
+def validate(record: dict[str, Any]) -> None:
+    claims = record.get("claims")
+    evidence = record.get("evidence")
+    authority_refs = record.get("authority_refs")
+
+    if not isinstance(claims, list) or not claims:
+        raise ValueError("claims[] required")
+    if not isinstance(evidence, list) or not evidence:
+        raise ValueError("evidence[] required")
+    if not isinstance(authority_refs, list) or not authority_refs:
+        raise ValueError("authority_refs[] required")
+
+    evidence_ids = {e.get("id") for e in evidence if isinstance(e, dict)}
+    authority_ids = {a.get("id") for a in authority_refs if isinstance(a, dict)}
+
+    for idx, claim in enumerate(claims):
+        if not isinstance(claim, dict):
+            raise ValueError(f"claim[{idx}] must be object")
+        evid = claim.get("evidence_id")
+        auth = claim.get("authority_id")
+        if evid not in evidence_ids:
+            raise ValueError(f"claim[{idx}] has unknown evidence_id '{evid}'")
+        if auth not in authority_ids:
+            raise ValueError(f"claim[{idx}] has unknown authority_id '{auth}'")
+
+
+def run_self_check() -> int:
+    sample = {
+        "claims": [{"id": "c1", "evidence_id": "e1", "authority_id": "a1"}],
+        "evidence": [{"id": "e1", "hash": "h1"}],
+        "authority_refs": [{"id": "a1", "role": "dri"}],
+    }
+    validate(sample)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "decision_record.json"
+        path.write_text(json.dumps(sample), encoding="utf-8")
+        validate(load_record(path))
+    print("PASS: claim/evidence/authority validator self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate claim->evidence->authority binding")
+    parser.add_argument("--record", default="artifacts/decision_record.json")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.self_check:
+            return run_self_check()
+        record = load_record(Path(args.record))
+        validate(record)
+    except Exception as exc:
+        return fail(str(exc))
+
+    print("PASS: claim/evidence/authority binding is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_v2_1_0_milestone.py
+++ b/scripts/validate_v2_1_0_milestone.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -24,6 +25,16 @@ REQUIRED_PROOFS = [
     "scripts/export_audit_neutral_pack.py",
 ]
 
+PROOF_SCRIPTS = [
+    "scripts/pre_exec_gate.py",
+    "scripts/validate_claim_evidence_authority.py",
+    "scripts/verify_authority_signature.py",
+    "scripts/idempotency_guard.py",
+    "scripts/capture_run_snapshot.py",
+    "scripts/replay_run.py",
+    "scripts/export_audit_neutral_pack.py",
+]
+
 REQUIRED_LAYERS = [
     "Layer_0_Intent",
     "Layer_1_AuditLogic",
@@ -31,10 +42,82 @@ REQUIRED_LAYERS = [
     "Layer_3_RuntimeSafety",
 ]
 
+SCHEMA_REQUIRED_KEYS = {
+    "intent_statement",
+    "scope",
+    "success_criteria",
+    "ttl_expires_at",
+    "author",
+    "authority",
+}
+
+INVARIANT_SNIPPETS = [
+    "Claim",
+    "Evidence",
+    "Authority",
+    "seal",
+    "version",
+    "patch",
+]
+
+PLACEHOLDER_PATTERNS = [
+    "TODO:",
+    "stub",
+    "implement me",
+    "placeholder",
+]
+
 
 def fail(msg: str) -> None:
     print(f"FAIL: {msg}")
     sys.exit(1)
+
+
+def pass_msg(msg: str) -> None:
+    print(f"PASS: {msg}")
+
+
+def check_placeholder_free(path: Path) -> None:
+    text = path.read_text(encoding="utf-8").lower()
+    hits = [p for p in PLACEHOLDER_PATTERNS if p.lower() in text]
+    if hits:
+        raise ValueError(f"{path} contains placeholder tokens: {', '.join(hits)}")
+
+
+def check_intent_schema(path: Path) -> None:
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    if schema.get("type") != "object":
+        raise ValueError("intent schema must define type=object")
+    required = set(schema.get("required", []))
+    missing = sorted(SCHEMA_REQUIRED_KEYS - required)
+    if missing:
+        raise ValueError(f"intent schema missing required keys: {', '.join(missing)}")
+    props = schema.get("properties", {})
+    if not isinstance(props, dict) or not props:
+        raise ValueError("intent schema properties must be a non-empty object")
+
+
+def check_invariants_doc(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for token in INVARIANT_SNIPPETS:
+        if token.lower() not in text.lower():
+            raise ValueError(f"decision invariants missing semantic token '{token}'")
+
+
+def run_script_self_check(script_rel: str) -> None:
+    cmd = [sys.executable, str(ROOT / script_rel), "--self-check"]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    output = (res.stdout + "\n" + res.stderr).strip()
+    if res.returncode != 0:
+        raise ValueError(f"self-check failed for {script_rel}:\n{output}")
+    if "PASS:" not in output:
+        raise ValueError(f"self-check for {script_rel} did not emit PASS: convention")
+
+
+def verify_pass_fail_convention(script_rel: str) -> None:
+    text = (ROOT / script_rel).read_text(encoding="utf-8")
+    if "PASS:" not in text or "FAIL:" not in text:
+        raise ValueError(f"{script_rel} must contain PASS:/FAIL: output conventions")
 
 
 def main() -> int:
@@ -56,9 +139,21 @@ def main() -> int:
 
     missing_proofs = [p for p in REQUIRED_PROOFS if not (ROOT / p).exists()]
     if missing_proofs:
-        fail("Missing v2.1.0 proof-point files (create stubs if needed):\n- " + "\n- ".join(missing_proofs))
+        fail("Missing v2.1.0 proof-point files:\n- " + "\n- ".join(missing_proofs))
 
-    print("PASS: v2.1.0 milestone gate satisfied (baseline proof points present).")
+    check_intent_schema(ROOT / "schemas/intent_packet.schema.json")
+    pass_msg("intent schema semantic checks passed")
+
+    check_invariants_doc(ROOT / "governance/decision_invariants.md")
+    pass_msg("decision invariants semantic checks passed")
+
+    for script in PROOF_SCRIPTS:
+        check_placeholder_free(ROOT / script)
+        verify_pass_fail_convention(script)
+        run_script_self_check(script)
+        pass_msg(f"validated {script}")
+
+    pass_msg("v2.1.0 milestone gate satisfied (no-theater semantics enforced)")
     return 0
 
 

--- a/scripts/verify_authority_signature.py
+++ b/scripts/verify_authority_signature.py
@@ -1,7 +1,76 @@
 #!/usr/bin/env python3
-"""Authority signature verification stub.
-Replace placeholder signing with real verification.
-"""
+from __future__ import annotations
 
-print("TODO: implement signature verification")
+import argparse
+import hashlib
+import hmac
+import os
+import tempfile
+from pathlib import Path
 
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}")
+    return 1
+
+
+def verify(message: str, signature_hex: str, key: str) -> bool:
+    digest = hmac.new(key.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, signature_hex)
+
+
+def run_self_check() -> int:
+    message = "rotate:key-1:v2"
+    key = "build-88-self-check-key"
+    signature = hmac.new(key.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not verify(message, signature, key):
+        return fail("self-check signature did not verify")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        msg_path = Path(tmp) / "message.txt"
+        sig_path = Path(tmp) / "signature.txt"
+        msg_path.write_text(message, encoding="utf-8")
+        sig_path.write_text(signature, encoding="utf-8")
+        if not verify(msg_path.read_text(encoding="utf-8"), sig_path.read_text(encoding="utf-8").strip(), key):
+            return fail("file-based self-check signature did not verify")
+
+    print("PASS: authority signature self-check passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify authority signature")
+    parser.add_argument("--message", help="message string", default=None)
+    parser.add_argument("--message-file", default=None)
+    parser.add_argument("--signature", help="hex signature", default=None)
+    parser.add_argument("--signature-file", default=None)
+    parser.add_argument("--key-env", default="DEEPSIGMA_SIGNING_KEY")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return run_self_check()
+
+    key = os.environ.get(args.key_env, "")
+    if not key:
+        return fail(f"missing signing key env var: {args.key_env}")
+
+    message = args.message
+    if args.message_file:
+        message = Path(args.message_file).read_text(encoding="utf-8")
+    signature = args.signature
+    if args.signature_file:
+        signature = Path(args.signature_file).read_text(encoding="utf-8").strip()
+
+    if not message or not signature:
+        return fail("provide --message/--message-file and --signature/--signature-file")
+
+    if not verify(message, signature, key):
+        return fail("signature verification failed")
+
+    print("PASS: authority signature verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Build 88: No-Theater Milestone Gate

### What changed
- Upgraded `scripts/validate_v2_1_0_milestone.py` from existence-only checks to semantic enforcement.
- Validator now fails if proof scripts contain placeholder tokens (`TODO`, `stub`, etc.).
- Validator now requires each proof script to:
  - emit `PASS:`/`FAIL:` conventions
  - pass `--self-check` with exit code 0
- Added semantic checks for:
  - `schemas/intent_packet.schema.json` required fields
  - `governance/decision_invariants.md` core invariant content

### Proof scripts upgraded from stubs to executable checks
- `scripts/pre_exec_gate.py`
- `scripts/validate_claim_evidence_authority.py`
- `scripts/verify_authority_signature.py`
- `scripts/idempotency_guard.py`
- `scripts/capture_run_snapshot.py`
- `scripts/replay_run.py`
- `scripts/export_audit_neutral_pack.py`

### Validation
- `make milestone-gate` (PASS)
- `ruff check` on all changed scripts (PASS)
