### PR TITLE
chore: cleanup pass for main directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ test-enterprise:
 	python -m pytest tests-enterprise/ -q
 
 release-artifacts:
-	python scripts/build_release_artifacts.py
+	python enterprise/scripts/build_release_artifacts.py

--- a/enterprise/scripts/build_release_artifacts.py
+++ b/enterprise/scripts/build_release_artifacts.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 import zipfile
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DIST = ROOT / "dist"
 
 CORE_TOP = {
@@ -21,7 +21,6 @@ CORE_TOP = {
     "pyproject.toml",
     "requirements.txt",
     "run_money_demo.sh",
-    "run_enterprise_demo.sh",
 }
 
 
@@ -41,7 +40,7 @@ def is_core_file(path: str) -> bool:
     p = Path(path)
     if path in CORE_TOP:
         return True
-    if p.parts[0] in {"docs", "tests", "requirements", "src", "scripts"}:
+    if p.parts[0] in {"docs", "tests", "requirements", "src"}:
         if p.parts[0] == "src":
             # Core edition ships only core namespace + temporary shim.
             return len(p.parts) > 1 and p.parts[1] in {"core", "coherence_ops"}


### PR DESCRIPTION
## Cleanup pass
- move release builder from root scripts/ to enterprise/scripts/
- update Makefile release target to new path
- keep CORE artifact pure (no enterprise runner, no top-level scripts)
- local transient folders cleaned: dist, .pytest_cache, .benchmarks, .DS_Store

## Validation
- make release-artifacts
- verified core zip excludes run_enterprise_demo.sh and top-level scripts/