### PR TITLE
ci: fix tag pipeline with dedicated release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
 permissions:
   contents: read
 

--- a/.github/workflows/release-editions.yml
+++ b/.github/workflows/release-editions.yml
@@ -1,0 +1,63 @@
+name: Release Editions
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-editions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PY_VERSION="$(python - <<'PY'
+          import re
+          from pathlib import Path
+          t = Path("pyproject.toml").read_text(encoding="utf-8")
+          m = re.search(r'^version\s*=\s*"([^"]+)"', t, re.M)
+          if not m:
+              raise SystemExit("version not found in pyproject.toml")
+          print(m.group(1))
+          PY
+          )"
+          if [ "$TAG_VERSION" != "$PY_VERSION" ]; then
+            echo "Tag version v$TAG_VERSION does not match pyproject version $PY_VERSION"
+            exit 1
+          fi
+
+      - name: Build edition artifacts
+        run: |
+          make release-artifacts
+          ls -lh dist/
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepsigma-edition-zips
+          path: |
+            dist/deepsigma-core-v*.zip
+            dist/deepsigma-enterprise-v*.zip
+          if-no-files-found: error
+
+      - name: Publish release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/deepsigma-core-v*.zip
+            dist/deepsigma-enterprise-v*.zip


### PR DESCRIPTION
## Problem
Tag pushes were running legacy CI jobs that depend on paths/tests no longer present in core-first layout, causing tag failures.

## Fix
- remove tag trigger from legacy .github/workflows/ci.yml
- add .github/workflows/release-editions.yml for tag/manual releases
- release workflow builds and publishes:
  - deepsigma-core-vX.Y.Z.zip
  - deepsigma-enterprise-vX.Y.Z.zip
- enforce tag version matches pyproject.toml

## Validation
- YAML parse for both workflow files
- make release-artifacts