### PR TITLE
Edition contract + enterprise extras alignment

### DIFF
--- a/EDITION_DIFF.md
+++ b/EDITION_DIFF.md
@@ -1,0 +1,53 @@
+# DeepSigma Edition Contract
+
+This file is the canonical boundary ledger between CORE and ENTERPRISE.
+
+## Scope
+
+- One product line, one version stream.
+- Two editions:
+  - CORE (default)
+  - ENTERPRISE (optional surfaces)
+
+## Source Layout Contract
+
+- CORE code lives in:
+  - `src/core/`
+  - `src/coherence_ops/`
+- ENTERPRISE code lives in:
+  - `enterprise/src/`
+  - `enterprise/dashboard/`
+  - `enterprise/docs/`
+  - `enterprise/scripts/`
+  - `enterprise/release_kpis/`
+
+## Packaging Contract
+
+- Base install:
+  - `pip install deepsigma`
+- Enterprise extras install:
+  - `pip install "deepsigma[enterprise]"`
+  - Extras are dependency-focused; enterprise repo surfaces are run from source in `enterprise/`.
+
+## Artifact Contract
+
+- CORE artifact:
+  - `dist/deepsigma-core-vX.Y.Z.zip`
+- ENTERPRISE artifact:
+  - `dist/deepsigma-enterprise-vX.Y.Z.zip`
+
+## CI Contract
+
+- CORE always-on gates:
+  - `make edition-guard`
+  - `make core-ci` (money demo + baseline + core tests)
+- ENTERPRISE optional gate:
+  - `make enterprise-ci` (enterprise demo + enterprise tests)
+- Guardrail:
+  - CORE must not import enterprise modules (`edition-guard`).
+
+## Change Rules
+
+- Changes that widen CORE scope must update this file.
+- Any move of files between CORE and ENTERPRISE must update this file.
+- CI gate changes must preserve CORE always-on and ENTERPRISE optional behavior unless explicitly versioned and approved.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ DeepSigma is institutional decision infrastructure: capture intent, run governed
 This repository ships as one product line with one version and two editions:
 
 - **CORE edition:** minimal, demo-first, deterministic (`pip install deepsigma`)
-- **ENTERPRISE edition:** extended adapters, dashboards, and ops surfaces (`pip install "deepsigma[enterprise]"`)
+- **ENTERPRISE edition:** extended adapters, dashboards, and ops surfaces (repo-native under `enterprise/`)
+
+Edition boundary ledger:
+- `EDITION_DIFF.md`
 
 ## Quick Start (Core)
 
@@ -52,6 +55,10 @@ Active Core surface at repo root:
 ### Enterprise Mode
 
 Use Enterprise mode when you need connectors, dashboards, extended security, broader telemetry, and integration-heavy workflows.
+
+Dependency note:
+- `pip install "deepsigma[enterprise]"` installs enterprise runtime extras used by telemetry/radar tooling.
+- Full enterprise code surfaces are repository-native under `enterprise/` and are run from source in this repo.
 
 Enterprise surfaces are first-class under:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dev = [
 excel = [
     "openpyxl>=3.1.0",
 ]
-enterprise = []
+enterprise = [
+    "matplotlib>=3.10.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/8ryanWh1t3/DeepSigma"


### PR DESCRIPTION
## Summary
- add root edition boundary ledger (`EDITION_DIFF.md`)
- populate enterprise extras in `pyproject.toml`
- align README enterprise install wording with packaging/runtime reality

## Notes
- CORE/ENTERPRISE CI gate model remains unchanged (core always, enterprise optional)
