### PR TITLE
Reduce PR check noise for Core branches

### DIFF
--- a/.github/workflows/admissibility_gate.yml
+++ b/.github/workflows/admissibility_gate.yml
@@ -14,17 +14,6 @@ on:
       - 'tests/test_seal_and_prove*'
       - 'tests/test_authority_ledger*'
       - 'tests/test_verify_pack*'
-  pull_request:
-    paths:
-      - 'src/tools/reconstruct/**'
-      - 'schemas/reconstruct/**'
-      - 'tests/test_transparency*'
-      - 'tests/test_multisig*'
-      - 'tests/test_merkle*'
-      - 'tests/test_seal_and_prove*'
-      - 'tests/test_authority_ledger*'
-      - 'tests/test_verify_pack*'
-
 jobs:
   admissibility:
     name: Court-Grade Admissibility

--- a/.github/workflows/branch_sync_guard.yml
+++ b/.github/workflows/branch_sync_guard.yml
@@ -1,7 +1,6 @@
 name: Branch Sync Guard
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-  pull_request:
-    branches: [main]
-
 permissions:
   contents: read
 

--- a/.github/workflows/determinism_gate.yml
+++ b/.github/workflows/determinism_gate.yml
@@ -11,14 +11,6 @@ on:
       - 'tests/test_deterministic_seal.py'
       - 'tests/test_reconstruct_replay.py'
       - 'tests/golden/**'
-  pull_request:
-    paths:
-      - 'src/tools/reconstruct/**'
-      - 'schemas/reconstruct/**'
-      - 'tests/test_deterministic_seal.py'
-      - 'tests/test_reconstruct_replay.py'
-      - 'tests/golden/**'
-
 jobs:
   determinism:
     name: Determinism Verification

--- a/.github/workflows/docker-coherence.yml
+++ b/.github/workflows/docker-coherence.yml
@@ -14,10 +14,6 @@ on:
       - 'pyproject.toml'
       - 'docker/Dockerfile.coherence'
       - '.github/workflows/docker-coherence.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.coherence'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-exhaust.yml
+++ b/.github/workflows/docker-exhaust.yml
@@ -17,11 +17,6 @@ on:
       - 'pyproject.toml'
       - 'docker/Dockerfile.exhaust'
       - '.github/workflows/docker-exhaust.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.exhaust'
-      - 'dashboard/server/exhaust_main.py'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-mcp.yml
+++ b/.github/workflows/docker-mcp.yml
@@ -12,10 +12,6 @@ on:
       - 'pyproject.toml'
       - 'docker/Dockerfile.mcp'
       - '.github/workflows/docker-mcp.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.mcp'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-otel.yml
+++ b/.github/workflows/docker-otel.yml
@@ -11,11 +11,6 @@ on:
       - 'pyproject.toml'
       - 'docker/Dockerfile.otel'
       - '.github/workflows/docker-otel.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.otel'
-      - 'src/adapters/otel/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,11 +18,6 @@ on:
       - 'specs/**'
       - 'src/adapters/**'
       - 'pyproject.toml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'dashboard/**'
-      - 'Dockerfile'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-rdf.yml
+++ b/.github/workflows/docker-rdf.yml
@@ -8,11 +8,6 @@ on:
       - 'docs/rdf/**'
       - 'docker/Dockerfile.rdf'
       - '.github/workflows/docker-rdf.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.rdf'
-      - 'docs/rdf/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-tools.yml
+++ b/.github/workflows/docker-tools.yml
@@ -15,10 +15,6 @@ on:
       - 'pyproject.toml'
       - 'docker/Dockerfile.tools'
       - '.github/workflows/docker-tools.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docker/Dockerfile.tools'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/helm_chart_validate.yml
+++ b/.github/workflows/helm_chart_validate.yml
@@ -1,11 +1,6 @@
 name: Helm Chart Validation
 
 on:
-  pull_request:
-    paths:
-      - "charts/**"
-      - "docs/deployment/HELM.md"
-      - ".github/workflows/helm_chart_validate.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/kpi.yml
+++ b/.github/workflows/kpi.yml
@@ -1,7 +1,6 @@
 name: Repo Radar KPI
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/kpi_gate.yml
+++ b/.github/workflows/kpi_gate.yml
@@ -1,7 +1,6 @@
 name: Repo KPI Gate
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mesh_wan_integration.yml
+++ b/.github/workflows/mesh_wan_integration.yml
@@ -1,7 +1,6 @@
 name: Mesh WAN Integration
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -1,7 +1,6 @@
 name: OpenAPI Sync
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/prompt_os_validate.yml
+++ b/.github/workflows/prompt_os_validate.yml
@@ -11,14 +11,6 @@ on:
       - 'src/tools/prompt_os/**'
       - 'docs/prompt_os/**'
       - 'tests/test_prompt_os_*.py'
-  pull_request:
-    paths:
-      - 'artifacts/sample_data/prompt_os_v2/**'
-      - 'schemas/prompt_os/**'
-      - 'src/tools/prompt_os/**'
-      - 'docs/prompt_os/**'
-      - 'tests/test_prompt_os_*.py'
-
 jobs:
   validate:
     name: CSV ↔ Schema Validation

--- a/.github/workflows/reconstruct_replay.yml
+++ b/.github/workflows/reconstruct_replay.yml
@@ -10,13 +10,6 @@ on:
       - 'src/tools/reconstruct/**'
       - 'docs/governance/**'
       - 'tests/test_reconstruct_*.py'
-  pull_request:
-    paths:
-      - 'schemas/reconstruct/**'
-      - 'src/tools/reconstruct/**'
-      - 'docs/governance/**'
-      - 'tests/test_reconstruct_*.py'
-
 jobs:
   reconstruct:
     name: Seal + Replay Validation

--- a/.github/workflows/roadmap_guard.yml
+++ b/.github/workflows/roadmap_guard.yml
@@ -1,7 +1,6 @@
 name: Roadmap Scope Guard
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scale_benchmark.yml
+++ b/.github/workflows/scale_benchmark.yml
@@ -2,14 +2,6 @@ name: Stateless API Scale Benchmark
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "docker/scale/**"
-      - "scripts/run_scale_benchmark.py"
-      - "scripts/run_scale_stack.sh"
-      - "docs/scaling/STATELESS_API_SCALE_GUIDE.md"
-      - "docs/examples/scale/**"
-
 permissions:
   contents: read
 

--- a/.github/workflows/security_gate.yml
+++ b/.github/workflows/security_gate.yml
@@ -1,7 +1,6 @@
 name: Security Gate
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/signature_gate.yml
+++ b/.github/workflows/signature_gate.yml
@@ -9,12 +9,6 @@ on:
       - 'src/tools/reconstruct/**'
       - 'schemas/reconstruct/signature_block_v1.json'
       - 'tests/test_signature_support.py'
-  pull_request:
-    paths:
-      - 'src/tools/reconstruct/**'
-      - 'schemas/reconstruct/signature_block_v1.json'
-      - 'tests/test_signature_support.py'
-
 jobs:
   signature:
     name: Sign + Verify Validation

--- a/.github/workflows/validate-llm-data-model.yml
+++ b/.github/workflows/validate-llm-data-model.yml
@@ -9,10 +9,6 @@ on:
     paths:
       - 'docs/llm_data_model/**'
       - '.github/workflows/validate-llm-data-model.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'docs/llm_data_model/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove pull_request triggers from non-core workflows
- Keep pull_request triggers only for required Core checks: coherence-ci and no-dupes
- Preserve push/workflow_dispatch behavior for non-core workflows

## Why
Core-focused PRs were showing large red check noise from enterprise workflows that are not required by branch protection.

## Result
PR signal is cleaner while required governance checks remain enforced.
