### PR TITLE
feat: add Authority Boundary Primitive (ABP) v1

### DIFF
--- a/enterprise/artifacts/public_demo_pack/abp_v1.json
+++ b/enterprise/artifacts/public_demo_pack/abp_v1.json
@@ -1,0 +1,159 @@
+{
+  "abp_version": "1.0",
+  "abp_id": "ABP-14dbac91",
+  "scope": {
+    "contract_id": "CTR-DEMO-001",
+    "program": "SEQUOIA",
+    "modules": [
+      "hiring",
+      "bid",
+      "compliance",
+      "boe"
+    ]
+  },
+  "authority_ref": {
+    "authority_entry_id": "AUTH-033059a5",
+    "authority_entry_hash": "sha256:521ae3f9e87b49dd954160ba859fe96205d15367c807bc96b8f6368e60d3d40c",
+    "authority_ledger_path": "enterprise/artifacts/public_demo_pack/authority_ledger.ndjson"
+  },
+  "objectives": {
+    "allowed": [
+      {
+        "id": "OBJ-001",
+        "description": "Evaluate bid/no-bid for opportunity DEC-001"
+      },
+      {
+        "id": "OBJ-002",
+        "description": "Assess staffing readiness for contract execution"
+      }
+    ],
+    "denied": [
+      {
+        "id": "OBJ-D01",
+        "description": "Modify sealed decisions",
+        "reason": "Sealed artifacts are immutable per governance policy"
+      }
+    ]
+  },
+  "tools": {
+    "allow": [
+      {
+        "name": "seal_bundle",
+        "scope": "DEC-001"
+      },
+      {
+        "name": "sign_artifact",
+        "scope": "DEC-001"
+      },
+      {
+        "name": "replay_sealed_run",
+        "scope": null
+      }
+    ],
+    "deny": [
+      {
+        "name": "authority_ledger_revoke",
+        "reason": "Only reviewers may revoke authority grants"
+      }
+    ]
+  },
+  "data": {
+    "permissions": [
+      {
+        "resource": "decision_log.csv",
+        "operations": [
+          "read"
+        ],
+        "roles": [
+          "Operator"
+        ],
+        "sensitivity": "internal"
+      },
+      {
+        "resource": "sealed_runs/*",
+        "operations": [
+          "read",
+          "write"
+        ],
+        "roles": [
+          "Operator"
+        ],
+        "sensitivity": "confidential"
+      }
+    ]
+  },
+  "approvals": {
+    "required": [
+      {
+        "action": "seal_decision",
+        "approver_role": "Reviewer",
+        "threshold": 1,
+        "timeout_ms": null
+      },
+      {
+        "action": "revoke_authority",
+        "approver_role": "Admin",
+        "threshold": 1,
+        "timeout_ms": 86400000
+      }
+    ]
+  },
+  "escalation": {
+    "paths": [
+      {
+        "trigger": "gate_fail",
+        "destination": "Reviewer",
+        "severity": "warn",
+        "auto": true
+      },
+      {
+        "trigger": "authority_expired",
+        "destination": "Admin",
+        "severity": "critical",
+        "auto": true
+      }
+    ]
+  },
+  "runtime": {
+    "validators": [
+      {
+        "name": "authority_envelope_complete",
+        "when": "pre_action",
+        "fail_action": "block",
+        "config": {}
+      },
+      {
+        "name": "policy_hash_matches",
+        "when": "pre_action",
+        "fail_action": "block",
+        "config": {}
+      },
+      {
+        "name": "drift_threshold",
+        "when": "periodic",
+        "fail_action": "escalate",
+        "config": {
+          "max_ds": 6
+        }
+      }
+    ]
+  },
+  "proof": {
+    "required": [
+      "seal",
+      "manifest",
+      "pack_hash",
+      "transparency_log",
+      "authority_ledger"
+    ]
+  },
+  "composition": {
+    "parent_abp_id": null,
+    "parent_abp_hash": null,
+    "children": []
+  },
+  "effective_at": "2026-02-21T00:00:00Z",
+  "expires_at": null,
+  "created_at": "2026-02-24T00:00:00Z",
+  "hash": "sha256:d1b8789663a8521006cd1b5cae10c1c3c835dec77d57e7b8cf77eb807c9aa4e8"
+}

--- a/enterprise/docs/31-abp.md
+++ b/enterprise/docs/31-abp.md
@@ -1,0 +1,147 @@
+# 31 — Authority Boundary Primitive (ABP)
+
+## What It Is
+
+The Authority Boundary Primitive (ABP) is a **stack-independent, pre-runtime governance declaration**. It declares what is allowed, denied, and required before any enforcement engine executes.
+
+Unlike the authority envelope (which captures runtime state at decision time), the ABP defines boundaries *before* runtime begins. Any enforcement engine can read an ABP to know the boundaries without needing DeepSigma's runtime. Authority becomes infrastructure; tooling becomes replaceable; governance stays stable.
+
+## Why It Exists
+
+DeepSigma's runtime proof layer (sealed runs, authority envelopes, DLR/RS/DS seals, transparency logs) provides enforcement **evidence** — proof that governance operated. The ABP provides the **specification** — what governance *should* enforce.
+
+| Layer | What | When | Example |
+| --- | --- | --- | --- |
+| ABP | Declaration | Pre-runtime | "Operators may seal decisions but cannot revoke authority" |
+| Authority Envelope | State capture | At decision time | "Operator X had direct authority, 5 gates checked, 0 failed" |
+| Sealed Run | Evidence | Post-execution | Hash-chained proof that all of the above happened |
+
+## Schema
+
+`enterprise/schemas/reconstruct/abp_v1.json`
+
+### Required Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `abp_version` | `"1.0"` | Schema version |
+| `abp_id` | `ABP-<hex8>` | Deterministic ID from `sha256(canonical(scope + authority_ref + created_at))` |
+| `scope` | object | Contract, program, and modules this ABP covers |
+| `authority_ref` | object | Binding to an authority ledger entry |
+| `objectives` | object | Allowed and denied objectives with reasons |
+| `tools` | object | Allowed and denied tools with scope/reason |
+| `data` | object | Data permissions by resource, operation, role, sensitivity |
+| `approvals` | object | Required approval workflows |
+| `escalation` | object | Escalation paths with triggers and severity |
+| `runtime` | object | Validators to run pre/post/periodic |
+| `proof` | object | Required proof artifacts (seal, manifest, etc.) |
+| `composition` | object | Parent/child ABP references for hierarchical composition |
+| `effective_at` | ISO 8601 | When ABP becomes effective |
+| `expires_at` | ISO 8601 or null | Expiry (null = no expiry) |
+| `created_at` | ISO 8601 | Creation timestamp |
+| `hash` | `sha256:...` | Self-authenticating content hash |
+
+### ABP ID
+
+Deterministic: `ABP-` + first 8 hex chars of `sha256(canonical(scope + authority_ref + created_at))`. Same inputs always produce the same ID.
+
+### Hash
+
+Self-authenticating: `sha256(canonical(abp with hash=""))`. Same pattern used by sealed runs and authority ledger entries.
+
+### Authority Ref
+
+Binds to an existing authority ledger entry by `entry_id` and `entry_hash`. Does not duplicate authority data — references it.
+
+## Lifecycle
+
+```
+1. Create ABP       build_abp() or build_abp.py CLI
+2. Bind to authority authority_ref points to ledger entry
+3. Attach to pack   seal_and_prove.py --auto-abp (or --abp-path)
+4. Verify            verify_abp.py or verify_pack.py (auto-discovers abp_v1.json)
+```
+
+## Composition
+
+Program-level ABPs can compose module-level ABPs:
+
+```
+Program ABP (parent)
+  ├── Hiring Module ABP (child)
+  ├── Compliance Module ABP (child)
+  └── BOE Module ABP (child)
+```
+
+The `compose_abps()` function merges boundaries from children and records child references in `composition.children`. Each child's `abp_id` and `hash` are preserved.
+
+## ABP vs Authority Envelope
+
+| Aspect | ABP | Authority Envelope |
+| --- | --- | --- |
+| **When** | Pre-runtime | At decision time |
+| **Declares** | What's allowed/denied/required | What actor had what authority |
+| **Contains** | Tool lists, data permissions, escalation paths | Gate outcomes, refusal state, policy snapshot |
+| **Portable** | Yes — any engine can read it | Bound to DeepSigma sealed run |
+| **Verifiable** | Hash + ID + authority ref | Embedded in sealed run hash chain |
+
+## Verification Checks
+
+`verify_abp.py` performs 7 checks:
+
+1. **abp.schema_valid** — validates against JSON schema
+2. **abp.hash_integrity** — recomputes content hash
+3. **abp.id_deterministic** — recomputes ABP ID from inputs
+4. **abp.authority_ref_valid** — entry exists in ledger, not revoked
+5. **abp.authority_not_expired** — ABP created_at within authority window
+6. **abp.composition_valid** — parent/child refs consistent, no duplicates
+7. **abp.no_contradictions** — no tool/objective in both allow and deny
+
+## CLI Usage
+
+### Build
+
+```bash
+python enterprise/src/tools/reconstruct/build_abp.py \
+    --scope '{"contract_id":"CTR-001","program":"SEQUOIA","modules":["hiring","bid"]}' \
+    --authority-entry-id AUTH-033059a5 \
+    --authority-ledger enterprise/artifacts/authority_ledger/ledger.ndjson \
+    --config abp_config.json \
+    --clock 2026-02-24T00:00:00Z \
+    --out-dir artifacts/abp
+```
+
+### Verify
+
+```bash
+python enterprise/src/tools/reconstruct/verify_abp.py \
+    --abp artifacts/abp/abp_v1.json \
+    --ledger enterprise/artifacts/authority_ledger/ledger.ndjson
+```
+
+### Pipeline Integration
+
+```bash
+python enterprise/src/tools/reconstruct/seal_and_prove.py \
+    --decision-id DEC-001 \
+    --clock 2026-02-21T00:00:00Z \
+    --sign-algo hmac --sign-key-id ds-dev --sign-key "$KEY" \
+    --auto-authority --auto-abp \
+    --pack-dir /tmp/pack
+```
+
+Pack verification automatically discovers and verifies `abp_v1.json`:
+
+```bash
+python enterprise/src/tools/reconstruct/verify_pack.py --pack /tmp/pack --key "$KEY"
+```
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `enterprise/schemas/reconstruct/abp_v1.json` | JSON Schema |
+| `enterprise/src/tools/reconstruct/build_abp.py` | Builder + CLI |
+| `enterprise/src/tools/reconstruct/verify_abp.py` | Standalone verifier |
+| `enterprise/artifacts/public_demo_pack/abp_v1.json` | Reference artifact |
+| `enterprise/tests/test_build_abp.py` | 22 unit tests |

--- a/enterprise/schemas/reconstruct/abp_v1.json
+++ b/enterprise/schemas/reconstruct/abp_v1.json
@@ -1,0 +1,321 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deepsigma.dev/schemas/reconstruct/abp_v1.json",
+  "title": "Authority Boundary Primitive v1",
+  "description": "Stack-independent, pre-runtime declaration of what is allowed, denied, and required before any enforcement engine executes.",
+  "type": "object",
+  "required": [
+    "abp_version",
+    "abp_id",
+    "scope",
+    "authority_ref",
+    "objectives",
+    "tools",
+    "data",
+    "approvals",
+    "escalation",
+    "runtime",
+    "proof",
+    "composition",
+    "effective_at",
+    "expires_at",
+    "created_at",
+    "hash"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "abp_version": {
+      "const": "1.0",
+      "description": "ABP schema version."
+    },
+    "abp_id": {
+      "type": "string",
+      "pattern": "^ABP-[a-f0-9]{8}$",
+      "description": "Deterministic ABP ID: ABP- + first 8 hex chars of sha256(canonical(scope + authority_ref + created_at))."
+    },
+    "scope": {
+      "type": "object",
+      "required": ["contract_id", "program", "modules"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_id": {
+          "type": ["string", "null"],
+          "description": "Contract identifier this ABP applies to."
+        },
+        "program": {
+          "type": ["string", "null"],
+          "description": "Program name (e.g. SEQUOIA)."
+        },
+        "modules": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Module names in scope (e.g. hiring, bid, compliance, boe)."
+        }
+      }
+    },
+    "authority_ref": {
+      "type": "object",
+      "required": ["authority_entry_id", "authority_entry_hash", "authority_ledger_path"],
+      "additionalProperties": false,
+      "properties": {
+        "authority_entry_id": {
+          "type": "string",
+          "pattern": "^AUTH-[a-f0-9]{8}$",
+          "description": "Entry ID from the authority ledger."
+        },
+        "authority_entry_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "Hash of the referenced authority ledger entry."
+        },
+        "authority_ledger_path": {
+          "type": ["string", "null"],
+          "description": "Relative path to the authority ledger file."
+        }
+      }
+    },
+    "objectives": {
+      "type": "object",
+      "required": ["allowed", "denied"],
+      "additionalProperties": false,
+      "properties": {
+        "allowed": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "description"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          },
+          "description": "Objectives the operator is permitted to pursue."
+        },
+        "denied": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "description", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "description": { "type": "string" },
+              "reason": { "type": "string" }
+            }
+          },
+          "description": "Objectives explicitly denied with reason."
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "required": ["allow", "deny"],
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "scope"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "scope": { "type": ["string", "null"] }
+            }
+          },
+          "description": "Tools the operator may invoke, optionally scoped."
+        },
+        "deny": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "reason": { "type": "string" }
+            }
+          },
+          "description": "Tools explicitly denied with reason."
+        }
+      }
+    },
+    "data": {
+      "type": "object",
+      "required": ["permissions"],
+      "additionalProperties": false,
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["resource", "operations", "roles", "sensitivity"],
+            "additionalProperties": false,
+            "properties": {
+              "resource": {
+                "type": "string",
+                "description": "Resource path or pattern."
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["read", "write", "delete"]
+                },
+                "description": "Permitted operations."
+              },
+              "roles": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Roles that hold this permission."
+              },
+              "sensitivity": {
+                "type": "string",
+                "enum": ["public", "internal", "confidential", "restricted"],
+                "description": "Data sensitivity tier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "approvals": {
+      "type": "object",
+      "required": ["required"],
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["action", "approver_role", "threshold", "timeout_ms"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "type": "string" },
+              "approver_role": { "type": "string" },
+              "threshold": { "type": "integer", "minimum": 1 },
+              "timeout_ms": { "type": ["integer", "null"] }
+            }
+          }
+        }
+      }
+    },
+    "escalation": {
+      "type": "object",
+      "required": ["paths"],
+      "additionalProperties": false,
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["trigger", "destination", "severity", "auto"],
+            "additionalProperties": false,
+            "properties": {
+              "trigger": { "type": "string" },
+              "destination": { "type": "string" },
+              "severity": {
+                "type": "string",
+                "enum": ["info", "warn", "critical"]
+              },
+              "auto": { "type": "boolean" }
+            }
+          }
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": ["validators"],
+      "additionalProperties": false,
+      "properties": {
+        "validators": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "when", "fail_action", "config"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "when": {
+                "type": "string",
+                "enum": ["pre_action", "post_action", "periodic"]
+              },
+              "fail_action": {
+                "type": "string",
+                "enum": ["block", "warn", "escalate", "degrade"]
+              },
+              "config": {
+                "type": "object",
+                "description": "Validator-specific configuration."
+              }
+            }
+          }
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "required": ["required"],
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["seal", "manifest", "pack_hash", "episode_log", "transparency_log", "authority_ledger"]
+          },
+          "description": "Proof artifacts the ABP expects enforcement engines to produce."
+        }
+      }
+    },
+    "composition": {
+      "type": "object",
+      "required": ["parent_abp_id", "parent_abp_hash", "children"],
+      "additionalProperties": false,
+      "properties": {
+        "parent_abp_id": {
+          "type": ["string", "null"],
+          "description": "Parent ABP ID if this is a child ABP."
+        },
+        "parent_abp_hash": {
+          "type": ["string", "null"],
+          "description": "Content hash of the parent ABP."
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["abp_id", "abp_hash"],
+            "additionalProperties": false,
+            "properties": {
+              "abp_id": { "type": "string" },
+              "abp_hash": { "type": "string" }
+            }
+          },
+          "description": "Child ABP references (for program-level composition)."
+        }
+      }
+    },
+    "effective_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this ABP becomes effective (ISO 8601)."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "When this ABP expires (ISO 8601). Null if no expiry."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this ABP was created (ISO 8601)."
+    },
+    "hash": {
+      "type": "string",
+      "description": "Self-authenticating content hash: sha256(canonical(abp with hash=''))."
+    }
+  }
+}

--- a/enterprise/src/tools/reconstruct/build_abp.py
+++ b/enterprise/src/tools/reconstruct/build_abp.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Build Authority Boundary Primitive (ABP) v1.
+
+Creates a stack-independent, pre-runtime governance declaration that any
+enforcement engine can read to know the boundaries — without needing
+DeepSigma's runtime.
+
+Usage:
+    python enterprise/src/tools/reconstruct/build_abp.py \\
+        --scope '{"contract_id":"CTR-001","program":"SEQUOIA","modules":["hiring","bid","compliance","boe"]}' \\
+        --authority-entry-id AUTH-033059a5 \\
+        --authority-ledger enterprise/artifacts/authority_ledger/ledger.ndjson \\
+        --config abp_config.json \\
+        --clock 2026-02-24T00:00:00Z \\
+        --out-dir /tmp/abp
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from canonical_json import canonical_dumps, sha256_text  # noqa: E402
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _compute_abp_id(scope: dict, authority_ref: dict, created_at: str) -> str:
+    seed = canonical_dumps({
+        "scope": scope,
+        "authority_ref": authority_ref,
+        "created_at": created_at,
+    })
+    return "ABP-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:8]
+
+
+def _compute_abp_hash(abp: dict) -> str:
+    copy = dict(abp)
+    copy["hash"] = ""
+    return sha256_text(canonical_dumps(copy))
+
+
+def _resolve_authority_ref(
+    authority_entry_id: str,
+    ledger_path: Path | None,
+) -> dict:
+    """Look up authority entry hash from the ledger."""
+    entry_hash = ""
+    ledger_rel = str(ledger_path) if ledger_path else None
+
+    if ledger_path and ledger_path.exists():
+        for line in ledger_path.read_text().strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            if entry.get("entry_id") == authority_entry_id:
+                entry_hash = entry.get("entry_hash", "")
+                break
+
+    if not entry_hash:
+        raise ValueError(
+            f"Authority entry '{authority_entry_id}' not found in ledger "
+            f"'{ledger_path}'"
+        )
+
+    return {
+        "authority_entry_id": authority_entry_id,
+        "authority_entry_hash": entry_hash,
+        "authority_ledger_path": ledger_rel,
+    }
+
+
+def _check_contradictions(abp: dict) -> None:
+    """Raise ValueError if any tool or objective appears in both allow and deny."""
+    allowed_obj_ids = {o["id"] for o in abp["objectives"]["allowed"]}
+    denied_obj_ids = {o["id"] for o in abp["objectives"]["denied"]}
+    overlap = allowed_obj_ids & denied_obj_ids
+    if overlap:
+        raise ValueError(f"Objective IDs in both allowed and denied: {overlap}")
+
+    allowed_tools = {t["name"] for t in abp["tools"]["allow"]}
+    denied_tools = {t["name"] for t in abp["tools"]["deny"]}
+    overlap = allowed_tools & denied_tools
+    if overlap:
+        raise ValueError(f"Tool names in both allow and deny: {overlap}")
+
+
+def build_abp(
+    scope: dict,
+    authority_ref: dict,
+    objectives: dict | None = None,
+    tools: dict | None = None,
+    data: dict | None = None,
+    approvals: dict | None = None,
+    escalation: dict | None = None,
+    runtime: dict | None = None,
+    proof: dict | None = None,
+    clock: str | None = None,
+    effective_at: str | None = None,
+    expires_at: str | None = None,
+    parent_abp_id: str | None = None,
+    parent_abp_hash: str | None = None,
+) -> dict:
+    """Build a complete ABP v1 object with deterministic ID and hash."""
+    created_at = clock or _now_utc()
+    eff_at = effective_at or created_at
+
+    abp = {
+        "abp_version": "1.0",
+        "abp_id": "",
+        "scope": scope,
+        "authority_ref": authority_ref,
+        "objectives": objectives or {"allowed": [], "denied": []},
+        "tools": tools or {"allow": [], "deny": []},
+        "data": data or {"permissions": []},
+        "approvals": approvals or {"required": []},
+        "escalation": escalation or {"paths": []},
+        "runtime": runtime or {"validators": []},
+        "proof": proof or {"required": ["seal", "manifest", "pack_hash", "transparency_log", "authority_ledger"]},
+        "composition": {
+            "parent_abp_id": parent_abp_id,
+            "parent_abp_hash": parent_abp_hash,
+            "children": [],
+        },
+        "effective_at": eff_at,
+        "expires_at": expires_at,
+        "created_at": created_at,
+        "hash": "",
+    }
+
+    abp["abp_id"] = _compute_abp_id(scope, authority_ref, created_at)
+    _check_contradictions(abp)
+    abp["hash"] = _compute_abp_hash(abp)
+
+    return abp
+
+
+def write_abp(abp: dict, out_dir: Path) -> Path:
+    """Write ABP to abp_v1.json in out_dir. Returns path."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "abp_v1.json"
+    path.write_text(json.dumps(abp, indent=2) + "\n")
+    return path
+
+
+def compose_abps(
+    parent_scope: dict,
+    parent_authority_ref: dict,
+    children: list[dict],
+    clock: str | None = None,
+    effective_at: str | None = None,
+    expires_at: str | None = None,
+) -> dict:
+    """Build a parent ABP from child ABPs. Merges boundaries, preserves child refs."""
+    merged_objectives: dict = {"allowed": [], "denied": []}
+    merged_tools: dict = {"allow": [], "deny": []}
+    merged_data: dict = {"permissions": []}
+    merged_approvals: dict = {"required": []}
+    merged_escalation: dict = {"paths": []}
+    merged_runtime: dict = {"validators": []}
+    merged_proof: set[str] = set()
+    child_refs: list[dict] = []
+
+    for child in children:
+        merged_objectives["allowed"].extend(child["objectives"]["allowed"])
+        merged_objectives["denied"].extend(child["objectives"]["denied"])
+        merged_tools["allow"].extend(child["tools"]["allow"])
+        merged_tools["deny"].extend(child["tools"]["deny"])
+        merged_data["permissions"].extend(child["data"]["permissions"])
+        merged_approvals["required"].extend(child["approvals"]["required"])
+        merged_escalation["paths"].extend(child["escalation"]["paths"])
+        merged_runtime["validators"].extend(child["runtime"]["validators"])
+        merged_proof.update(child["proof"]["required"])
+        child_refs.append({
+            "abp_id": child["abp_id"],
+            "abp_hash": child["hash"],
+        })
+
+    parent = build_abp(
+        scope=parent_scope,
+        authority_ref=parent_authority_ref,
+        objectives=merged_objectives,
+        tools=merged_tools,
+        data=merged_data,
+        approvals=merged_approvals,
+        escalation=merged_escalation,
+        runtime=merged_runtime,
+        proof={"required": sorted(merged_proof)},
+        clock=clock,
+        effective_at=effective_at,
+        expires_at=expires_at,
+    )
+
+    # Inject children and recompute hash
+    parent["composition"]["children"] = child_refs
+    parent["hash"] = _compute_abp_hash(parent)
+
+    return parent
+
+
+def verify_abp_hash(abp: dict) -> bool:
+    """Recompute and verify ABP content hash."""
+    return _compute_abp_hash(abp) == abp.get("hash", "")
+
+
+def verify_abp_id(abp: dict) -> bool:
+    """Recompute and verify ABP ID is deterministic."""
+    expected = _compute_abp_id(
+        abp["scope"], abp["authority_ref"], abp["created_at"]
+    )
+    return expected == abp.get("abp_id", "")
+
+
+def verify_abp_authority(abp: dict, ledger_path: Path) -> bool:
+    """Verify ABP's authority_ref exists and is not revoked in the ledger."""
+    if not ledger_path.exists():
+        return False
+
+    entry_id = abp["authority_ref"]["authority_entry_id"]
+    entry_hash = abp["authority_ref"]["authority_entry_hash"]
+
+    for line in ledger_path.read_text().strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        entry = json.loads(line)
+        if entry.get("entry_id") == entry_id:
+            if entry.get("entry_hash") != entry_hash:
+                return False
+            if entry.get("revoked_at") is not None:
+                return False
+            return True
+
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build Authority Boundary Primitive (ABP) v1"
+    )
+    parser.add_argument("--scope", required=True,
+                        help="JSON scope object: {contract_id, program, modules}")
+    parser.add_argument("--authority-entry-id", required=True,
+                        help="Authority ledger entry ID (e.g. AUTH-033059a5)")
+    parser.add_argument("--authority-ledger", type=Path, default=None,
+                        help="Path to authority ledger NDJSON")
+    parser.add_argument("--config", type=Path, default=None,
+                        help="JSON config with objectives/tools/data/approvals/escalation/runtime/proof")
+    parser.add_argument("--clock", default=None,
+                        help="Fixed clock (ISO8601 UTC)")
+    parser.add_argument("--effective-at", default=None,
+                        help="Effective date (ISO8601 UTC, defaults to clock)")
+    parser.add_argument("--expires-at", default=None,
+                        help="Expiry date (ISO8601 UTC, defaults to null)")
+    parser.add_argument("--out-dir", type=Path, required=True,
+                        help="Output directory for abp_v1.json")
+    args = parser.parse_args()
+
+    scope = json.loads(args.scope)
+
+    # Resolve authority ref from ledger
+    authority_ref = _resolve_authority_ref(
+        args.authority_entry_id,
+        args.authority_ledger,
+    )
+
+    # Load config sections
+    config = {}
+    if args.config and args.config.exists():
+        config = json.loads(args.config.read_text())
+
+    abp = build_abp(
+        scope=scope,
+        authority_ref=authority_ref,
+        objectives=config.get("objectives"),
+        tools=config.get("tools"),
+        data=config.get("data"),
+        approvals=config.get("approvals"),
+        escalation=config.get("escalation"),
+        runtime=config.get("runtime"),
+        proof=config.get("proof"),
+        clock=args.clock,
+        effective_at=args.effective_at,
+        expires_at=args.expires_at,
+    )
+
+    path = write_abp(abp, args.out_dir)
+
+    print(f"ABP written: {path}")
+    print(f"  abp_id:   {abp['abp_id']}")
+    print(f"  hash:     {abp['hash']}")
+    print(f"  scope:    {abp['scope']['program']} / {abp['scope']['contract_id']}")
+    print(f"  auth_ref: {abp['authority_ref']['authority_entry_id']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise/src/tools/reconstruct/verify_abp.py
+++ b/enterprise/src/tools/reconstruct/verify_abp.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Verify Authority Boundary Primitive (ABP) v1.
+
+Standalone verifier — also callable from verify_pack.py.
+
+Checks:
+  1. abp.schema_valid      — validates against abp_v1.json schema
+  2. abp.hash_integrity    — recomputes hash, matches recorded
+  3. abp.id_deterministic  — recomputes ABP ID from scope+authority_ref+created_at
+  4. abp.authority_ref_valid — authority_entry_id exists in ledger, not revoked
+  5. abp.authority_not_expired — authority window contains ABP created_at
+  6. abp.composition_valid — parent/children refs consistent
+  7. abp.no_contradictions — no objective/tool in both allow and deny
+
+Usage:
+    python enterprise/src/tools/reconstruct/verify_abp.py \\
+        --abp enterprise/artifacts/public_demo_pack/abp_v1.json \\
+        --ledger enterprise/artifacts/public_demo_pack/authority_ledger.ndjson
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from build_abp import verify_abp_hash, verify_abp_id  # noqa: E402
+
+
+class VerifyAbpResult:
+    """Accumulates ABP verification checks."""
+
+    def __init__(self) -> None:
+        self.checks: list[tuple[str, bool, str]] = []
+
+    def check(self, name: str, passed: bool, detail: str = "") -> None:
+        self.checks.append((name, passed, detail))
+
+    @property
+    def passed(self) -> bool:
+        return all(ok for _, ok, _ in self.checks)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for _, ok, _ in self.checks if not ok)
+
+
+def _parse_dt(s: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def verify_abp(
+    abp_path: Path,
+    ledger_path: Path | None = None,
+    schema_path: Path | None = None,
+) -> VerifyAbpResult:
+    """Full ABP verification. Returns structured result with checks list."""
+    result = VerifyAbpResult()
+
+    if not abp_path.exists():
+        result.check("abp.file_exists", False, f"Not found: {abp_path}")
+        return result
+
+    try:
+        abp = json.loads(abp_path.read_text())
+    except json.JSONDecodeError as e:
+        result.check("abp.json_valid", False, str(e))
+        return result
+    result.check("abp.json_valid", True, "Valid JSON")
+
+    # 1. Schema validation (optional — only if jsonschema is available)
+    if schema_path is None:
+        schema_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "schemas" / "reconstruct" / "abp_v1.json"
+        )
+    if schema_path.exists():
+        try:
+            import jsonschema
+            schema = json.loads(schema_path.read_text())
+            jsonschema.validate(abp, schema)
+            result.check("abp.schema_valid", True, "Validates against abp_v1.json")
+        except ImportError:
+            result.check("abp.schema_valid", True, "jsonschema not installed — skipped")
+        except jsonschema.ValidationError as e:
+            result.check("abp.schema_valid", False, e.message)
+    else:
+        result.check("abp.schema_valid", True, f"Schema not found at {schema_path} — skipped")
+
+    # 2. Hash integrity
+    hash_ok = verify_abp_hash(abp)
+    result.check("abp.hash_integrity", hash_ok,
+                 "Content hash verified" if hash_ok else "Hash mismatch — ABP may be tampered")
+
+    # 3. ID deterministic
+    id_ok = verify_abp_id(abp)
+    result.check("abp.id_deterministic", id_ok,
+                 f"ABP ID verified ({abp.get('abp_id', '?')})" if id_ok
+                 else "ABP ID mismatch — not derived from scope+authority_ref+created_at")
+
+    # 4. Authority ref valid (if ledger provided)
+    if ledger_path and ledger_path.exists():
+        entry_id = abp.get("authority_ref", {}).get("authority_entry_id", "")
+        entry_hash = abp.get("authority_ref", {}).get("authority_entry_hash", "")
+        found = False
+        revoked = False
+        hash_match = False
+        entry_data: dict | None = None
+
+        for line in ledger_path.read_text().strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            if entry.get("entry_id") == entry_id:
+                found = True
+                hash_match = entry.get("entry_hash") == entry_hash
+                revoked = entry.get("revoked_at") is not None
+                entry_data = entry
+                break
+
+        if not found:
+            result.check("abp.authority_ref_valid", False,
+                         f"Entry {entry_id} not found in ledger")
+        elif not hash_match:
+            result.check("abp.authority_ref_valid", False,
+                         f"Entry hash mismatch for {entry_id}")
+        elif revoked:
+            result.check("abp.authority_ref_valid", False,
+                         f"Authority {entry_id} has been revoked")
+        else:
+            result.check("abp.authority_ref_valid", True,
+                         f"Authority {entry_id} valid and active")
+
+        # 5. Authority not expired
+        if found and entry_data:
+            eff = _parse_dt(entry_data.get("effective_at", ""))
+            exp_str = entry_data.get("expires_at")
+            exp = _parse_dt(exp_str) if exp_str else None
+            abp_created = _parse_dt(abp.get("created_at", ""))
+
+            if eff and abp_created:
+                in_window = eff <= abp_created
+                if exp:
+                    in_window = in_window and abp_created <= exp
+                result.check("abp.authority_not_expired", in_window,
+                             "ABP created_at within authority window" if in_window
+                             else "ABP created_at outside authority effective/expires window")
+            else:
+                result.check("abp.authority_not_expired", True,
+                             "Could not parse timestamps — skipped")
+    else:
+        detail = "No ledger provided" if not ledger_path else f"Ledger not found: {ledger_path}"
+        result.check("abp.authority_ref_valid", True, f"{detail} — skipped")
+        result.check("abp.authority_not_expired", True, f"{detail} — skipped")
+
+    # 6. Composition valid
+    comp = abp.get("composition", {})
+    parent_id = comp.get("parent_abp_id")
+    parent_hash = comp.get("parent_abp_hash")
+    children = comp.get("children", [])
+
+    if parent_id and not parent_hash:
+        result.check("abp.composition_valid", False,
+                     "parent_abp_id set but parent_abp_hash is missing")
+    elif not parent_id and parent_hash:
+        result.check("abp.composition_valid", False,
+                     "parent_abp_hash set but parent_abp_id is missing")
+    else:
+        child_ids = [c.get("abp_id") for c in children]
+        has_dup = len(child_ids) != len(set(child_ids))
+        if has_dup:
+            result.check("abp.composition_valid", False, "Duplicate child ABP IDs")
+        else:
+            detail = f"{len(children)} children"
+            if parent_id:
+                detail = f"parent={parent_id}, {detail}"
+            result.check("abp.composition_valid", True, detail)
+
+    # 7. No contradictions
+    allowed_obj_ids = {o["id"] for o in abp.get("objectives", {}).get("allowed", [])}
+    denied_obj_ids = {o["id"] for o in abp.get("objectives", {}).get("denied", [])}
+    obj_overlap = allowed_obj_ids & denied_obj_ids
+
+    allowed_tools = {t["name"] for t in abp.get("tools", {}).get("allow", [])}
+    denied_tools = {t["name"] for t in abp.get("tools", {}).get("deny", [])}
+    tool_overlap = allowed_tools & denied_tools
+
+    if obj_overlap or tool_overlap:
+        parts = []
+        if obj_overlap:
+            parts.append(f"objectives: {obj_overlap}")
+        if tool_overlap:
+            parts.append(f"tools: {tool_overlap}")
+        result.check("abp.no_contradictions", False,
+                     f"Contradictions found — {', '.join(parts)}")
+    else:
+        result.check("abp.no_contradictions", True, "No contradictions")
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify Authority Boundary Primitive (ABP) v1"
+    )
+    parser.add_argument("--abp", type=Path, required=True,
+                        help="Path to abp_v1.json")
+    parser.add_argument("--ledger", type=Path, default=None,
+                        help="Path to authority ledger NDJSON")
+    parser.add_argument("--schema", type=Path, default=None,
+                        help="Path to abp_v1.json schema (auto-detected if omitted)")
+    args = parser.parse_args()
+
+    result = verify_abp(args.abp, args.ledger, args.schema)
+
+    print("=" * 60)
+    print("  ABP Verification Report")
+    print("=" * 60)
+    for name, passed, detail in result.checks:
+        icon = "PASS" if passed else "FAIL"
+        print(f"  [{icon}] {name}: {detail}")
+    print("-" * 60)
+    total = len(result.checks)
+    passed_count = sum(1 for _, ok, _ in result.checks if ok)
+    if result.passed:
+        print(f"  RESULT: ABP VALID  ({passed_count}/{total} checks passed)")
+    else:
+        print(f"  RESULT: ABP INVALID  ({result.failed_count} failures)")
+    print("=" * 60)
+
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise/tests/test_build_abp.py
+++ b/enterprise/tests/test_build_abp.py
@@ -1,0 +1,345 @@
+"""Tests for ABP v1 — Authority Boundary Primitive."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src" / "tools" / "reconstruct"))
+
+from build_abp import (  # noqa: E402
+    build_abp,
+    compose_abps,
+    verify_abp_hash,
+    verify_abp_id,
+    write_abp,
+)
+from verify_abp import verify_abp, VerifyAbpResult  # noqa: E402
+
+FIXED_CLOCK = "2026-02-24T00:00:00Z"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "reconstruct" / "abp_v1.json"
+
+DEMO_SCOPE = {
+    "contract_id": "CTR-TEST-001",
+    "program": "TESTPROG",
+    "modules": ["hiring", "compliance"],
+}
+
+DEMO_AUTH_REF = {
+    "authority_entry_id": "AUTH-aabbccdd",
+    "authority_entry_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+    "authority_ledger_path": "ledger.ndjson",
+}
+
+
+def _build_test_ledger(tmpdir: str, entry_id: str = "AUTH-aabbccdd",
+                       revoked: bool = False) -> Path:
+    """Create a minimal test ledger for authority ref verification."""
+    from canonical_json import canonical_dumps, sha256_text
+
+    entry = {
+        "entry_version": "1.0",
+        "entry_id": entry_id,
+        "authority_id": "AUTO-TEST",
+        "actor_id": "tester",
+        "actor_role": "Operator",
+        "grant_type": "direct",
+        "scope_bound": {"decisions": ["DEC-TEST"], "claims": [], "patches": [], "prompts": [], "datasets": []},
+        "policy_version": "GOV-1.0",
+        "policy_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "effective_at": "2026-01-01T00:00:00Z",
+        "expires_at": None,
+        "revoked_at": "2026-03-01T00:00:00Z" if revoked else None,
+        "revocation_reason": "test revocation" if revoked else None,
+        "witness_required": False,
+        "witness_role": None,
+        "signing_key_id": None,
+        "signature_ref": None,
+        "commit_hash_refs": [],
+        "notes": "",
+        "prev_entry_hash": None,
+        "entry_hash": "",
+        "observed_at": "2026-01-01T00:00:00Z",
+    }
+    copy = dict(entry)
+    copy["entry_hash"] = ""
+    entry["entry_hash"] = sha256_text(canonical_dumps(copy))
+
+    ledger_path = Path(tmpdir) / "ledger.ndjson"
+    ledger_path.write_text(json.dumps(entry, sort_keys=True) + "\n")
+    return ledger_path, entry["entry_hash"]
+
+
+class TestBuildAbpBasic(unittest.TestCase):
+    """Test basic ABP construction."""
+
+    def test_build_abp_basic(self):
+        abp = build_abp(
+            scope=DEMO_SCOPE,
+            authority_ref=DEMO_AUTH_REF,
+            clock=FIXED_CLOCK,
+        )
+        required_keys = [
+            "abp_version", "abp_id", "scope", "authority_ref", "objectives",
+            "tools", "data", "approvals", "escalation", "runtime", "proof",
+            "composition", "effective_at", "expires_at", "created_at", "hash",
+        ]
+        for key in required_keys:
+            self.assertIn(key, abp, f"Missing required key: {key}")
+        self.assertEqual(abp["abp_version"], "1.0")
+        self.assertTrue(abp["abp_id"].startswith("ABP-"))
+        self.assertEqual(len(abp["abp_id"]), 12)  # ABP- + 8 hex
+        self.assertTrue(abp["hash"].startswith("sha256:"))
+
+    def test_abp_defaults_empty_sections(self):
+        abp = build_abp(
+            scope=DEMO_SCOPE,
+            authority_ref=DEMO_AUTH_REF,
+            clock=FIXED_CLOCK,
+        )
+        self.assertEqual(abp["objectives"], {"allowed": [], "denied": []})
+        self.assertEqual(abp["tools"], {"allow": [], "deny": []})
+        self.assertEqual(abp["data"], {"permissions": []})
+        self.assertEqual(abp["approvals"], {"required": []})
+        self.assertEqual(abp["escalation"], {"paths": []})
+        self.assertEqual(abp["runtime"], {"validators": []})
+
+    def test_abp_with_all_sections(self):
+        abp = build_abp(
+            scope=DEMO_SCOPE,
+            authority_ref=DEMO_AUTH_REF,
+            objectives={"allowed": [{"id": "O1", "description": "test"}], "denied": []},
+            tools={"allow": [{"name": "seal", "scope": None}], "deny": []},
+            data={"permissions": [{"resource": "x", "operations": ["read"], "roles": ["Op"], "sensitivity": "internal"}]},
+            approvals={"required": [{"action": "seal", "approver_role": "Rev", "threshold": 1, "timeout_ms": None}]},
+            escalation={"paths": [{"trigger": "fail", "destination": "Rev", "severity": "warn", "auto": True}]},
+            runtime={"validators": [{"name": "v1", "when": "pre_action", "fail_action": "block", "config": {}}]},
+            proof={"required": ["seal", "manifest"]},
+            clock=FIXED_CLOCK,
+        )
+        self.assertEqual(len(abp["objectives"]["allowed"]), 1)
+        self.assertEqual(len(abp["tools"]["allow"]), 1)
+        self.assertEqual(len(abp["data"]["permissions"]), 1)
+
+
+class TestAbpDeterminism(unittest.TestCase):
+    """Test deterministic ID and hash generation."""
+
+    def test_hash_deterministic(self):
+        abp1 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp2 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        self.assertEqual(abp1["hash"], abp2["hash"])
+
+    def test_id_deterministic(self):
+        abp1 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp2 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        self.assertEqual(abp1["abp_id"], abp2["abp_id"])
+
+    def test_different_scope_different_id(self):
+        abp1 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        scope2 = dict(DEMO_SCOPE, contract_id="CTR-OTHER")
+        abp2 = build_abp(scope=scope2, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        self.assertNotEqual(abp1["abp_id"], abp2["abp_id"])
+
+    def test_different_clock_different_id(self):
+        abp1 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp2 = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock="2026-03-01T00:00:00Z")
+        self.assertNotEqual(abp1["abp_id"], abp2["abp_id"])
+
+
+class TestAbpHashVerify(unittest.TestCase):
+    """Test hash integrity verification."""
+
+    def test_hash_verify_passes(self):
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        self.assertTrue(verify_abp_hash(abp))
+
+    def test_tamper_detected(self):
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp["scope"]["program"] = "TAMPERED"
+        self.assertFalse(verify_abp_hash(abp))
+
+    def test_id_verify_passes(self):
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        self.assertTrue(verify_abp_id(abp))
+
+    def test_id_tamper_detected(self):
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp["abp_id"] = "ABP-00000000"
+        self.assertFalse(verify_abp_id(abp))
+
+
+class TestAbpComposition(unittest.TestCase):
+    """Test ABP composition (parent from children)."""
+
+    def test_compose_basic(self):
+        child1 = build_abp(
+            scope={"contract_id": "CTR-C1", "program": "P", "modules": ["hiring"]},
+            authority_ref=DEMO_AUTH_REF,
+            objectives={"allowed": [{"id": "O1", "description": "Hire"}], "denied": []},
+            tools={"allow": [{"name": "t1", "scope": None}], "deny": []},
+            clock=FIXED_CLOCK,
+        )
+        child2 = build_abp(
+            scope={"contract_id": "CTR-C2", "program": "P", "modules": ["compliance"]},
+            authority_ref=DEMO_AUTH_REF,
+            objectives={"allowed": [{"id": "O2", "description": "Comply"}], "denied": []},
+            tools={"allow": [{"name": "t2", "scope": None}], "deny": []},
+            clock=FIXED_CLOCK,
+        )
+        parent = compose_abps(
+            parent_scope={"contract_id": "CTR-PARENT", "program": "P", "modules": ["hiring", "compliance"]},
+            parent_authority_ref=DEMO_AUTH_REF,
+            children=[child1, child2],
+            clock=FIXED_CLOCK,
+        )
+        self.assertEqual(len(parent["composition"]["children"]), 2)
+        self.assertEqual(parent["composition"]["children"][0]["abp_id"], child1["abp_id"])
+        self.assertEqual(parent["composition"]["children"][1]["abp_id"], child2["abp_id"])
+        self.assertEqual(len(parent["objectives"]["allowed"]), 2)
+        self.assertEqual(len(parent["tools"]["allow"]), 2)
+        self.assertTrue(verify_abp_hash(parent))
+
+
+class TestAbpContradictions(unittest.TestCase):
+    """Test contradiction detection."""
+
+    def test_tool_contradiction_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            build_abp(
+                scope=DEMO_SCOPE,
+                authority_ref=DEMO_AUTH_REF,
+                tools={
+                    "allow": [{"name": "seal_bundle", "scope": None}],
+                    "deny": [{"name": "seal_bundle", "reason": "nope"}],
+                },
+                clock=FIXED_CLOCK,
+            )
+        self.assertIn("seal_bundle", str(ctx.exception))
+
+    def test_objective_contradiction_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            build_abp(
+                scope=DEMO_SCOPE,
+                authority_ref=DEMO_AUTH_REF,
+                objectives={
+                    "allowed": [{"id": "OBJ-1", "description": "do it"}],
+                    "denied": [{"id": "OBJ-1", "description": "dont", "reason": "no"}],
+                },
+                clock=FIXED_CLOCK,
+            )
+        self.assertIn("OBJ-1", str(ctx.exception))
+
+
+class TestAbpWriteAndVerify(unittest.TestCase):
+    """Test write_abp and full verify_abp pipeline."""
+
+    def test_write_and_read(self):
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = write_abp(abp, Path(tmpdir))
+            self.assertTrue(path.exists())
+            loaded = json.loads(path.read_text())
+            self.assertEqual(loaded["abp_id"], abp["abp_id"])
+            self.assertEqual(loaded["hash"], abp["hash"])
+
+    def test_verify_abp_full(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path, entry_hash = _build_test_ledger(tmpdir)
+            auth_ref = {
+                "authority_entry_id": "AUTH-aabbccdd",
+                "authority_entry_hash": entry_hash,
+                "authority_ledger_path": str(ledger_path),
+            }
+            abp = build_abp(scope=DEMO_SCOPE, authority_ref=auth_ref, clock=FIXED_CLOCK)
+            abp_path = write_abp(abp, Path(tmpdir))
+            result = verify_abp(abp_path, ledger_path, SCHEMA_PATH)
+            for name, ok, detail in result.checks:
+                self.assertTrue(ok, f"{name}: {detail}")
+            self.assertTrue(result.passed)
+
+
+class TestVerifyAbpAuthority(unittest.TestCase):
+    """Test ABP authority ref verification against ledger."""
+
+    def test_valid_authority(self):
+        from build_abp import verify_abp_authority
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path, entry_hash = _build_test_ledger(tmpdir)
+            auth_ref = {
+                "authority_entry_id": "AUTH-aabbccdd",
+                "authority_entry_hash": entry_hash,
+                "authority_ledger_path": str(ledger_path),
+            }
+            abp = build_abp(scope=DEMO_SCOPE, authority_ref=auth_ref, clock=FIXED_CLOCK)
+            self.assertTrue(verify_abp_authority(abp, ledger_path))
+
+    def test_revoked_authority(self):
+        from build_abp import verify_abp_authority
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path, entry_hash = _build_test_ledger(tmpdir, revoked=True)
+            auth_ref = {
+                "authority_entry_id": "AUTH-aabbccdd",
+                "authority_entry_hash": entry_hash,
+                "authority_ledger_path": str(ledger_path),
+            }
+            abp = build_abp(scope=DEMO_SCOPE, authority_ref=auth_ref, clock=FIXED_CLOCK)
+            self.assertFalse(verify_abp_authority(abp, ledger_path))
+
+    def test_missing_authority(self):
+        from build_abp import verify_abp_authority
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path, _ = _build_test_ledger(tmpdir)
+            auth_ref = {
+                "authority_entry_id": "AUTH-00000000",
+                "authority_entry_hash": "sha256:0000",
+                "authority_ledger_path": str(ledger_path),
+            }
+            abp = build_abp(scope=DEMO_SCOPE, authority_ref=auth_ref, clock=FIXED_CLOCK)
+            self.assertFalse(verify_abp_authority(abp, ledger_path))
+
+
+class TestAbpSchemaValidation(unittest.TestCase):
+    """Test ABP validates against its JSON schema."""
+
+    def test_valid_abp_passes_schema(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+
+        schema = json.loads(SCHEMA_PATH.read_text())
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        jsonschema.validate(abp, schema)
+
+    def test_missing_field_fails_schema(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+
+        schema = json.loads(SCHEMA_PATH.read_text())
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        del abp["scope"]
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(abp, schema)
+
+    def test_extra_field_fails_schema(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+
+        schema = json.loads(SCHEMA_PATH.read_text())
+        abp = build_abp(scope=DEMO_SCOPE, authority_ref=DEMO_AUTH_REF, clock=FIXED_CLOCK)
+        abp["rogue_field"] = "should fail"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(abp, schema)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Introduces ABP v1 — a stack-independent, pre-runtime governance declaration that any enforcement engine can read to know the boundaries without needing DeepSigma's runtime
- Full build/verify toolchain: schema, builder CLI, standalone verifier, pipeline integration (`--auto-abp`), pack auto-discovery
- 22 unit tests, reference artifact in public demo pack, spec doc

## Files
- **New:** `enterprise/schemas/reconstruct/abp_v1.json`, `build_abp.py`, `verify_abp.py`, `abp_v1.json` artifact, `test_build_abp.py`, `31-abp.md`
- **Modified:** `seal_and_prove.py` (Step 1c + CLI args), `verify_pack.py` (ABP discovery + verification section)

## Test plan
- [x] `pytest enterprise/tests/test_build_abp.py -v` — 22/22 passed
- [x] `verify_abp.py` on demo pack — 8/8 checks passed
- [x] `verify_pack.py` on demo pack — 90/90 checks passed (including new ABP section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)