### PR TITLE
docs: ABP wiki, mermaid, and feature catalog

### DIFF
--- a/enterprise/docs/FEATURE_CATALOG.md
+++ b/enterprise/docs/FEATURE_CATALOG.md
@@ -23,6 +23,25 @@ Governance enforced before execution: default deny, halt on ambiguity, proof-fir
   - Enforcement: scripts/pre_exec_gate.py, scripts/validate_v2_1_0_milestone.py
   - KPI axes: Authority_Modeling, Operational_Maturity
 
+### Authority Boundary Primitive
+Stack-independent pre-runtime governance declarations: what's allowed, denied, and required before enforcement.
+
+- **ABP v1** (`ABP_V1`)
+  - Portable JSON primitive declaring scope, authority ref, objectives, tools, data permissions, approvals, escalation, runtime validators, and proof requirements.
+  - Artifacts: schemas/reconstruct/abp_v1.json, artifacts/public_demo_pack/abp_v1.json
+  - Enforcement: src/tools/reconstruct/build_abp.py, src/tools/reconstruct/verify_abp.py
+  - KPI axes: Authority_Modeling, Enterprise_Readiness, Technical_Completeness
+- **ABP Composition** (`ABP_COMPOSITION`)
+  - Program-level ABPs compose module-level ABPs with merged boundaries and child references.
+  - Artifacts: artifacts/public_demo_pack/abp_v1.json
+  - Enforcement: src/tools/reconstruct/build_abp.py (compose_abps)
+  - KPI axes: Authority_Modeling, Enterprise_Readiness
+- **ABP Pipeline Integration** (`ABP_PIPELINE`)
+  - Auto-build or attach ABP during seal-and-prove; auto-verify during pack verification.
+  - Artifacts: abp_v1.json (in admissibility pack)
+  - Enforcement: src/tools/reconstruct/seal_and_prove.py --auto-abp, src/tools/reconstruct/verify_pack.py
+  - KPI axes: Authority_Modeling, Operational_Maturity
+
 ### Intent Capture & Governance
 Intent declared pre-action and bound to execution.
 

--- a/enterprise/docs/mermaid/16-authority-boundary-primitive.md
+++ b/enterprise/docs/mermaid/16-authority-boundary-primitive.md
@@ -1,0 +1,121 @@
+# Authority Boundary Primitive (ABP)
+
+Pre-runtime governance declaration lifecycle: declare boundaries, build deterministic ABP, attach to admissibility pack, verify integrity.
+
+## ABP Lifecycle
+
+```mermaid
+flowchart TD
+    subgraph Declare["1. Declare Boundaries"]
+        D1["Scope\n(contract, program, modules)"]
+        D2["Authority Ref\n(ledger entry binding)"]
+        D3["Objectives\n(allowed / denied)"]
+        D4["Tools\n(allow / deny)"]
+        D5["Data Permissions\n(resource, ops, roles, sensitivity)"]
+        D6["Approvals + Escalation"]
+        D7["Runtime Validators"]
+        D8["Proof Requirements"]
+    end
+
+    subgraph Build["2. Build ABP"]
+        B1["Canonical JSON\n(deterministic serialization)"]
+        B2["ABP ID\nsha256(scope + auth_ref + created_at)[:8]"]
+        B3["Content Hash\nsha256(canonical(abp with hash=''))"]
+        B4["Contradiction Check\n(no tool/objective in both allow+deny)"]
+    end
+
+    subgraph Attach["3. Attach to Pack"]
+        A1["seal_and_prove.py\n--auto-abp"]
+        A2["abp_v1.json\n(in admissibility pack)"]
+    end
+
+    subgraph Verify["4. Verify"]
+        V1["schema_valid"]
+        V2["hash_integrity"]
+        V3["id_deterministic"]
+        V4["authority_ref_valid"]
+        V5["authority_not_expired"]
+        V6["composition_valid"]
+        V7["no_contradictions"]
+    end
+
+    D1 --> B1
+    D2 --> B1
+    D3 --> B1
+    D4 --> B1
+    D5 --> B1
+    D6 --> B1
+    D7 --> B1
+    D8 --> B1
+
+    B1 --> B2
+    B1 --> B3
+    B1 --> B4
+    B4 -->|pass| A1
+    B4 -->|fail| REJECT["ValueError:\ncontradiction detected"]
+
+    A1 --> A2
+    A2 --> V1
+    V1 --> V2
+    V2 --> V3
+    V3 --> V4
+    V4 --> V5
+    V5 --> V6
+    V6 --> V7
+    V7 -->|all pass| VERIFIED["ABP Verified"]
+    V7 -->|any fail| FAILED["Verification Failed"]
+
+    style REJECT fill:#ff6b6b,color:#fff
+    style VERIFIED fill:#51cf66,color:#fff
+    style FAILED fill:#ff6b6b,color:#fff
+```
+
+## ABP vs Authority Envelope
+
+```mermaid
+graph LR
+    subgraph PreRuntime["Pre-Runtime (ABP)"]
+        ABP["Authority Boundary Primitive\n- What's allowed/denied/required\n- Tool lists + data permissions\n- Escalation paths\n- Portable: any engine reads it"]
+    end
+
+    subgraph AtDecision["At Decision Time (Envelope)"]
+        ENV["Authority Envelope\n- What actor had what authority\n- Gate outcomes + refusal state\n- Policy snapshot\n- Bound to sealed run"]
+    end
+
+    subgraph PostExecution["Post-Execution (Sealed Run)"]
+        SEAL["Sealed Run\n- Hash-chained proof\n- All of the above happened\n- Immutable evidence"]
+    end
+
+    ABP -->|"specifies boundaries"| ENV
+    ENV -->|"captures state"| SEAL
+
+    style PreRuntime fill:#e7f5ff,stroke:#1c7ed6
+    style AtDecision fill:#fff3bf,stroke:#f59f00
+    style PostExecution fill:#d3f9d8,stroke:#37b24d
+```
+
+## ABP Composition
+
+```mermaid
+graph TD
+    PARENT["Program ABP\n(parent)\nABP-aabb1122"]
+
+    CHILD1["Hiring Module ABP\n(child)\nABP-cc334455"]
+    CHILD2["Compliance Module ABP\n(child)\nABP-dd556677"]
+    CHILD3["BOE Module ABP\n(child)\nABP-ee778899"]
+
+    PARENT -->|"composition.children[0]"| CHILD1
+    PARENT -->|"composition.children[1]"| CHILD2
+    PARENT -->|"composition.children[2]"| CHILD3
+
+    CHILD1 -->|"abp_id + hash preserved"| PARENT
+    CHILD2 -->|"abp_id + hash preserved"| PARENT
+    CHILD3 -->|"abp_id + hash preserved"| PARENT
+
+    style PARENT fill:#e7f5ff,stroke:#1c7ed6
+    style CHILD1 fill:#fff3bf,stroke:#f59f00
+    style CHILD2 fill:#fff3bf,stroke:#f59f00
+    style CHILD3 fill:#fff3bf,stroke:#f59f00
+```
+
+Boundaries from children are merged into the parent. `compose_abps()` concatenates allowed/denied objectives, tool allow/deny lists, data permissions, and records each child's `abp_id` and `hash` in `composition.children`.

--- a/enterprise/docs/mermaid/README.md
+++ b/enterprise/docs/mermaid/README.md
@@ -1,6 +1,6 @@
 # Mermaid Diagrams (Canonical)
 
-Nine diagrams define the visual language of Sigma OVERWATCH. Everything else is archived to reduce drift.
+Ten diagrams define the visual language of Sigma OVERWATCH. Everything else is archived to reduce drift.
 
 ## Canonical Set
 
@@ -15,6 +15,7 @@ Nine diagrams define the visual language of Sigma OVERWATCH. Everything else is 
 | 13 | [Release Preflight Flow](13-release-preflight-flow.md) | Flowchart | Tag integrity gate before PyPI/GHCR publishing |
 | 14 | [KPI Confidence Bands Flow](14-kpi-confidence-bands-flow.md) | Flowchart | KPI score + confidence/bands pipeline from evidence signals |
 | 15 | [DISR Dual-Mode Architecture](15-disr-dual-mode-architecture.md) | Graph | Local default crypto provider with optional KMS plug-ins and authority controls |
+| 16 | [Authority Boundary Primitive](16-authority-boundary-primitive.md) | Flowchart + Graph | Pre-runtime ABP lifecycle: declare → build → attach → verify + composition model |
 
 ## Archive
 
@@ -33,5 +34,6 @@ New diagrams require justification and must map to one of these canonical purpos
 6. **Release governance** — strict release/tag gates
 7. **KPI telemetry** — scoring confidence and uncertainty bands
 8. **DISR security architecture** — provider model + authority contracts
+9. **Authority boundaries** — pre-runtime governance declarations and composition
 
 To add a diagram, update this index and ensure `tools/mermaid_audit.py` passes.

--- a/enterprise/docs/wiki/Architecture.md
+++ b/enterprise/docs/wiki/Architecture.md
@@ -35,4 +35,5 @@ Mermaid diagrams:
 - [Release Preflight Flow](https://github.com/8ryanWh1t3/DeepSigma/blob/main/enterprise/docs/mermaid/13-release-preflight-flow.md)
 - [KPI Confidence Bands Flow](https://github.com/8ryanWh1t3/DeepSigma/blob/main/enterprise/docs/mermaid/14-kpi-confidence-bands-flow.md)
 - [DISR Dual-Mode Architecture](https://github.com/8ryanWh1t3/DeepSigma/blob/main/enterprise/docs/mermaid/15-disr-dual-mode-architecture.md)
+- [Authority Boundary Primitive](https://github.com/8ryanWh1t3/DeepSigma/blob/main/enterprise/docs/mermaid/16-authority-boundary-primitive.md)
 - [Archive Index](https://github.com/8ryanWh1t3/DeepSigma/blob/main/enterprise/docs/archive/mermaid/ARCHIVE_INDEX.md)

--- a/enterprise/docs/wiki/Authority-Boundary-Primitive.md
+++ b/enterprise/docs/wiki/Authority-Boundary-Primitive.md
@@ -1,0 +1,120 @@
+# Authority Boundary Primitive (ABP)
+
+The Authority Boundary Primitive is a **stack-independent, pre-runtime governance declaration**. It declares what is allowed, denied, and required before any enforcement engine executes.
+
+Unlike the authority envelope (which captures runtime state at decision time), the ABP defines boundaries *before* runtime begins. Any enforcement engine can read an ABP to know the boundaries without needing DeepSigma's runtime.
+
+## What It Contains
+
+| Section | Purpose |
+| --- | --- |
+| `scope` | Contract, program, and modules this ABP covers |
+| `authority_ref` | Binding to an authority ledger entry (entry_id + entry_hash) |
+| `objectives` | Allowed and denied objectives with reasons |
+| `tools` | Allowed and denied tools with scope/reason |
+| `data` | Data permissions by resource, operation, role, sensitivity |
+| `approvals` | Required approval workflows (action, approver, threshold) |
+| `escalation` | Escalation paths with triggers, destinations, severity |
+| `runtime` | Validators to run pre/post/periodic with fail actions |
+| `proof` | Required proof artifacts (seal, manifest, pack_hash, etc.) |
+| `composition` | Parent/child ABP references for hierarchical composition |
+
+## Deterministic Properties
+
+- **ABP ID**: `ABP-` + first 8 hex chars of `sha256(canonical(scope + authority_ref + created_at))`. Same inputs always produce the same ID.
+- **Hash**: `sha256(canonical(abp with hash=""))`. Same self-authenticating pattern used by sealed runs.
+- **Authority Ref**: Binds to an existing authority ledger entry by `entry_id` and `entry_hash`. Does not duplicate authority data.
+
+## Lifecycle
+
+```text
+1. Create ABP       build_abp() or build_abp.py CLI
+2. Bind to authority authority_ref points to ledger entry
+3. Attach to pack   seal_and_prove.py --auto-abp (or --abp-path)
+4. Verify            verify_abp.py or verify_pack.py (auto-discovers abp_v1.json)
+```
+
+## Composition
+
+Program-level ABPs compose module-level ABPs:
+
+```text
+Program ABP (parent)
+  +-- Hiring Module ABP (child)
+  +-- Compliance Module ABP (child)
+  +-- BOE Module ABP (child)
+```
+
+The `compose_abps()` function merges boundaries from children and records child references in `composition.children`. Each child's `abp_id` and `hash` are preserved.
+
+## ABP vs Authority Envelope
+
+| Aspect | ABP | Authority Envelope |
+| --- | --- | --- |
+| **When** | Pre-runtime | At decision time |
+| **Declares** | What's allowed/denied/required | What actor had what authority |
+| **Contains** | Tool lists, data permissions, escalation paths | Gate outcomes, refusal state, policy snapshot |
+| **Portable** | Yes — any engine can read it | Bound to DeepSigma sealed run |
+| **Verifiable** | Hash + ID + authority ref | Embedded in sealed run hash chain |
+
+## Verification (7 Checks)
+
+`verify_abp.py` performs:
+
+1. **abp.schema_valid** — validates against JSON schema
+2. **abp.hash_integrity** — recomputes content hash
+3. **abp.id_deterministic** — recomputes ABP ID from inputs
+4. **abp.authority_ref_valid** — entry exists in ledger, not revoked
+5. **abp.authority_not_expired** — ABP created_at within authority window
+6. **abp.composition_valid** — parent/child refs consistent, no duplicates
+7. **abp.no_contradictions** — no tool/objective in both allow and deny
+
+## CLI Usage
+
+### Build
+
+```bash
+python enterprise/src/tools/reconstruct/build_abp.py \
+    --scope '{"contract_id":"CTR-001","program":"SEQUOIA","modules":["hiring","bid"]}' \
+    --authority-entry-id AUTH-033059a5 \
+    --authority-ledger enterprise/artifacts/authority_ledger/ledger.ndjson \
+    --config abp_config.json \
+    --clock 2026-02-24T00:00:00Z \
+    --out-dir artifacts/abp
+```
+
+### Verify
+
+```bash
+python enterprise/src/tools/reconstruct/verify_abp.py \
+    --abp artifacts/abp/abp_v1.json \
+    --ledger enterprise/artifacts/authority_ledger/ledger.ndjson
+```
+
+### Pipeline Integration
+
+```bash
+python enterprise/src/tools/reconstruct/seal_and_prove.py \
+    --decision-id DEC-001 \
+    --clock 2026-02-21T00:00:00Z \
+    --sign-algo hmac --sign-key-id ds-dev --sign-key "$KEY" \
+    --auto-authority --auto-abp \
+    --pack-dir /tmp/pack
+```
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `enterprise/schemas/reconstruct/abp_v1.json` | JSON Schema |
+| `enterprise/src/tools/reconstruct/build_abp.py` | Builder + CLI |
+| `enterprise/src/tools/reconstruct/verify_abp.py` | Standalone verifier |
+| `enterprise/artifacts/public_demo_pack/abp_v1.json` | Reference artifact |
+| `enterprise/tests/test_build_abp.py` | 22 unit tests |
+| `enterprise/docs/31-abp.md` | Spec document |
+
+## See Also
+
+- [Architecture](Architecture) — System diagram with ABP mermaid link
+- [Contracts](Contracts) — Runtime action contracts (ABP operates before these)
+- [Sealing & Episodes](Sealing-and-Episodes) — How sealed runs reference ABP

--- a/enterprise/docs/wiki/Home.md
+++ b/enterprise/docs/wiki/Home.md
@@ -33,6 +33,7 @@ The runtime enforces four contracts on every decision before it is sealed.
 | [Sealing & Episodes](Sealing-and-Episodes) | Immutable `DecisionEpisode` envelope + SHA-256 seal |
 | [Runtime Flow](Runtime-Flow) | Step-by-step request lifecycle |
 | [Policy Packs](Policy-Packs) | Versioned bundles of DTE + Action constraints |
+| [Authority Boundary Primitive](Authority-Boundary-Primitive) | Pre-runtime governance declaration — what's allowed/denied/required before enforcement |
 
 ---
 
@@ -86,6 +87,7 @@ Captures AI interaction exhaust (prompts, completions, tool calls, metrics) and 
 | [Claim Schema](Unified-Atomic-Claims) | Unified Atomic Claim |
 | [Canon Schema](Canon) | Canon entry format |
 | [Retcon Schema](Retcon) | Retroactive correction record |
+| [ABP Schema](Authority-Boundary-Primitive) | Authority Boundary Primitive v1 |
 | [Schemas](Schemas) | Full index of all JSON Schema specs |
 
 ---

--- a/enterprise/docs/wiki/Wiki-Index.md
+++ b/enterprise/docs/wiki/Wiki-Index.md
@@ -18,6 +18,7 @@ Canonical wiki structure for Sigma OVERWATCH / DeepSigma docs.
 - [Drift -> Patch](Drift-to-Patch)
 - [Coherence Ops Mapping](Coherence-Ops-Mapping)
 - [IRIS](IRIS)
+- [Authority Boundary Primitive](Authority-Boundary-Primitive)
 
 ## Data Model + Schemas
 
@@ -30,6 +31,7 @@ Canonical wiki structure for Sigma OVERWATCH / DeepSigma docs.
 - [Unified Atomic Claims](Unified-Atomic-Claims)
 - [Canon](Canon)
 - [Retcon](Retcon)
+- [ABP Schema](Authority-Boundary-Primitive)
 
 ## Integrations
 

--- a/enterprise/docs/wiki/_Sidebar.md
+++ b/enterprise/docs/wiki/_Sidebar.md
@@ -13,6 +13,7 @@
   - [Verifiers](Verifiers)
   - [Sealing & Episodes](Sealing-and-Episodes)
   - [Drift → Patch](Drift-to-Patch)
+  - [Authority Boundary Primitive](Authority-Boundary-Primitive)
 - **Schemas**
   - [Schemas](Schemas)
   - [Episode Schema](Episode-Schema)
@@ -24,6 +25,7 @@
   - [DLR Schema](Unified-Atomic-Claims)
   - [Canon Schema](Canon)
   - [Retcon Schema](Retcon)
+  - [ABP Schema](Authority-Boundary-Primitive)
 - **Exhaust Inbox**
   - [Exhaust Inbox](Exhaust-Inbox)
 - **Integrations**


### PR DESCRIPTION
## Summary
- Add Authority Boundary Primitive wiki page (field reference, lifecycle, composition, verification, CLI)
- Add mermaid diagram #16 (3 charts: ABP lifecycle, ABP vs Envelope, ABP composition)
- Add ABP to sidebar, wiki index, home, architecture mermaid list
- Add ABP section to feature catalog (ABP_V1, ABP_COMPOSITION, ABP_PIPELINE)

Single commit — no squash merge data loss this time.

## Test plan
- [ ] Wiki page renders correctly on GitHub
- [ ] Mermaid diagrams render in GitHub markdown preview
- [ ] All navigation links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)