### PR TITLE
Pulse insights metrics + TEC/C-TEC integration

### DIFF
--- a/.github/workflows/kpi.yml
+++ b/.github/workflows/kpi.yml
@@ -34,6 +34,7 @@ jobs:
           make issue-label-gate
           make kpi-issues
           make roadmap-gate
+          make pulse-insights
 
       - name: Run KPI
         run: |
@@ -52,6 +53,7 @@ jobs:
             release_kpis/kpi_bands_*.json
             release_kpis/history.json
             release_kpis/issue_deltas.json
+            release_kpis/insights_metrics.json
             release_kpis/badge_latest.svg
             release_kpis/roadmap_badge.svg
             release_kpis/roadmap_forecast.json

--- a/.github/workflows/kpi_gate.yml
+++ b/.github/workflows/kpi_gate.yml
@@ -32,6 +32,7 @@ jobs:
           make issue-label-gate
           make kpi-issues
           make roadmap-gate
+          make pulse-insights
 
       - name: Run KPI (includes gate)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: demo core-demo core-baseline test-core core-ci \
 	enterprise-demo test-enterprise enterprise-ci \
 	edition-guard secret-scan security-gate openapi-check version-sync-check \
-	test-money release-artifacts
+	test-money release-artifacts pulse-insights
 
 demo:
 	bash run_money_demo.sh
@@ -50,3 +50,6 @@ version-sync-check:
 
 release-artifacts:
 	python enterprise/scripts/build_release_artifacts.py
+
+pulse-insights:
+	python enterprise/scripts/pulse_insights.py

--- a/enterprise/governance/tec_weights.yaml
+++ b/enterprise/governance/tec_weights.yaml
@@ -48,3 +48,15 @@ complexity:
   # Coordination/dependency complexity from issue references.
   dependency_ref_step: 0.05
   dependency_ref_cap: 0.4
+
+# Pulse insights adjustment for C-TEC.
+# Neutral score: 5.0
+# Lower scores increase effort; higher scores can reduce effort.
+insights:
+  enabled: true
+  neutral_score: 5.0
+  score_sensitivity: 0.02
+  max_reduction: 0.12
+  max_increase: 0.18
+  signal_step: 0.015
+  signal_cap: 0.12

--- a/enterprise/release_kpis/KPI_SUMMARY.md
+++ b/enterprise/release_kpis/KPI_SUMMARY.md
@@ -5,5 +5,6 @@
 - KPI is driven by:
   - Manual baseline file: `release_kpis/kpi_<version>.json`
   - Telemetry overlay (optional): `scripts/kpi_compute.py`
+  - Insights telemetry (optional): `release_kpis/insights_metrics.json`
   - Issue deltas: `scripts/kpi_from_issues.py` -> `release_kpis/issue_deltas.json`
   - Gate + history: `scripts/kpi_gate.py` -> `release_kpis/history.json`

--- a/enterprise/release_kpis/TEC_SUMMARY.md
+++ b/enterprise/release_kpis/TEC_SUMMARY.md
@@ -3,9 +3,9 @@
 ## Counts
 - issues_total: **167**
 - prs_merged: **190**
-- workflows: **29**
-- test_files: **99**
-- doc_files: **326**
+- workflows: **0**
+- test_files: **100**
+- doc_files: **323**
 - security_issues_tagged: **4**
 - committee_cycles_est: **0**
 - issues_with_pr_link_est: **90**
@@ -14,30 +14,39 @@
 - issues_weighted: **1574.8**
 - issues_complexity_weighted: **1981.0**
 - pr_overhead: **285.0**
-- workflows: **145.0**
-- tests: **198.0**
-- docs: **489.0**
+- workflows: **0.0**
+- tests: **200.0**
+- docs: **484.5**
 - committee: **0.0**
-- total_base: **2691.8**
-- total_ctec: **3098.0**
+- total_base: **2544.2**
+- total_ctec: **2782.9**
+- total_ctec_unadjusted: **2950.5**
+- insights_adjustment_hours: **-167.6**
 
 ## Complexity (C-TEC v1.0)
 - avg_index: **1.244**
 - max_index: **1.95**
 - signals: PR diff size, changed files, cross-subsystem touch, issue duration, dependency refs
 
+## Pulse Insights Adjustment
+- insights_present: **True**
+- insights_score: **7.84**
+- signal_count: **0**
+- adjustment_factor: **0.9432x**
+- adjustment_hours: **-167.6**
+
 ## Tiers (Low / Base / High)
 ### Internal @ $150/hr
-- Low:  2478.4 hrs | $371760.0
-- Base: 3098.0 hrs | $464700.0
-- High: 4182.3 hrs | $627345.0
+- Low:  2226.3 hrs | $333949.0
+- Base: 2782.9 hrs | $417437.0
+- High: 3756.9 hrs | $563540.0
 
 ### Executive @ $225/hr
-- Low:  2478.4 hrs | $557640.0
-- Base: 3098.0 hrs | $697050.0
-- High: 4182.3 hrs | $941018.0
+- Low:  2226.3 hrs | $500924.0
+- Base: 2782.9 hrs | $626155.0
+- High: 3756.9 hrs | $845309.0
 
 ### DoD Fully Burdened @ $275/hr
-- Low:  2478.4 hrs | $681560.0
-- Base: 3098.0 hrs | $851950.0
-- High: 4182.3 hrs | $1150132.0
+- Low:  2226.3 hrs | $612241.0
+- Base: 2782.9 hrs | $765301.0
+- High: 3756.9 hrs | $1033156.0

--- a/enterprise/release_kpis/insights_metrics.json
+++ b/enterprise/release_kpis/insights_metrics.json
@@ -1,0 +1,23 @@
+{
+  "schema": "pulse_insights_v1",
+  "generated_at": "2026-02-24T12:09:24Z",
+  "version": "v2.0.6",
+  "source": "pulse",
+  "insights_score": 7.84,
+  "signal_count": 0,
+  "signals": [],
+  "inputs": {
+    "issue_deltas_present": true,
+    "kpi_merged_present": true,
+    "history_present": true
+  },
+  "diagnostics": {
+    "closed_since_total": 42,
+    "open_total": 6,
+    "credit_delta_total": 5.3,
+    "debt_delta_total": 0.0,
+    "open_p0_caps": 0,
+    "kpi_average": 7.98,
+    "kpi_average_delta": 0.0
+  }
+}

--- a/enterprise/release_kpis/tec_dod.json
+++ b/enterprise/release_kpis/tec_dod.json
@@ -3,9 +3,9 @@
   "counts": {
     "issues_total": 167,
     "prs_merged": 190,
-    "workflows": 29,
-    "test_files": 99,
-    "doc_files": 326,
+    "workflows": 0,
+    "test_files": 100,
+    "doc_files": 323,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
     "issues_with_pr_link_est": 90
@@ -14,12 +14,14 @@
     "issues_weighted": 1574.8,
     "issues_complexity_weighted": 1981.0,
     "pr_overhead": 285.0,
-    "workflows": 145.0,
-    "tests": 198.0,
-    "docs": 489.0,
+    "workflows": 0.0,
+    "tests": 200.0,
+    "docs": 484.5,
     "committee": 0.0,
-    "total_base": 2691.8,
-    "total_ctec": 3098.0
+    "total_base": 2544.2,
+    "total_ctec": 2782.9,
+    "total_ctec_unadjusted": 2950.5,
+    "insights_adjustment_hours": -167.6
   },
   "complexity": {
     "avg_index": 1.244,
@@ -40,17 +42,26 @@
       "dependency_ref_cap": 0.4
     }
   },
+  "insights": {
+    "enabled": true,
+    "source": "release_kpis/insights_metrics.json",
+    "present": true,
+    "score": 7.84,
+    "signal_count": 0,
+    "factor": 0.9432,
+    "hours_delta": -167.6
+  },
   "rate_hourly": 275.0,
   "low": {
-    "hours": 2478.4,
-    "cost": 681560.0
+    "hours": 2226.3,
+    "cost": 612241.0
   },
   "base": {
-    "hours": 3098.0,
-    "cost": 851950.0
+    "hours": 2782.9,
+    "cost": 765301.0
   },
   "high": {
-    "hours": 4182.3,
-    "cost": 1150132.0
+    "hours": 3756.9,
+    "cost": 1033156.0
   }
 }

--- a/enterprise/release_kpis/tec_executive.json
+++ b/enterprise/release_kpis/tec_executive.json
@@ -3,9 +3,9 @@
   "counts": {
     "issues_total": 167,
     "prs_merged": 190,
-    "workflows": 29,
-    "test_files": 99,
-    "doc_files": 326,
+    "workflows": 0,
+    "test_files": 100,
+    "doc_files": 323,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
     "issues_with_pr_link_est": 90
@@ -14,12 +14,14 @@
     "issues_weighted": 1574.8,
     "issues_complexity_weighted": 1981.0,
     "pr_overhead": 285.0,
-    "workflows": 145.0,
-    "tests": 198.0,
-    "docs": 489.0,
+    "workflows": 0.0,
+    "tests": 200.0,
+    "docs": 484.5,
     "committee": 0.0,
-    "total_base": 2691.8,
-    "total_ctec": 3098.0
+    "total_base": 2544.2,
+    "total_ctec": 2782.9,
+    "total_ctec_unadjusted": 2950.5,
+    "insights_adjustment_hours": -167.6
   },
   "complexity": {
     "avg_index": 1.244,
@@ -40,17 +42,26 @@
       "dependency_ref_cap": 0.4
     }
   },
+  "insights": {
+    "enabled": true,
+    "source": "release_kpis/insights_metrics.json",
+    "present": true,
+    "score": 7.84,
+    "signal_count": 0,
+    "factor": 0.9432,
+    "hours_delta": -167.6
+  },
   "rate_hourly": 225.0,
   "low": {
-    "hours": 2478.4,
-    "cost": 557640.0
+    "hours": 2226.3,
+    "cost": 500924.0
   },
   "base": {
-    "hours": 3098.0,
-    "cost": 697050.0
+    "hours": 2782.9,
+    "cost": 626155.0
   },
   "high": {
-    "hours": 4182.3,
-    "cost": 941018.0
+    "hours": 3756.9,
+    "cost": 845309.0
   }
 }

--- a/enterprise/release_kpis/tec_internal.json
+++ b/enterprise/release_kpis/tec_internal.json
@@ -3,9 +3,9 @@
   "counts": {
     "issues_total": 167,
     "prs_merged": 190,
-    "workflows": 29,
-    "test_files": 99,
-    "doc_files": 326,
+    "workflows": 0,
+    "test_files": 100,
+    "doc_files": 323,
     "security_issues_tagged": 4,
     "committee_cycles_est": 0,
     "issues_with_pr_link_est": 90
@@ -14,12 +14,14 @@
     "issues_weighted": 1574.8,
     "issues_complexity_weighted": 1981.0,
     "pr_overhead": 285.0,
-    "workflows": 145.0,
-    "tests": 198.0,
-    "docs": 489.0,
+    "workflows": 0.0,
+    "tests": 200.0,
+    "docs": 484.5,
     "committee": 0.0,
-    "total_base": 2691.8,
-    "total_ctec": 3098.0
+    "total_base": 2544.2,
+    "total_ctec": 2782.9,
+    "total_ctec_unadjusted": 2950.5,
+    "insights_adjustment_hours": -167.6
   },
   "complexity": {
     "avg_index": 1.244,
@@ -40,17 +42,26 @@
       "dependency_ref_cap": 0.4
     }
   },
+  "insights": {
+    "enabled": true,
+    "source": "release_kpis/insights_metrics.json",
+    "present": true,
+    "score": 7.84,
+    "signal_count": 0,
+    "factor": 0.9432,
+    "hours_delta": -167.6
+  },
   "rate_hourly": 150.0,
   "low": {
-    "hours": 2478.4,
-    "cost": 371760.0
+    "hours": 2226.3,
+    "cost": 333949.0
   },
   "base": {
-    "hours": 3098.0,
-    "cost": 464700.0
+    "hours": 2782.9,
+    "cost": 417437.0
   },
   "high": {
-    "hours": 4182.3,
-    "cost": 627345.0
+    "hours": 3756.9,
+    "cost": 563540.0
   }
 }

--- a/enterprise/scripts/pulse_insights.py
+++ b/enterprise/scripts/pulse_insights.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def clamp(value: float, lo: float = 0.0, hi: float = 10.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def version_from_file(outdir: Path) -> str:
+    version_file = outdir / "VERSION.txt"
+    if not version_file.exists():
+        return "v0.0.0"
+    return version_file.read_text(encoding="utf-8").strip()
+
+
+def average(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def score_from_inputs(
+    issue_deltas: dict[str, Any] | None,
+    merged: dict[str, Any] | None,
+    history: dict[str, Any] | None,
+) -> tuple[float, list[dict[str, Any]], dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    base = 5.0
+
+    diagnostics: dict[str, Any] = {
+        "closed_since_total": 0,
+        "open_total": 0,
+        "credit_delta_total": 0.0,
+        "debt_delta_total": 0.0,
+        "open_p0_caps": 0,
+        "kpi_average": None,
+        "kpi_average_delta": None,
+    }
+
+    if issue_deltas:
+        kpis = issue_deltas.get("kpis", {})
+        if isinstance(kpis, dict):
+            closed = 0
+            open_count = 0
+            credit = 0.0
+            debt = 0.0
+            p0_caps = 0
+            for details in kpis.values():
+                if not isinstance(details, dict):
+                    continue
+                closed += int(details.get("closed_since_count", 0))
+                open_count += int(details.get("open_count", 0))
+                credit += float(details.get("credit_delta", 0.0))
+                debt += float(details.get("debt_delta", 0.0))
+                if details.get("cap_if_open_p0") is not None:
+                    p0_caps += 1
+
+            diagnostics["closed_since_total"] = closed
+            diagnostics["open_total"] = open_count
+            diagnostics["credit_delta_total"] = round(credit, 2)
+            diagnostics["debt_delta_total"] = round(debt, 2)
+            diagnostics["open_p0_caps"] = p0_caps
+
+            base += min(2.0, closed / 25.0)
+            base -= min(2.5, debt / 10.0)
+            base -= min(1.0, open_count / 200.0)
+
+            if debt > credit:
+                signals.append(
+                    {
+                        "id": "debt_exceeds_credit",
+                        "severity": "high",
+                        "message": "Issue debt delta exceeds closure credit delta.",
+                        "value": {"credit_delta": round(credit, 2), "debt_delta": round(debt, 2)},
+                    }
+                )
+            if p0_caps > 0:
+                signals.append(
+                    {
+                        "id": "open_p0_caps",
+                        "severity": "high",
+                        "message": "One or more KPI tracks report open P0 caps.",
+                        "value": {"kpi_tracks": p0_caps},
+                    }
+                )
+
+    if merged:
+        values = merged.get("values", {})
+        if isinstance(values, dict):
+            numeric_values = [float(v) for v in values.values() if isinstance(v, (int, float))]
+            kpi_avg = average(numeric_values)
+            diagnostics["kpi_average"] = round(kpi_avg, 2)
+            base += clamp((kpi_avg - 5.0) / 2.5, -2.0, 2.0)
+            if kpi_avg < 6.0:
+                signals.append(
+                    {
+                        "id": "kpi_mean_low",
+                        "severity": "medium",
+                        "message": "Merged KPI mean is below target threshold (6.0).",
+                        "value": {"kpi_average": round(kpi_avg, 2)},
+                    }
+                )
+
+    if history:
+        entries = history.get("entries", [])
+        if isinstance(entries, list) and len(entries) >= 2:
+            latest = entries[-1].get("values", {})
+            previous = entries[-2].get("values", {})
+            if isinstance(latest, dict) and isinstance(previous, dict):
+                deltas = []
+                for key, current in latest.items():
+                    if key in previous and isinstance(current, (int, float)) and isinstance(
+                        previous[key], (int, float)
+                    ):
+                        deltas.append(float(current) - float(previous[key]))
+                avg_delta = average(deltas)
+                diagnostics["kpi_average_delta"] = round(avg_delta, 3)
+                base += clamp(avg_delta, -1.0, 1.0)
+                if avg_delta < 0:
+                    signals.append(
+                        {
+                            "id": "kpi_trend_down",
+                            "severity": "medium",
+                            "message": "KPI average trend is negative versus previous release.",
+                            "value": {"avg_delta": round(avg_delta, 3)},
+                        }
+                    )
+
+    return round(clamp(base), 2), signals, diagnostics
+
+
+def main() -> int:
+    outdir = ROOT / "release_kpis"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    version = version_from_file(outdir)
+    issue_deltas = load_json(outdir / "issue_deltas.json")
+    merged = load_json(outdir / f"kpi_{version}_merged.json")
+    history = load_json(outdir / "history.json")
+
+    score, signals, diagnostics = score_from_inputs(issue_deltas, merged, history)
+    payload = {
+        "schema": "pulse_insights_v1",
+        "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "version": version,
+        "source": "pulse",
+        "insights_score": score,
+        "signal_count": len(signals),
+        "signals": signals,
+        "inputs": {
+            "issue_deltas_present": issue_deltas is not None,
+            "kpi_merged_present": merged is not None,
+            "history_present": history is not None,
+        },
+        "diagnostics": diagnostics,
+    }
+
+    out_path = outdir / "insights_metrics.json"
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/enterprise/tests/test_pulse_insights.py
+++ b/enterprise/tests/test_pulse_insights.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module(repo_root: Path):
+    mod_path = repo_root / "scripts" / "pulse_insights.py"
+    spec = importlib.util.spec_from_file_location("pulse_insights", mod_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pulse_insights_writes_metrics_file(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True, exist_ok=True)
+    (repo / "release_kpis").mkdir(parents=True, exist_ok=True)
+
+    source = Path(__file__).resolve().parents[1] / "scripts" / "pulse_insights.py"
+    (repo / "scripts" / "pulse_insights.py").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    release_kpis = repo / "release_kpis"
+    output = release_kpis / "insights_metrics.json"
+    (release_kpis / "VERSION.txt").write_text("v2.0.6\n", encoding="utf-8")
+    (release_kpis / "issue_deltas.json").write_text(
+        json.dumps(
+            {
+                "kpis": {
+                    "automation_depth": {
+                        "open_count": 4,
+                        "closed_since_count": 3,
+                        "credit_delta": 2.2,
+                        "debt_delta": 0.5,
+                        "cap_if_open_p0": None,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (release_kpis / "kpi_v2.0.6_merged.json").write_text(
+        json.dumps(
+            {
+                "values": {
+                    "technical_completeness": 7.1,
+                    "automation_depth": 6.8,
+                    "authority_modeling": 6.2,
+                    "enterprise_readiness": 6.0,
+                    "scalability": 6.1,
+                    "data_integration": 6.4,
+                    "economic_measurability": 5.9,
+                    "operational_maturity": 6.5,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (release_kpis / "history.json").write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {"version": "v2.0.5", "values": {"automation_depth": 6.0}},
+                    {"version": "v2.0.6", "values": {"automation_depth": 6.8}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    module = _load_module(repo)
+    module.ROOT = repo
+    module.OUT = repo / "release_kpis"
+    assert module.main() == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema"] == "pulse_insights_v1"
+    assert payload["source"] == "pulse"
+    assert isinstance(payload["insights_score"], (int, float))
+    assert "signals" in payload
+    assert payload["inputs"]["issue_deltas_present"] is True

--- a/enterprise/tests/test_tec_estimate_insights.py
+++ b/enterprise/tests/test_tec_estimate_insights.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module(repo_root: Path):
+    mod_path = repo_root / "scripts" / "tec_estimate.py"
+    spec = importlib.util.spec_from_file_location("tec_estimate", mod_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_weights(path: Path) -> None:
+    path.write_text(
+        """
+rates:
+  internal_hourly: 150
+  exec_hourly: 225
+  dod_fully_burdened_hourly: 275
+uncertainty:
+  low: 0.8
+  base: 1.0
+  high: 1.35
+issue_hours:
+  type:feature: 8
+  security_default: 12
+  committee_cycle: 8
+severity_multiplier:
+  sev:P2: 1.0
+complexity: {}
+insights:
+  enabled: true
+  neutral_score: 5.0
+  score_sensitivity: 0.02
+  max_reduction: 0.12
+  max_increase: 0.18
+  signal_step: 0.015
+  signal_cap: 0.12
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_insights_adjustment_reduces_hours_for_high_score(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True, exist_ok=True)
+    (repo / "governance").mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parents[1] / "scripts" / "tec_estimate.py"
+    (repo / "scripts" / "tec_estimate.py").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    _write_weights(repo / "governance" / "tec_weights.yaml")
+
+    module = _load_module(repo)
+    adjusted, details = module._insights_adjustment(100.0, {"insights_score": 9.0, "signal_count": 0})
+    assert adjusted < 100.0
+    assert details["factor"] < 1.0
+
+
+def test_insights_adjustment_increases_hours_for_low_score_and_signals(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True, exist_ok=True)
+    (repo / "governance").mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parents[1] / "scripts" / "tec_estimate.py"
+    (repo / "scripts" / "tec_estimate.py").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    _write_weights(repo / "governance" / "tec_weights.yaml")
+
+    module = _load_module(repo)
+    adjusted, details = module._insights_adjustment(
+        100.0, {"insights_score": 2.0, "signals": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
+    )
+    assert adjusted > 100.0
+    assert details["signal_count"] == 3
+    assert details["factor"] > 1.0


### PR DESCRIPTION
## Summary
- add Pulse insights writer (`enterprise/scripts/pulse_insights.py`) to generate `enterprise/release_kpis/insights_metrics.json`
- wire Pulse insights generation into KPI workflows before KPI execution
- expose insights telemetry in KPI compute and PR comment outputs
- integrate insights-based adjustment into TEC/C-TEC estimates with bounded weighting
- add tests for pulse insights and TEC insights adjustment

## Validation
- `python -m pytest enterprise/tests/test_pulse_insights.py enterprise/tests/test_tec_estimate_insights.py enterprise/tests/test_kpi_compute_security_metrics.py -q`
- `python -m ruff check enterprise/scripts/pulse_insights.py enterprise/scripts/tec_estimate.py enterprise/tests/test_pulse_insights.py enterprise/tests/test_tec_estimate_insights.py`
- `make pulse-insights`
- `python enterprise/scripts/tec_estimate.py`
