### PR TITLE
docs(wiki): refresh Home intro from RAL to execution governance

### DIFF
--- a/_park_enterprise/docs/wiki/Home.md
+++ b/_park_enterprise/docs/wiki/Home.md
@@ -1,9 +1,9 @@
-# Σ OVERWATCH / RAL — Wiki
+# DeepSigma Enterprise Wiki
 
-**Σ OVERWATCH (RAL — Reality Await Layer)** is a runtime control plane for agentic AI.
-It enforces deadlines, freshness, safe actions, and verification — then seals every decision into an immutable `DecisionEpisode` and feeds the Drift → Patch learning loop.
+**DeepSigma** is an execution-governance and coherence-operations platform for AI and human decision systems.
+It applies pre-execution authority gates, policy-bound execution contracts, and sealed decision evidence to ensure governance is enforceable before state changes, then routes outcomes into the Drift → Patch learning loop.
 
-> If you only read one thing: **RAL is "await for reality."**
+> If you only read one thing: **governance must constrain execution, not just describe it afterward.**
 
 ---
 


### PR DESCRIPTION
## Summary\n- update wiki Home heading and opening paragraph\n- replace legacy Overwatch/RAL framing with current DeepSigma execution-governance positioning\n- keep the rest of wiki navigation unchanged\n\n## Notes\n- requested update to top paragraph only