### PR TITLE
Build 90: add feature catalog artifacts and README links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,3 +126,7 @@ stability:
 
 kpi-confidence:
 	python scripts/kpi_confidence_bands.py
+
+.PHONY: feature-catalog
+feature-catalog:
+	python scripts/render_feature_catalog.py

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ See: [docs/release/RELEASE_NOTES_v2.0.6.md](docs/release/RELEASE_NOTES_v2.0.6.md
 - Nonlinear stability report: [release_kpis/nonlinear_stability_report.md](release_kpis/nonlinear_stability_report.md)
 - SSI artifact (current release): [release_kpis/stability_v2.0.6.json](release_kpis/stability_v2.0.6.json)
 - Stability-adjusted forecast: [release_kpis/stability_adjusted_forecast.json](release_kpis/stability_adjusted_forecast.json)
+- Feature catalog (human): [docs/FEATURE_CATALOG.md](docs/FEATURE_CATALOG.md)
+- Feature catalog (machine): [release_kpis/feature_catalog.json](release_kpis/feature_catalog.json)
+- Feature catalog renderer: [scripts/render_feature_catalog.py](scripts/render_feature_catalog.py)
 
 ### Active Track (v2.1.0 — Security Hardening)
 - DISR hardening

--- a/docs/FEATURE_CATALOG.md
+++ b/docs/FEATURE_CATALOG.md
@@ -1,0 +1,110 @@
+# DeepSigma Feature Catalog
+
+Machine source of truth: `release_kpis/feature_catalog.json`
+
+## Categories
+
+### Deterministic Governance Boundary  \nGovernance enforced before execution: default deny, halt on ambiguity, proof-first artifacts.
+
+- **Pre-Execution Gate** (`PRE_EXEC_GATE`)
+  - Blocks execution unless intent+authority+policy requirements are satisfied.
+  - Artifacts: runs/intent_packet.json, runs/authority_contract.json, runs/input_snapshot.json
+  - Enforcement: make milestone-gate, CI: ci.yml, CI: kpi_gate.yml
+  - KPI axes: Automation_Depth, Authority_Modeling, Operational_Maturity
+- **Default Deny** (`DEFAULT_DENY`)
+  - If required conditions cannot be evaluated or are missing, execution is denied.
+  - Artifacts: governance/ambiguity_policy.md
+  - Enforcement: scripts/pre_exec_gate.py
+  - KPI axes: Authority_Modeling, Operational_Maturity
+- **Halt on Ambiguity** (`HALT_ON_AMBIGUITY`)
+  - Conflicts/unknowns/insufficient provenance trigger a hard fail before routing.
+  - Artifacts: governance/ambiguity_policy.md
+  - Enforcement: scripts/pre_exec_gate.py, scripts/validate_v2_1_0_milestone.py
+  - KPI axes: Authority_Modeling, Operational_Maturity
+
+### Intent Capture & Governance  \nIntent declared pre-action and bound to execution.
+
+- **Intent Packet Schema** (`INTENT_PACKET_SCHEMA`)
+  - Formal structure for intent, scope, success criteria, TTL, author, authority.
+  - Artifacts: schemas/intent_packet.schema.json, runs/intent_packet.json
+  - Enforcement: scripts/validate_intent_packet.py, scripts/validate_v2_1_0_milestone.py
+  - KPI axes: Authority_Modeling, Technical_Completeness
+- **Intent TTL Enforcement** (`INTENT_TTL`)
+  - Intent expires; expired intent blocks execution.
+  - Artifacts: runs/intent_packet.json
+  - Enforcement: scripts/validate_intent_packet.py
+  - KPI axes: Operational_Maturity, Authority_Modeling
+- **Intent Hash Binding** (`INTENT_HASH_BINDING`)
+  - Intent hash is bound into proof chain and audit pack.
+  - Artifacts: runs/proof_bundle.json
+  - Enforcement: scripts/crypto_proof.py
+  - KPI axes: Technical_Completeness, Authority_Modeling
+
+### Audit-Neutral Decision Logic  \nClaim→Evidence→Authority and context-free audit export.
+
+- **Decision Invariants Ledger** (`DECISION_INVARIANTS`)
+  - Rules like claim→evidence required, no overwrite, authority precedence, TTL/half-life.
+  - Artifacts: governance/decision_invariants.md
+  - Enforcement: scripts/validate_v2_1_0_milestone.py
+  - KPI axes: Operational_Maturity, Enterprise_Readiness
+- **Claim→Evidence→Authority Validator** (`CEA_VALIDATOR`)
+  - Machine-checkable binding of claims, evidence, and authority references.
+  - Artifacts: runs/decision_record.json
+  - Enforcement: scripts/validate_claim_evidence_authority.py
+  - KPI axes: Technical_Completeness, Enterprise_Readiness
+- **Audit-Neutral Export Pack** (`AUDIT_NEUTRAL_PACK`)
+  - Exports sealed facts + hashes + authority + proof bundle without political narrative.
+  - Artifacts: packs/audit_neutral/*
+  - Enforcement: scripts/export_audit_neutral_pack.py
+  - KPI axes: Enterprise_Readiness, Operational_Maturity
+
+### Deterministic Replay & Proof Chain  \nHash chain + optional signature verification + replay checks.
+
+- **Sealed Input Snapshot** (`INPUT_SNAPSHOT`)
+  - Inputs captured and hashed for deterministic evidence.
+  - Artifacts: runs/input_snapshot.json
+  - Enforcement: scripts/capture_run_snapshot.py
+  - KPI axes: Technical_Completeness, Operational_Maturity
+- **Proof Bundle** (`PROOF_BUNDLE`)
+  - Hash chain across intent, snapshot, authority contract, outputs; optional signature verify.
+  - Artifacts: runs/proof_bundle.json
+  - Enforcement: scripts/crypto_proof.py
+  - KPI axes: Technical_Completeness, Authority_Modeling
+- **Replay Validation** (`REPLAY_VALIDATION`)
+  - Validates proof chain presence and readiness for deterministic replay.
+  - Artifacts: runs/proof_bundle.json
+  - Enforcement: scripts/replay_run.py
+  - KPI axes: Operational_Maturity, Enterprise_Readiness
+
+### Repo Radar KPI System  \n8 KPI axes, radar render, badge_latest, PR comment, composite history.
+
+- **KPI Run Pipeline** (`KPI_RUN`)
+  - Computes KPI scores and emits render + PR artifacts.
+  - Artifacts: release_kpis/radar_*.png, release_kpis/badge_latest*.svg, release_kpis/PR_COMMENT*.md
+  - Enforcement: CI: kpi.yml, CI: kpi_gate.yml
+  - KPI axes: All
+- **Layer Coverage Injection** (`LAYER_COVERAGE`)
+  - Appends Decision Infrastructure layer→KPI mapping into PR comment.
+  - Artifacts: release_kpis/PR_COMMENT*.md
+  - Enforcement: scripts/kpi_run.py
+  - KPI axes: Operational_Maturity, Enterprise_Readiness
+
+### Economic Measurability (TEC / C-TEC)  \nEffort/cost modeling, sensitivity bands, complexity scaling.
+
+- **TEC Baseline** (`TEC_MODEL`)
+  - Time/Effort/Cost estimation outputs.
+  - Artifacts: release_kpis/TEC*.json, release_kpis/TEC*.md
+  - Enforcement: scripts/tec_run.py (if present)
+  - KPI axes: Economic_Measurability
+- **TEC Sensitivity Bands** (`TEC_SENSITIVITY`)
+  - Best/expected/worst bounds + volatility metrics.
+  - Artifacts: release_kpis/TEC_SENSITIVITY*.json
+  - Enforcement: scripts/tec_run.py (if present)
+  - KPI axes: Economic_Measurability, Operational_Maturity
+
+## Outer-Edge Boundaries
+
+- Not claiming full jurisdictional policy packs (EU AI Act article-by-article enforcement) yet
+- Not claiming full cryptographic attestation across all pipelines and connectors yet
+- Not claiming enterprise connectors (Jira/ServiceNow/SharePoint adapters) as complete (target v2.1.1)
+- Not claiming a full runtime control plane is governance (runtime is subordinate)

--- a/release_kpis/feature_catalog.json
+++ b/release_kpis/feature_catalog.json
@@ -1,0 +1,186 @@
+{
+  "meta": {
+    "catalog_name": "DeepSigma Feature Catalog",
+    "catalog_version": "v1",
+    "repo_release_line": "v2.x",
+    "source_of_truth": "release_kpis/feature_catalog.json"
+  },
+  "categories": [
+    {
+      "id": "DG_BOUNDARY",
+      "name": "Deterministic Governance Boundary",
+      "summary": "Governance enforced before execution: default deny, halt on ambiguity, proof-first artifacts.",
+      "features": [
+        {
+          "id": "PRE_EXEC_GATE",
+          "name": "Pre-Execution Gate",
+          "description": "Blocks execution unless intent+authority+policy requirements are satisfied.",
+          "artifacts": ["runs/intent_packet.json", "runs/authority_contract.json", "runs/input_snapshot.json"],
+          "enforcement": ["make milestone-gate", "CI: ci.yml", "CI: kpi_gate.yml"],
+          "kpi_axes": ["Automation_Depth", "Authority_Modeling", "Operational_Maturity"]
+        },
+        {
+          "id": "DEFAULT_DENY",
+          "name": "Default Deny",
+          "description": "If required conditions cannot be evaluated or are missing, execution is denied.",
+          "artifacts": ["governance/ambiguity_policy.md"],
+          "enforcement": ["scripts/pre_exec_gate.py"],
+          "kpi_axes": ["Authority_Modeling", "Operational_Maturity"]
+        },
+        {
+          "id": "HALT_ON_AMBIGUITY",
+          "name": "Halt on Ambiguity",
+          "description": "Conflicts/unknowns/insufficient provenance trigger a hard fail before routing.",
+          "artifacts": ["governance/ambiguity_policy.md"],
+          "enforcement": ["scripts/pre_exec_gate.py", "scripts/validate_v2_1_0_milestone.py"],
+          "kpi_axes": ["Authority_Modeling", "Operational_Maturity"]
+        }
+      ]
+    },
+    {
+      "id": "INTENT_GOV",
+      "name": "Intent Capture & Governance",
+      "summary": "Intent declared pre-action and bound to execution.",
+      "features": [
+        {
+          "id": "INTENT_PACKET_SCHEMA",
+          "name": "Intent Packet Schema",
+          "description": "Formal structure for intent, scope, success criteria, TTL, author, authority.",
+          "artifacts": ["schemas/intent_packet.schema.json", "runs/intent_packet.json"],
+          "enforcement": ["scripts/validate_intent_packet.py", "scripts/validate_v2_1_0_milestone.py"],
+          "kpi_axes": ["Authority_Modeling", "Technical_Completeness"]
+        },
+        {
+          "id": "INTENT_TTL",
+          "name": "Intent TTL Enforcement",
+          "description": "Intent expires; expired intent blocks execution.",
+          "artifacts": ["runs/intent_packet.json"],
+          "enforcement": ["scripts/validate_intent_packet.py"],
+          "kpi_axes": ["Operational_Maturity", "Authority_Modeling"]
+        },
+        {
+          "id": "INTENT_HASH_BINDING",
+          "name": "Intent Hash Binding",
+          "description": "Intent hash is bound into proof chain and audit pack.",
+          "artifacts": ["runs/proof_bundle.json"],
+          "enforcement": ["scripts/crypto_proof.py"],
+          "kpi_axes": ["Technical_Completeness", "Authority_Modeling"]
+        }
+      ]
+    },
+    {
+      "id": "AUDIT_NEUTRAL",
+      "name": "Audit-Neutral Decision Logic",
+      "summary": "Claim→Evidence→Authority and context-free audit export.",
+      "features": [
+        {
+          "id": "DECISION_INVARIANTS",
+          "name": "Decision Invariants Ledger",
+          "description": "Rules like claim→evidence required, no overwrite, authority precedence, TTL/half-life.",
+          "artifacts": ["governance/decision_invariants.md"],
+          "enforcement": ["scripts/validate_v2_1_0_milestone.py"],
+          "kpi_axes": ["Operational_Maturity", "Enterprise_Readiness"]
+        },
+        {
+          "id": "CEA_VALIDATOR",
+          "name": "Claim→Evidence→Authority Validator",
+          "description": "Machine-checkable binding of claims, evidence, and authority references.",
+          "artifacts": ["runs/decision_record.json"],
+          "enforcement": ["scripts/validate_claim_evidence_authority.py"],
+          "kpi_axes": ["Technical_Completeness", "Enterprise_Readiness"]
+        },
+        {
+          "id": "AUDIT_NEUTRAL_PACK",
+          "name": "Audit-Neutral Export Pack",
+          "description": "Exports sealed facts + hashes + authority + proof bundle without political narrative.",
+          "artifacts": ["packs/audit_neutral/*"],
+          "enforcement": ["scripts/export_audit_neutral_pack.py"],
+          "kpi_axes": ["Enterprise_Readiness", "Operational_Maturity"]
+        }
+      ]
+    },
+    {
+      "id": "PROOF_REPLAY",
+      "name": "Deterministic Replay & Proof Chain",
+      "summary": "Hash chain + optional signature verification + replay checks.",
+      "features": [
+        {
+          "id": "INPUT_SNAPSHOT",
+          "name": "Sealed Input Snapshot",
+          "description": "Inputs captured and hashed for deterministic evidence.",
+          "artifacts": ["runs/input_snapshot.json"],
+          "enforcement": ["scripts/capture_run_snapshot.py"],
+          "kpi_axes": ["Technical_Completeness", "Operational_Maturity"]
+        },
+        {
+          "id": "PROOF_BUNDLE",
+          "name": "Proof Bundle",
+          "description": "Hash chain across intent, snapshot, authority contract, outputs; optional signature verify.",
+          "artifacts": ["runs/proof_bundle.json"],
+          "enforcement": ["scripts/crypto_proof.py"],
+          "kpi_axes": ["Technical_Completeness", "Authority_Modeling"]
+        },
+        {
+          "id": "REPLAY_VALIDATION",
+          "name": "Replay Validation",
+          "description": "Validates proof chain presence and readiness for deterministic replay.",
+          "artifacts": ["runs/proof_bundle.json"],
+          "enforcement": ["scripts/replay_run.py"],
+          "kpi_axes": ["Operational_Maturity", "Enterprise_Readiness"]
+        }
+      ]
+    },
+    {
+      "id": "REPO_RADAR",
+      "name": "Repo Radar KPI System",
+      "summary": "8 KPI axes, radar render, badge_latest, PR comment, composite history.",
+      "features": [
+        {
+          "id": "KPI_RUN",
+          "name": "KPI Run Pipeline",
+          "description": "Computes KPI scores and emits render + PR artifacts.",
+          "artifacts": ["release_kpis/radar_*.png", "release_kpis/badge_latest*.svg", "release_kpis/PR_COMMENT*.md"],
+          "enforcement": ["CI: kpi.yml", "CI: kpi_gate.yml"],
+          "kpi_axes": ["All"]
+        },
+        {
+          "id": "LAYER_COVERAGE",
+          "name": "Layer Coverage Injection",
+          "description": "Appends Decision Infrastructure layer→KPI mapping into PR comment.",
+          "artifacts": ["release_kpis/PR_COMMENT*.md"],
+          "enforcement": ["scripts/kpi_run.py"],
+          "kpi_axes": ["Operational_Maturity", "Enterprise_Readiness"]
+        }
+      ]
+    },
+    {
+      "id": "ECON",
+      "name": "Economic Measurability (TEC / C-TEC)",
+      "summary": "Effort/cost modeling, sensitivity bands, complexity scaling.",
+      "features": [
+        {
+          "id": "TEC_MODEL",
+          "name": "TEC Baseline",
+          "description": "Time/Effort/Cost estimation outputs.",
+          "artifacts": ["release_kpis/TEC*.json", "release_kpis/TEC*.md"],
+          "enforcement": ["scripts/tec_run.py (if present)"],
+          "kpi_axes": ["Economic_Measurability"]
+        },
+        {
+          "id": "TEC_SENSITIVITY",
+          "name": "TEC Sensitivity Bands",
+          "description": "Best/expected/worst bounds + volatility metrics.",
+          "artifacts": ["release_kpis/TEC_SENSITIVITY*.json"],
+          "enforcement": ["scripts/tec_run.py (if present)"],
+          "kpi_axes": ["Economic_Measurability", "Operational_Maturity"]
+        }
+      ]
+    }
+  ],
+  "outer_edge_boundaries": [
+    "Not claiming full jurisdictional policy packs (EU AI Act article-by-article enforcement) yet",
+    "Not claiming full cryptographic attestation across all pipelines and connectors yet",
+    "Not claiming enterprise connectors (Jira/ServiceNow/SharePoint adapters) as complete (target v2.1.1)",
+    "Not claiming a full runtime control plane is governance (runtime is subordinate)"
+  ]
+}

--- a/scripts/kpi_run.py
+++ b/scripts/kpi_run.py
@@ -137,3 +137,27 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+# --- Feature Coverage (Catalog) ---
+def _append_feature_coverage_to_pr_comment(pr_comment_path: str = "release_kpis/PR_COMMENT.md") -> None:
+    import json
+    from pathlib import Path
+
+    cat_path = Path("release_kpis/feature_catalog.json")
+    if not cat_path.exists():
+        return
+
+    data = json.loads(cat_path.read_text(encoding="utf-8"))
+    lines = []
+    lines.append("")
+    lines.append("## 🧩 Feature Coverage (Catalog)")
+    for c in data.get("categories", []):
+        lines.append(f"- **{c.get('name','(unnamed)')}**: {len(c.get('features', []))} features")
+    p = Path(pr_comment_path)
+    if p.exists():
+        p.write_text(p.read_text(encoding="utf-8") + "\n" + "\n".join(lines) + "\n", encoding="utf-8")
+
+try:
+    _append_feature_coverage_to_pr_comment()
+except Exception:
+    pass

--- a/scripts/render_feature_catalog.py
+++ b/scripts/render_feature_catalog.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+CAT = Path("release_kpis/feature_catalog.json")
+OUT = Path("docs/FEATURE_CATALOG.md")
+
+def main():
+    data = json.loads(CAT.read_text(encoding="utf-8"))
+
+    lines = []
+    lines.append("# DeepSigma Feature Catalog")
+    lines.append("")
+    lines.append("Machine source of truth: `release_kpis/feature_catalog.json`")
+    lines.append("")
+    lines.append("## Categories")
+    lines.append("")
+
+    for c in data["categories"]:
+        lines.append(f"### {c['name']}  \\n{c['summary']}")
+        lines.append("")
+        for f in c["features"]:
+            lines.append(f"- **{f['name']}** (`{f['id']}`)")
+            lines.append(f"  - {f['description']}")
+            if f.get("artifacts"):
+                lines.append(f"  - Artifacts: {', '.join(f['artifacts'])}")
+            if f.get("enforcement"):
+                lines.append(f"  - Enforcement: {', '.join(f['enforcement'])}")
+            if f.get("kpi_axes"):
+                lines.append(f"  - KPI axes: {', '.join(f['kpi_axes'])}")
+        lines.append("")
+
+    lines.append("## Outer-Edge Boundaries")
+    lines.append("")
+    for b in data.get("outer_edge_boundaries", []):
+        lines.append(f"- {b}")
+    lines.append("")
+
+    OUT.write_text("\n".join(lines), encoding="utf-8")
+    print("PASS: rendered docs/FEATURE_CATALOG.md")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add machine-readable feature catalog JSON\n- add catalog renderer script and generated docs page\n- wire feature coverage into KPI PR comment output\n- add top-level README links to feature catalog assets\n\n## Verification\n- make feature-catalog\n- python -m py_compile scripts/kpi_run.py scripts/render_feature_catalog.py