### PR TITLE
feat: EDGE Coherence Dashboard v2.0.0

### DIFF
--- a/edge/EDGE_Coherence_Dashboard_v2.0.0.html
+++ b/edge/EDGE_Coherence_Dashboard_v2.0.0.html
@@ -1177,15 +1177,16 @@
             overflow: hidden;
         }
 
-        .goal-fill {
+        .dimension-fill {
             height: 100%;
             border-radius: 3px;
             width: 0;
             transition: width 1.5s cubic-bezier(0.4, 0, 0.2, 1);
         }
 
-        .goal-fill.green { background: var(--success); }
-        .goal-fill.yellow { background: var(--warning); }
+        .dimension-fill.green { background: var(--success); }
+        .dimension-fill.yellow { background: var(--warning); }
+        .dimension-fill.red { background: var(--danger); }
 
         .goal-meta {
             display: flex;
@@ -1246,28 +1247,257 @@
             font-weight: 700;
         }
 
-        .claim-type.DLR { background: rgba(59, 130, 246, 0.15); color: var(--info); }
-        .claim-type.TRM { background: rgba(34, 197, 94, 0.15); color: var(--success); }
-        .claim-type.ASM { background: rgba(234, 179, 8, 0.15); color: var(--warning); }
-        .claim-type.DEP { background: rgba(139, 92, 246, 0.15); color: var(--purple); }
+        /* truthType badges (DeepSigma claim.schema.json) */
+        .claim-type.observation { background: rgba(59, 130, 246, 0.15); color: var(--info); }
+        .claim-type.inference { background: rgba(139, 92, 246, 0.15); color: var(--purple); }
+        .claim-type.assumption { background: rgba(234, 179, 8, 0.15); color: var(--warning); }
+        .claim-type.forecast { background: rgba(249, 115, 22, 0.15); color: var(--accent); }
+        .claim-type.norm { background: rgba(34, 197, 94, 0.15); color: var(--success); }
+        .claim-type.constraint { background: rgba(239, 68, 68, 0.15); color: var(--danger); }
 
-        .claim-status {
+        /* statusLight indicator (green/yellow/red) */
+        .status-light {
             display: inline-flex;
             align-items: center;
             gap: 4px;
             font-size: 10px;
+            text-transform: capitalize;
         }
 
-        .claim-status::before {
+        .status-light::before {
             content: '';
-            width: 6px;
-            height: 6px;
+            width: 8px;
+            height: 8px;
             border-radius: 50%;
         }
 
-        .claim-status.active::before { background: var(--success); }
-        .claim-status.challenged::before { background: var(--danger); }
-        .claim-status.expiring::before { background: var(--warning); }
+        .status-light.green::before { background: var(--success); box-shadow: 0 0 4px var(--success-glow); }
+        .status-light.yellow::before { background: var(--warning); box-shadow: 0 0 4px var(--warning-glow); }
+        .status-light.red::before { background: var(--danger); box-shadow: 0 0 4px var(--danger-glow); }
+
+        /* Coherence Dimension bars */
+        .dimension-row {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border);
+        }
+        .dimension-row:last-child { border-bottom: none; }
+        .dimension-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .dimension-name {
+            font-size: 12px;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .dimension-weight {
+            font-size: 9px;
+            color: var(--text-muted);
+            background: var(--bg-secondary);
+            padding: 1px 5px;
+            border-radius: 3px;
+        }
+        .dimension-score {
+            font-size: 13px;
+            font-weight: 700;
+        }
+        .dimension-bar {
+            height: 6px;
+            background: var(--bg-secondary);
+            border-radius: 3px;
+            overflow: hidden;
+        }
+        .dimension-fill {
+            height: 100%;
+            border-radius: 3px;
+            transition: width 1s ease;
+            width: 0;
+        }
+        .dimension-fill.green { background: var(--success); }
+        .dimension-fill.yellow { background: var(--warning); }
+        .dimension-fill.red { background: var(--danger); }
+
+        /* Grade badge */
+        .grade-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 32px;
+            height: 32px;
+            border-radius: 8px;
+            font-weight: 800;
+            font-size: 16px;
+            margin-left: 8px;
+        }
+        .grade-badge.A { background: rgba(34,197,94,0.2); color: var(--success); }
+        .grade-badge.B { background: rgba(59,130,246,0.2); color: var(--info); }
+        .grade-badge.C { background: rgba(234,179,8,0.2); color: var(--warning); }
+        .grade-badge.D { background: rgba(249,115,22,0.2); color: var(--accent); }
+        .grade-badge.F { background: rgba(239,68,68,0.2); color: var(--danger); }
+
+        /* Drift panel styles */
+        .drift-signal {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 12px;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            margin-bottom: 8px;
+            border-left: 3px solid var(--border);
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .drift-signal:hover { background: var(--bg-card-hover); }
+        .drift-signal.severity-red { border-left-color: var(--danger); }
+        .drift-signal.severity-yellow { border-left-color: var(--warning); }
+        .drift-signal.severity-green { border-left-color: var(--success); }
+        .drift-type-badge {
+            font-size: 9px;
+            font-weight: 700;
+            padding: 2px 6px;
+            border-radius: 4px;
+            background: var(--bg-card);
+            color: var(--text-secondary);
+            text-transform: uppercase;
+        }
+        .drift-severity {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+        .drift-severity.red { background: var(--danger); }
+        .drift-severity.yellow { background: var(--warning); }
+        .drift-severity.green { background: var(--success); }
+        .drift-content {
+            flex: 1;
+            min-width: 0;
+        }
+        .drift-title {
+            font-size: 12px;
+            font-weight: 600;
+        }
+        .drift-meta {
+            font-size: 10px;
+            color: var(--text-muted);
+            margin-top: 2px;
+        }
+        .drift-patch-badge {
+            font-size: 9px;
+            padding: 2px 6px;
+            border-radius: 4px;
+            background: rgba(139,92,246,0.15);
+            color: var(--purple);
+        }
+        .drift-summary-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+        .drift-summary-card {
+            padding: 12px;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            text-align: center;
+        }
+        .drift-summary-value {
+            font-size: 24px;
+            font-weight: 800;
+        }
+        .drift-summary-label {
+            font-size: 10px;
+            color: var(--text-muted);
+            text-transform: uppercase;
+        }
+
+        /* Graph edge colors (blast radius) */
+        .blast-edge-depends { stroke: var(--info); }
+        .blast-edge-contradicts { stroke: var(--danger); stroke-dasharray: 6,3; }
+        .blast-edge-supersedes { stroke: var(--accent); stroke-dasharray: 3,3; }
+        .blast-edge-supports { stroke: var(--success); }
+        .blast-edge-patches { stroke: var(--purple); stroke-dasharray: 6,3; }
+
+        .blast-legend-edge {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 10px;
+            color: var(--text-secondary);
+        }
+        .blast-legend-line {
+            width: 20px;
+            height: 2px;
+        }
+
+        /* Half-life indicator */
+        .halflife-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 10px;
+            padding: 2px 6px;
+            border-radius: 4px;
+            background: var(--bg-secondary);
+        }
+        .halflife-badge.urgent { background: rgba(239,68,68,0.15); color: var(--danger); }
+        .halflife-badge.warning { background: rgba(234,179,8,0.15); color: var(--warning); }
+        .halflife-badge.ok { background: rgba(34,197,94,0.15); color: var(--success); }
+
+        /* Confidence bar in table */
+        .conf-bar {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .conf-bar-track {
+            flex: 1;
+            height: 4px;
+            background: var(--bg-secondary);
+            border-radius: 2px;
+            overflow: hidden;
+            min-width: 40px;
+        }
+        .conf-bar-fill {
+            height: 100%;
+            border-radius: 2px;
+        }
+        .conf-bar-value {
+            font-size: 10px;
+            font-weight: 600;
+            min-width: 28px;
+            text-align: right;
+        }
+
+        /* IRIS query results */
+        .iris-result {
+            padding: 10px 12px;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            margin-bottom: 6px;
+            border-left: 3px solid var(--accent);
+        }
+        .iris-result-title {
+            font-size: 12px;
+            font-weight: 600;
+        }
+        .iris-result-body {
+            font-size: 11px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+        .iris-provenance {
+            font-size: 9px;
+            color: var(--text-muted);
+            margin-top: 4px;
+        }
 
         /* Toast Notifications */
         .toast-container {
@@ -2648,6 +2878,11 @@
                         <span class="nav-icon">🔬</span>
                         <span class="nav-text">Analysis</span>
                     </div>
+                    <div class="nav-item" data-view="drift">
+                        <span class="nav-icon">📡</span>
+                        <span class="nav-text">Drift Signals</span>
+                        <span class="nav-badge" style="background: var(--warning)">8</span>
+                    </div>
                     <div class="nav-item" data-view="blast">
                         <span class="nav-icon">💥</span>
                         <span class="nav-text">Blast Radius</span>
@@ -2656,15 +2891,15 @@
 
                 <div class="nav-section">
                     <div class="nav-label">Alerts</div>
-                    <div class="nav-item" data-filter="challenged">
-                        <span class="nav-icon">⚠️</span>
-                        <span class="nav-text">Challenged</span>
-                        <span class="nav-badge">3</span>
+                    <div class="nav-item" data-filter="red">
+                        <span class="nav-icon">🔴</span>
+                        <span class="nav-text">Red Signals</span>
+                        <span class="nav-badge">2</span>
                     </div>
-                    <div class="nav-item" data-filter="expiring">
-                        <span class="nav-icon">⏰</span>
-                        <span class="nav-text">Expiring</span>
-                        <span class="nav-badge" style="background: var(--warning)">12</span>
+                    <div class="nav-item" data-filter="halflife">
+                        <span class="nav-icon">⏳</span>
+                        <span class="nav-text">Half-Life Warnings</span>
+                        <span class="nav-badge" style="background: var(--warning)">5</span>
                     </div>
                 </div>
             </nav>
@@ -2691,15 +2926,16 @@
                     <div class="header-tabs">
                         <div class="header-tab active" data-tab="overview">Overview</div>
                         <div class="header-tab" data-tab="claims">Claims</div>
+                        <div class="header-tab" data-tab="drift">Drift</div>
                         <div class="header-tab" data-tab="analysis">Analysis</div>
                         <div class="header-tab" data-tab="blast">Blast Radius</div>
                         <div class="header-tab" data-tab="compare">Compare</div>
                     </div>
                     <div class="filter-presets">
                         <div class="filter-preset active" data-filter="all">All</div>
-                        <div class="filter-preset" data-filter="active">Active</div>
-                        <div class="filter-preset" data-filter="challenged">Critical</div>
-                        <div class="filter-preset" data-filter="expiring">Expiring</div>
+                        <div class="filter-preset" data-filter="green">Green</div>
+                        <div class="filter-preset" data-filter="yellow">Yellow</div>
+                        <div class="filter-preset" data-filter="red">Red</div>
                     </div>
                 </div>
                 <div class="header-right">
@@ -2723,11 +2959,11 @@
                 <!-- Overview -->
                 <div class="content active" id="overviewContent">
                     <div class="grid grid-3" style="margin-bottom: 16px;">
-                        <!-- CI Card -->
+                        <!-- CI Card with 4D Scoring -->
                         <div class="card">
                             <div class="card-header">
                                 <span class="card-title">Coherence Index</span>
-                                <span class="card-badge badge-success">Healthy</span>
+                                <span class="card-badge badge-success" id="ciBadge">Healthy</span>
                             </div>
                             <div class="card-body">
                                 <div class="ci-container">
@@ -2743,18 +2979,18 @@
                                             <path class="gauge-fill" id="ciGauge" d="M 16 80 A 64 64 0 0 1 144 80"/>
                                         </svg>
                                         <div class="ci-value-box">
-                                            <span class="ci-value"><span id="ciValue">0</span>%</span>
+                                            <span class="ci-value"><span id="ciValue">0</span><span class="grade-badge" id="ciGrade">-</span></span>
                                             <div class="ci-label">CI Score</div>
                                         </div>
                                     </div>
                                     <div class="ci-status">
                                         <div class="live-dot"></div>
-                                        System Healthy
+                                        <span id="ciStatusText">System Healthy</span>
                                     </div>
                                     <div class="ci-trend">
                                         <div class="ci-trend-item">
                                             <div class="ci-trend-label">Target</div>
-                                            <div class="ci-trend-value">&gt;80%</div>
+                                            <div class="ci-trend-value">&gt;75 (B)</div>
                                         </div>
                                         <div class="ci-trend-item">
                                             <div class="ci-trend-label">Change</div>
@@ -2799,45 +3035,39 @@
                             </div>
                         </div>
 
-                        <!-- Donut -->
+                        <!-- Donut: statusLight distribution -->
                         <div class="card">
                             <div class="card-header">
-                                <span class="card-title">Claims by Status</span>
+                                <span class="card-title">Status Light Distribution</span>
                             </div>
                             <div class="card-body">
                                 <div class="donut-container">
                                     <div class="donut-chart">
                                         <svg viewBox="0 0 120 120" width="120" height="120">
-                                            <circle class="donut-segment" id="donutActive" cx="60" cy="60" r="50" stroke="#22c55e"/>
-                                            <circle class="donut-segment" id="donutDraft" cx="60" cy="60" r="50" stroke="#eab308"/>
-                                            <circle class="donut-segment" id="donutChallenged" cx="60" cy="60" r="50" stroke="#ef4444"/>
-                                            <circle class="donut-segment" id="donutExpired" cx="60" cy="60" r="50" stroke="#64748b"/>
+                                            <circle class="donut-segment" id="donutGreen" cx="60" cy="60" r="50" stroke="#22c55e"/>
+                                            <circle class="donut-segment" id="donutYellow" cx="60" cy="60" r="50" stroke="#eab308"/>
+                                            <circle class="donut-segment" id="donutRed" cx="60" cy="60" r="50" stroke="#ef4444"/>
                                         </svg>
                                         <div class="donut-center">
                                             <div class="donut-value" id="donutTotal">0</div>
                                             <div class="donut-label">Total</div>
                                         </div>
                                     </div>
-                                    <div class="donut-legend">
+                                    <div class="donut-legend" id="donutLegend">
                                         <div class="legend-row">
                                             <div class="legend-dot green"></div>
-                                            <span class="legend-text">Active</span>
-                                            <span class="legend-value">789 (93%)</span>
+                                            <span class="legend-text">Green</span>
+                                            <span class="legend-value" id="legendGreen">-</span>
                                         </div>
                                         <div class="legend-row">
                                             <div class="legend-dot yellow"></div>
-                                            <span class="legend-text">Draft</span>
-                                            <span class="legend-value">34 (4%)</span>
+                                            <span class="legend-text">Yellow</span>
+                                            <span class="legend-value" id="legendYellow">-</span>
                                         </div>
                                         <div class="legend-row">
                                             <div class="legend-dot red"></div>
-                                            <span class="legend-text">Challenged</span>
-                                            <span class="legend-value">3</span>
-                                        </div>
-                                        <div class="legend-row">
-                                            <div class="legend-dot gray"></div>
-                                            <span class="legend-text">Expired</span>
-                                            <span class="legend-value">21</span>
+                                            <span class="legend-text">Red</span>
+                                            <span class="legend-value" id="legendRed">-</span>
                                         </div>
                                     </div>
                                 </div>
@@ -2846,21 +3076,22 @@
                     </div>
 
                     <div class="grid grid-2-1">
-                        <!-- Goals -->
+                        <!-- Coherence Dimensions -->
                         <div class="card">
                             <div class="card-header">
-                                <span class="card-title">PMG Strategic Alignment</span>
+                                <span class="card-title">Coherence Dimensions</span>
+                                <span class="card-badge badge-info">4D Scoring</span>
                             </div>
                             <div class="card-body">
-                                <div class="goals-list" id="goalsList"></div>
+                                <div class="dimensions-list" id="dimensionsList"></div>
                             </div>
                         </div>
 
-                        <!-- Alerts -->
+                        <!-- Drift-Derived Alerts -->
                         <div class="card">
                             <div class="card-header">
                                 <span class="card-title">Alerts</span>
-                                <span class="card-badge badge-danger">6</span>
+                                <span class="card-badge badge-danger" id="alertCount">0</span>
                             </div>
                             <div class="card-body">
                                 <div class="alerts-list" id="alertsList"></div>
@@ -2878,19 +3109,18 @@
                                 <input type="text" class="search-input" id="tableSearch" placeholder="Search claims..." style="width: 180px;" oninput="filterClaimsTable()">
                                 <select class="search-input" style="width: auto; padding-left: 10px;" id="typeFilter" onchange="filterClaimsTable()">
                                     <option value="">All Types</option>
-                                    <option value="DLR">DLR</option>
-                                    <option value="TRM">TRM</option>
-                                    <option value="ASM">ASM</option>
-                                    <option value="DEP">DEP</option>
-                                    <option value="AUT">AUT</option>
-                                    <option value="NAR">NAR</option>
+                                    <option value="observation">Observation</option>
+                                    <option value="inference">Inference</option>
+                                    <option value="assumption">Assumption</option>
+                                    <option value="forecast">Forecast</option>
+                                    <option value="norm">Norm</option>
+                                    <option value="constraint">Constraint</option>
                                 </select>
                                 <select class="search-input" style="width: auto; padding-left: 10px;" id="statusFilter" onchange="filterClaimsTable()">
-                                    <option value="">All Status</option>
-                                    <option value="active">Active</option>
-                                    <option value="draft">Draft</option>
-                                    <option value="challenged">Challenged</option>
-                                    <option value="expiring">Expiring</option>
+                                    <option value="">All Lights</option>
+                                    <option value="green">Green</option>
+                                    <option value="yellow">Yellow</option>
+                                    <option value="red">Red</option>
                                 </select>
                                 <button class="btn btn-primary" onclick="switchTab('newclaim')">+ New Claim</button>
                             </div>
@@ -2912,13 +3142,13 @@
                                 <thead>
                                     <tr>
                                         <th class="th-checkbox"><input type="checkbox" id="selectAll" onchange="toggleSelectAll()"></th>
-                                        <th class="sortable" data-sort="id" onclick="sortTable('id')">ID <span class="sort-icon">↕</span></th>
-                                        <th class="sortable" data-sort="type" onclick="sortTable('type')">Type <span class="sort-icon">↕</span></th>
+                                        <th class="sortable" data-sort="claimId" onclick="sortTable('claimId')">Claim ID <span class="sort-icon">↕</span></th>
+                                        <th class="sortable" data-sort="truthType" onclick="sortTable('truthType')">Truth Type <span class="sort-icon">↕</span></th>
                                         <th>Statement</th>
                                         <th class="sortable" data-sort="owner" onclick="sortTable('owner')">Owner <span class="sort-icon">↕</span></th>
-                                        <th class="sortable" data-sort="status" onclick="sortTable('status')">Status <span class="sort-icon">↕</span></th>
-                                        <th class="sortable" data-sort="goal" onclick="sortTable('goal')">Goal <span class="sort-icon">↕</span></th>
-                                        <th class="sortable" data-sort="expires" onclick="sortTable('expires')">Expires <span class="sort-icon">↕</span></th>
+                                        <th class="sortable" data-sort="statusLight" onclick="sortTable('statusLight')">Light <span class="sort-icon">↕</span></th>
+                                        <th>Confidence</th>
+                                        <th>Half-Life</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
@@ -2927,6 +3157,37 @@
                         </div>
                         <div class="table-footer">
                             <span class="table-info" id="tableInfo">Showing 26 claims</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Drift Signals -->
+                <div class="content" id="driftContent">
+                    <div class="card" style="margin-bottom: 16px;">
+                        <div class="card-header">
+                            <span class="card-title">Drift Signal Summary</span>
+                            <span class="card-badge badge-warning" id="driftTotalBadge">0</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="drift-summary-grid" id="driftSummaryGrid"></div>
+                        </div>
+                    </div>
+                    <div class="grid grid-2">
+                        <div class="card">
+                            <div class="card-header">
+                                <span class="card-title">Signals by Type</span>
+                            </div>
+                            <div class="card-body">
+                                <div class="bar-chart" id="driftTypeChart"></div>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <div class="card-header">
+                                <span class="card-title">Active Drift Signals</span>
+                            </div>
+                            <div class="card-body">
+                                <div class="drift-list" id="driftList"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2951,7 +3212,7 @@
                         </div>
                         <div class="card">
                             <div class="card-header">
-                                <span class="card-title" id="calendarTitle">Expiry Calendar</span>
+                                <span class="card-title" id="calendarTitle">Half-Life Calendar</span>
                             </div>
                             <div class="card-body">
                                 <div class="calendar-widget" id="calendar"></div>
@@ -3029,113 +3290,131 @@
                             </div>
                             <div class="card-body">
                                 <div class="form-grid">
-                                    <!-- Row 1: Type & Auto ID -->
+                                    <!-- Row 1: Truth Type & Auto ID -->
                                     <div class="form-group">
-                                        <label class="form-label">Claim Type *</label>
+                                        <label class="form-label">Truth Type *</label>
                                         <select class="form-select" id="newClaimType" required onchange="generateClaimId()">
                                             <option value="">Select type...</option>
-                                            <option value="DLR">DLR - Decision / Lineage Record</option>
-                                            <option value="TRM">TRM - Term / Definition</option>
-                                            <option value="ASM">ASM - Assumption</option>
-                                            <option value="DEP">DEP - Dependency</option>
-                                            <option value="AUT">AUT - Authority Reference</option>
-                                            <option value="NAR">NAR - Narrative Claim</option>
+                                            <option value="observation">Observation - Directly observed fact</option>
+                                            <option value="inference">Inference - Derived from reasoning</option>
+                                            <option value="assumption">Assumption - Accepted without proof</option>
+                                            <option value="forecast">Forecast - Future projection</option>
+                                            <option value="norm">Norm - Policy or standard</option>
+                                            <option value="constraint">Constraint - Hard boundary</option>
                                         </select>
-                                        <span class="form-hint">What type of knowledge does this claim capture?</span>
+                                        <span class="form-hint">Epistemic type per DeepSigma claim schema</span>
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label">Claim ID</label>
-                                        <input type="text" class="form-input readonly" id="newClaimId" placeholder="Auto-generated" readonly>
-                                        <span class="form-hint">Generated based on type and sequence</span>
+                                        <input type="text" class="form-input readonly" id="newClaimId" placeholder="CLAIM-YYYY-NNNN" readonly>
+                                        <span class="form-hint">Auto-generated: CLAIM-YYYY-NNNN</span>
                                     </div>
 
                                     <!-- Row 2: Statement (full width) -->
                                     <div class="form-group form-full">
                                         <label class="form-label">Claim Statement *</label>
-                                        <textarea class="form-textarea" id="newClaimStatement" rows="3" required 
+                                        <textarea class="form-textarea" id="newClaimStatement" rows="3" required
                                             placeholder="Enter the atomic claim. Be specific and unambiguous."
                                             oninput="updateClaimPreview()"></textarea>
                                         <span class="form-hint">The core assertion. Should be verifiable and self-contained.</span>
                                     </div>
 
-                                    <!-- Row 3: Rationale (full width) -->
-                                    <div class="form-group form-full">
-                                        <label class="form-label">Rationale / Evidence *</label>
-                                        <textarea class="form-textarea" id="newClaimRationale" rows="3" required 
-                                            placeholder="Why is this claim true? What evidence supports it?"
+                                    <!-- Row 3: Confidence -->
+                                    <div class="form-group">
+                                        <label class="form-label">Confidence Score *</label>
+                                        <div class="confidence-control">
+                                            <input type="range" class="form-range" id="newClaimConfidence"
+                                                min="0" max="100" value="75" step="1" oninput="updateConfidenceDisplay()">
+                                            <div class="confidence-display">
+                                                <span class="confidence-label">0.00</span>
+                                                <span class="confidence-value" id="confidenceValue">0.75</span>
+                                                <span class="confidence-label">1.00</span>
+                                            </div>
+                                        </div>
+                                        <span class="form-hint">0.00-1.00 scale. Green >= 0.80, Red < 0.50</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Confidence Explanation</label>
+                                        <textarea class="form-textarea" id="newClaimConfExplain" rows="2"
+                                            placeholder="Why this confidence level?"
                                             oninput="updateClaimPreview()"></textarea>
-                                        <span class="form-hint">Reference regulations, data sources, or prior decisions.</span>
+                                        <span class="form-hint">Evidence basis for the confidence score</span>
                                     </div>
 
-                                    <!-- ═══ TASK ALIGNMENT SECTION ═══ -->
+                                    <!-- ═══ SCOPE SECTION ═══ -->
                                     <div class="form-group form-full" style="margin-top: 8px; padding-top: 16px; border-top: 1px dashed var(--border);">
                                         <div class="section-header">
-                                            <span class="section-title">📎 Task Alignment</span>
-                                            <span class="section-subtitle">How does this claim connect work to mission?</span>
+                                            <span class="section-title">📍 Scope &amp; Context</span>
+                                            <span class="section-subtitle">Where and when does this claim apply?</span>
                                         </div>
                                     </div>
 
-                                    <!-- Row 3b: Mission Thread & Alignment Type -->
                                     <div class="form-group">
-                                        <label class="form-label">Mission Thread *</label>
-                                        <select class="form-select" id="newClaimThread" required onchange="updateClaimPreview()">
-                                            <option value="">Select thread...</option>
-                                            <optgroup label="Physical Security">
-                                                <option value="Access Control">Access Control</option>
-                                                <option value="Perimeter Security">Perimeter Security</option>
-                                                <option value="Visitor Management">Visitor Management</option>
-                                                <option value="Badge Operations">Badge Operations</option>
-                                            </optgroup>
-                                            <optgroup label="Law Enforcement">
-                                                <option value="Patrol Operations">Patrol Operations</option>
-                                                <option value="Traffic Enforcement">Traffic Enforcement</option>
-                                                <option value="Emergency Response">Emergency Response</option>
-                                            </optgroup>
-                                            <optgroup label="Investigations">
-                                                <option value="Criminal Investigations">Criminal Investigations</option>
-                                                <option value="Background Checks">Background Checks</option>
-                                                <option value="Evidence Management">Evidence Management</option>
-                                            </optgroup>
-                                            <optgroup label="Operations">
-                                                <option value="Training & Readiness">Training & Readiness</option>
-                                                <option value="Resource Management">Resource Management</option>
-                                                <option value="Policy & Compliance">Policy & Compliance</option>
-                                            </optgroup>
-                                        </select>
-                                        <span class="form-hint">Which operational area does this support?</span>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label">Alignment Type *</label>
-                                        <select class="form-select" id="newClaimAlignment" required onchange="updateClaimPreview()">
-                                            <option value="">Select alignment...</option>
-                                            <option value="Authorizes">⚡ Authorizes - Permits an action or process</option>
-                                            <option value="Constrains">🚫 Constrains - Limits or restricts</option>
-                                            <option value="Defines">📖 Defines - Establishes terms/scope</option>
-                                            <option value="Assumes">💭 Assumes - Relies on condition being true</option>
-                                            <option value="Enables">✅ Enables - Makes possible</option>
-                                            <option value="Requires">📋 Requires - Mandates action</option>
-                                        </select>
-                                        <span class="form-hint">How does this claim connect to operational tasks?</span>
-                                    </div>
-
-                                    <!-- Row 3c: Supported Task & Work Product -->
-                                    <div class="form-group">
-                                        <label class="form-label">Supported Task/Activity *</label>
-                                        <input type="text" class="form-input" id="newClaimTask" required
-                                            placeholder="e.g., Badge Renewal Process, Gate Screening"
+                                        <label class="form-label">Scope: Where *</label>
+                                        <input type="text" class="form-input" id="newClaimScopeWhere" required
+                                            placeholder="e.g., Installation, Zone B, Gate 4"
                                             oninput="updateClaimPreview()">
-                                        <span class="form-hint">What work does this claim enable or justify?</span>
+                                        <span class="form-hint">Geographic or organizational scope</span>
                                     </div>
                                     <div class="form-group">
-                                        <label class="form-label">Work Product Reference</label>
-                                        <input type="text" class="form-input" id="newClaimWorkProduct"
-                                            placeholder="Optional: SharePoint link, SOP number, system name">
-                                        <span class="form-hint">Link to actual document/system (not stored here)</span>
+                                        <label class="form-label">Scope: When *</label>
+                                        <input type="text" class="form-input" id="newClaimScopeWhen" required
+                                            placeholder="e.g., FY25, Q1 2025, Ongoing"
+                                            oninput="updateClaimPreview()">
+                                        <span class="form-hint">Temporal scope of validity</span>
                                     </div>
 
-                                    <!-- ═══ END TASK ALIGNMENT ═══ -->
+                                    <!-- ═══ HALF-LIFE SECTION ═══ -->
+                                    <div class="form-group form-full" style="margin-top: 8px; padding-top: 16px; border-top: 1px dashed var(--border);">
+                                        <div class="section-header">
+                                            <span class="section-title">⏳ Half-Life Configuration</span>
+                                            <span class="section-subtitle">When does this claim need refreshing?</span>
+                                        </div>
+                                    </div>
 
-                                    <!-- Row 4: Owner & Goal -->
+                                    <div class="form-group">
+                                        <label class="form-label">Half-Life Value *</label>
+                                        <input type="number" class="form-input" id="newClaimHLValue" min="1" value="30"
+                                            oninput="updateClaimPreview()">
+                                        <span class="form-hint">Time until confidence halves</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Half-Life Unit *</label>
+                                        <select class="form-select" id="newClaimHLUnit" onchange="updateClaimPreview()">
+                                            <option value="days" selected>Days</option>
+                                            <option value="hours">Hours</option>
+                                            <option value="ms">Milliseconds</option>
+                                        </select>
+                                        <span class="form-hint">Unit for the half-life period</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Refresh Trigger</label>
+                                        <select class="form-select" id="newClaimHLTrigger" onchange="updateClaimPreview()">
+                                            <option value="expiry" selected>Expiry</option>
+                                            <option value="contradiction">Contradiction</option>
+                                            <option value="new_source">New Source</option>
+                                            <option value="schedule">Schedule</option>
+                                        </select>
+                                        <span class="form-hint">What triggers a review?</span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Classification</label>
+                                        <select class="form-select" id="newClaimClassification" onchange="updateClaimPreview()">
+                                            <option value="internal" selected>Internal</option>
+                                            <option value="public">Public</option>
+                                            <option value="restricted">Restricted</option>
+                                            <option value="secret">Secret</option>
+                                        </select>
+                                        <span class="form-hint">Information classification tag</span>
+                                    </div>
+
+                                    <!-- ═══ OWNERSHIP ═══ -->
+                                    <div class="form-group form-full" style="margin-top: 8px; padding-top: 16px; border-top: 1px dashed var(--border);">
+                                        <div class="section-header">
+                                            <span class="section-title">👤 Ownership &amp; Source</span>
+                                        </div>
+                                    </div>
+
                                     <div class="form-group">
                                         <label class="form-label">Claim Owner *</label>
                                         <select class="form-select" id="newClaimOwner" required onchange="updateClaimPreview()">
@@ -3149,68 +3428,28 @@
                                         <span class="form-hint">Position responsible for maintaining this claim</span>
                                     </div>
                                     <div class="form-group">
-                                        <label class="form-label">PMG Goal Alignment *</label>
-                                        <select class="form-select" id="newClaimGoal" required onchange="updateClaimPreview()">
-                                            <option value="">Select goal...</option>
-                                            <option value="Goal 1">Goal 1: Physical Security</option>
-                                            <option value="Goal 2">Goal 2: Law Enforcement</option>
-                                            <option value="Goal 3">Goal 3: Corrections</option>
-                                            <option value="Goal 4">Goal 4: Criminal Investigation</option>
-                                            <option value="Goal 5">Goal 5: Workforce Development</option>
-                                        </select>
-                                        <span class="form-hint">Which strategic goal does this support?</span>
+                                        <label class="form-label">Source Reference</label>
+                                        <input type="text" class="form-input" id="newClaimSourceRef"
+                                            placeholder="e.g., AR 190-13, gate-sensor-data-2024">
+                                        <span class="form-hint">Primary source for this claim</span>
                                     </div>
 
-                                    <!-- Row 5: Expiration & Confidence -->
-                                    <div class="form-group">
-                                        <label class="form-label">Review/Expiration Date *</label>
-                                        <input type="date" class="form-input" id="newClaimExpires" required onchange="updateClaimPreview()">
-                                        <span class="form-hint">When should this claim be reviewed?</span>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label">Confidence Level</label>
-                                        <div class="confidence-control">
-                                            <input type="range" class="form-range" id="newClaimConfidence" 
-                                                min="0" max="100" value="75" oninput="updateConfidenceDisplay()">
-                                            <div class="confidence-display">
-                                                <span class="confidence-label">Low</span>
-                                                <span class="confidence-value" id="confidenceValue">75%</span>
-                                                <span class="confidence-label">High</span>
-                                            </div>
-                                        </div>
-                                        <span class="form-hint">How confident are we in this claim?</span>
-                                    </div>
-
-                                    <!-- Row 6: Dependencies -->
+                                    <!-- Row: Graph Dependencies -->
                                     <div class="form-group form-full">
-                                        <label class="form-label">Dependencies (Optional)</label>
+                                        <label class="form-label">Depends On (Optional)</label>
                                         <div class="dependency-input">
-                                            <input type="text" class="form-input" id="depSearchInput" 
+                                            <input type="text" class="form-input" id="depSearchInput"
                                                 placeholder="Search claims to link as dependencies...">
                                             <div class="dep-suggestions" id="depSuggestions"></div>
                                         </div>
                                         <div class="dep-tags" id="selectedDeps"></div>
-                                        <span class="form-hint">Which claims does this depend on? (affects Blast Radius)</span>
+                                        <span class="form-hint">graph.dependsOn — claims this depends on</span>
                                     </div>
 
-                                    <!-- Row 7: Status & Tags -->
-                                    <div class="form-group">
-                                        <label class="form-label">Initial Status</label>
-                                        <div class="status-toggle">
-                                            <label class="status-option">
-                                                <input type="radio" name="newClaimStatus" value="draft" checked>
-                                                <span class="status-pill draft">📝 Draft</span>
-                                            </label>
-                                            <label class="status-option">
-                                                <input type="radio" name="newClaimStatus" value="active">
-                                                <span class="status-pill active">✅ Active</span>
-                                            </label>
-                                        </div>
-                                        <span class="form-hint">Draft requires review before activation</span>
-                                    </div>
-                                    <div class="form-group">
+                                    <!-- Tags -->
+                                    <div class="form-group form-full">
                                         <label class="form-label">Tags (Optional)</label>
-                                        <input type="text" class="form-input" id="newClaimTags" 
+                                        <input type="text" class="form-input" id="newClaimTags"
                                             placeholder="security, zone-b, access-control">
                                         <span class="form-hint">Comma-separated for easier searching</span>
                                     </div>
@@ -3250,33 +3489,33 @@
                             <!-- Quick Reference -->
                             <div class="card">
                                 <div class="card-header">
-                                    <span class="card-title">📖 Claim Type Guide</span>
+                                    <span class="card-title">📖 Truth Type Guide</span>
                                 </div>
                                 <div class="card-body">
                                     <div class="type-guide">
                                         <div class="type-guide-item">
-                                            <span class="claim-type DLR">DLR</span>
-                                            <span>Decision records with full lineage</span>
+                                            <span class="claim-type observation">OBS</span>
+                                            <span>Directly observed facts</span>
                                         </div>
                                         <div class="type-guide-item">
-                                            <span class="claim-type TRM">TRM</span>
-                                            <span>Terms and definitions</span>
+                                            <span class="claim-type inference">INF</span>
+                                            <span>Derived from reasoning over evidence</span>
                                         </div>
                                         <div class="type-guide-item">
-                                            <span class="claim-type ASM">ASM</span>
-                                            <span>Assumptions requiring validation</span>
+                                            <span class="claim-type assumption">ASM</span>
+                                            <span>Accepted without current proof</span>
                                         </div>
                                         <div class="type-guide-item">
-                                            <span class="claim-type DEP">DEP</span>
-                                            <span>Dependencies between claims</span>
+                                            <span class="claim-type forecast">FCT</span>
+                                            <span>Future projections or predictions</span>
                                         </div>
                                         <div class="type-guide-item">
-                                            <span class="claim-type AUT">AUT</span>
-                                            <span>Authority references (regs, policies)</span>
+                                            <span class="claim-type norm">NRM</span>
+                                            <span>Policies, standards, regulations</span>
                                         </div>
                                         <div class="type-guide-item">
-                                            <span class="claim-type NAR">NAR</span>
-                                            <span>Narrative claims for context</span>
+                                            <span class="claim-type constraint">CON</span>
+                                            <span>Hard boundaries and dependencies</span>
                                         </div>
                                     </div>
                                 </div>
@@ -3308,7 +3547,7 @@
         <div class="cmd-palette">
             <div class="cmd-input-wrapper">
                 <span class="cmd-input-icon">🔍</span>
-                <input type="text" class="cmd-input" id="cmdInput" placeholder="Search claims, run commands...">
+                <input type="text" class="cmd-input" id="cmdInput" placeholder="Search claims, IRIS queries (why, drift, status)...">
                 <span class="cmd-kbd">ESC</span>
             </div>
             <div class="cmd-results" id="cmdResults"></div>
@@ -3374,8 +3613,8 @@
         }
 
         // Persistence
-        var STORAGE_KEY = 'ds_edge_coherence_v1';
-        var DRAFT_KEY = 'ds_edge_coherence_draft_v1';
+        var STORAGE_KEY = 'ds_edge_coherence_v2';
+        var DRAFT_KEY = 'ds_edge_coherence_draft_v2';
 
         function saveState() {
             try {
@@ -3383,7 +3622,7 @@
                     claims: data.claims,
                     theme: document.documentElement.classList.contains('light-theme') ? 'light' : 'dark',
                     notifications: notificationsEnabled,
-                    version: '1.1.0'
+                    version: '2.0.0'
                 };
                 localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
             } catch (e) { /* quota exceeded — silently fail */ }
@@ -3406,9 +3645,10 @@
         function saveDraft() {
             try {
                 var form = {};
-                ['newClaimType','newClaimId','newClaimStatement','newClaimRationale',
-                 'newClaimOwner','newClaimGoal','newClaimExpires','newClaimConfidence',
-                 'newClaimThread','newClaimAlignment','newClaimTask','newClaimWorkProduct','newClaimTags'].forEach(function(id) {
+                ['newClaimType','newClaimId','newClaimStatement','newClaimConfidence','newClaimConfExplain',
+                 'newClaimOwner','newClaimScopeWhere','newClaimScopeWhen',
+                 'newClaimHLValue','newClaimHLUnit','newClaimHLTrigger','newClaimClassification',
+                 'newClaimSourceRef','newClaimTags'].forEach(function(id) {
                     var el = document.getElementById(id);
                     if (el) form[id] = el.value;
                 });
@@ -3433,102 +3673,123 @@
             try { localStorage.removeItem(DRAFT_KEY); } catch (e) {}
         }
 
-        // Data
+        // ── Helper: derive statusLight per claim.schema.json ──
+        function deriveStatusLight(claim) {
+            var score = claim.confidence.score;
+            var hasStrongSource = (claim.sources || []).some(function(s) { return s.reliability === 'high'; });
+            var hasContradiction = (claim.graph.contradicts || []).length > 0;
+            if (hasContradiction || score < 0.50) return 'red';
+            if (score >= 0.80 && hasStrongSource) return 'green';
+            return 'yellow';
+        }
+
+        // ── Helper: days remaining until half-life expiry ──
+        function halfLifeDaysRemaining(claim) {
+            if (!claim.halfLife || !claim.halfLife.expiresAt) return Infinity;
+            var exp = new Date(claim.halfLife.expiresAt);
+            var now = new Date();
+            return Math.ceil((exp - now) / 86400000);
+        }
+
+        // ── Helper: grade from score (matches scoring.py) ──
+        function ciGrade(score) {
+            if (score >= 90) return 'A';
+            if (score >= 75) return 'B';
+            if (score >= 60) return 'C';
+            if (score >= 40) return 'D';
+            return 'F';
+        }
+
+        // ── Helper: short truthType label for table ──
+        function truthTypeShort(tt) {
+            var map = { observation:'OBS', inference:'INF', assumption:'ASM', forecast:'FCT', norm:'NRM', constraint:'CON' };
+            return map[tt] || tt;
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // DATA — Aligned with DeepSigma claim.schema.json + scoring.py
+        // ══════════════════════════════════════════════════════════════
         const data = {
-            ci: 87.6,
+            // 4D Coherence Report (mirrors CoherenceScorer output)
+            coherenceReport: {
+                overall: 82.4,
+                grade: 'B',
+                dimensions: [
+                    { name: 'policy_adherence', label: 'Policy Adherence', score: 88.0, weight: 0.25, details: { stamped: 22, total: 26 } },
+                    { name: 'outcome_health', label: 'Outcome Health', score: 79.5, weight: 0.30, details: { success_rate: 0.85, verification_pass_rate: 0.72 } },
+                    { name: 'drift_control', label: 'Drift Control', score: 85.0, weight: 0.25, details: { total_signals: 8, red_count: 1, recurring: 2 } },
+                    { name: 'memory_completeness', label: 'Memory Completeness', score: 76.0, weight: 0.20, details: { episode_nodes: 19, expected: 25 } }
+                ]
+            },
             metrics: [
-                { icon: '📋', value: 847, label: 'Total Claims', change: '+12', up: true, color: 'blue', spark: [82,83,82,84,83,84,85] },
-                { icon: '⏰', value: 12, label: 'Expiring <30d', change: '+3', up: false, color: 'yellow', spark: [8,9,10,9,11,10,12] },
-                { icon: '⚠️', value: 3, label: 'Challenged', change: '-1', up: true, color: 'red', spark: [5,4,5,4,4,3,3] },
-                { icon: '📉', value: 27, label: 'Low Confidence', change: '-5', up: true, color: 'orange', spark: [35,33,32,31,30,28,27] }
+                { icon: '📋', value: 26, label: 'Total Claims', change: '+3', up: true, color: 'blue', spark: [22,23,22,24,23,25,26] },
+                { icon: '⏳', value: 5, label: 'Half-Life Warnings', change: '+1', up: false, color: 'yellow', spark: [3,3,4,4,4,5,5] },
+                { icon: '📡', value: 8, label: 'Drift Signals', change: '-2', up: true, color: 'orange', spark: [12,11,10,10,9,9,8] },
+                { icon: '🔴', value: 4, label: 'Low Confidence', change: '-1', up: true, color: 'red', spark: [7,6,6,5,5,4,4] }
             ],
             types: [
-                { name: 'Decision (DLR)', value: 234, color: 'blue' },
-                { name: 'Term (TRM)', value: 198, color: 'green' },
-                { name: 'Assumption (ASM)', value: 156, color: 'yellow' },
-                { name: 'Dependency (DEP)', value: 89, color: 'purple' },
-                { name: 'Narrative', value: 78, color: 'pink' },
-                { name: 'Authority (AUT)', value: 45, color: 'orange' }
+                { name: 'Inference', value: 9, color: 'purple' },
+                { name: 'Assumption', value: 7, color: 'yellow' },
+                { name: 'Norm', value: 5, color: 'green' },
+                { name: 'Constraint', value: 2, color: 'red' },
+                { name: 'Observation', value: 2, color: 'blue' },
+                { name: 'Forecast', value: 1, color: 'orange' }
             ],
-            status: { active: 789, draft: 34, challenged: 3, expired: 21 },
+            statusCounts: { green: 15, yellow: 7, red: 4 },
             activities: [
-                { type: 'create', icon: '✅', title: 'DLR-2025-001 Created', desc: 'Badge renewal procedures', time: '2m ago' },
-                { type: 'update', icon: '✏️', title: 'TRM-2024-034 Updated', desc: 'Zone B definition revised', time: '15m ago' },
-                { type: 'challenge', icon: '⚠️', title: 'DLR-2024-089 Challenged', desc: 'Challenge filed by MAJ Thompson', time: '1h ago' },
-                { type: 'expire', icon: '⏰', title: 'ASM-2024-045 Expiring', desc: 'Expires in 3 days', time: '2h ago' },
-                { type: 'create', icon: '✅', title: 'TRM-2025-002 Created', desc: 'Red Zone perimeter defined', time: '3h ago' },
-                { type: 'update', icon: '✏️', title: 'DEP-2024-018 Updated', desc: 'Added DBIDS dependency', time: '5h ago' }
+                { type: 'create', icon: '✅', title: 'CLAIM-2025-0001 sealed', desc: 'Badge renewal background check', time: '2m ago' },
+                { type: 'drift', icon: '📡', title: 'DS-2024-003 detected', desc: 'Freshness drift: badge TTL stale', time: '15m ago' },
+                { type: 'patch', icon: '🔧', title: 'Patch applied', desc: 'ttl_change for CLAIM-2024-0002', time: '1h ago' },
+                { type: 'update', icon: '✏️', title: 'CLAIM-2024-0003 superseded', desc: 'Zone B definition updated v2', time: '2h ago' },
+                { type: 'expire', icon: '⏳', title: 'CLAIM-2024-0005 half-life', desc: 'Confidence decaying, 3d remaining', time: '3h ago' },
+                { type: 'create', icon: '✅', title: 'CLAIM-2024-0006 sealed', desc: 'Red Zone clearance definition', time: '5h ago' }
             ],
-            alerts: [
-                { type: 'critical', icon: '🔴', title: 'DLR-2024-089 CHALLENGED', desc: 'Contractor Escort Policy', meta: 'MAJ Thompson • 3d' },
-                { type: 'critical', icon: '🔴', title: 'ASM-2024-045 EXPIRES 3D', desc: 'Visitor Badge Validity', meta: '4 dependents' },
-                { type: 'critical', icon: '🔴', title: 'DLR-2024-078 CHALLENGED', desc: 'After-hours access protocol', meta: 'CW3 Martinez • 1d' },
-                { type: 'warning', icon: '🟡', title: 'ASM-2024-012 EXPIRES 15D', desc: 'DBIDS Reliability', meta: '7 dependents' },
-                { type: 'warning', icon: '🟡', title: 'TRM-2024-034 EXPIRES 22D', desc: 'Zone B Definition', meta: '12 dependents' },
-                { type: 'warning', icon: '🟡', title: 'DEP-2024-019 EXPIRES 28D', desc: 'Gate staffing dependency', meta: '3 dependents' }
-            ],
-            goals: [
-                { name: 'Goal 1: Physical Security', pct: 87, claims: 412, status: 'green', note: '2 expiring' },
-                { name: 'Goal 2: Law Enforcement', pct: 84, claims: 198, status: 'green', note: '1 challenged' },
-                { name: 'Goal 3: Corrections', pct: 72, claims: 89, status: 'yellow', note: '⚠️ Below target' },
-                { name: 'Goal 4: Criminal Investigation', pct: 89, claims: 67, status: 'green', note: 'Healthy' },
-                { name: 'Goal 5: Workforce Dev', pct: 68, claims: 81, status: 'yellow', note: '⚠️ Needs focus' }
+            // Drift Signals (mirrors DriftSignalCollector)
+            driftSignals: [
+                { driftId: 'DS-2024-001', driftType: 'freshness', severity: 'yellow', detectedAt: '2024-12-10T14:30:00Z', episodeId: 'EP-041', evidenceRefs: ['CLAIM-2024-0002'], recommendedPatchType: 'ttl_change', fingerprint: { key: 'badge-ttl-stale', version: '1' }, notes: 'Badge TTL assumption past half-life' },
+                { driftId: 'DS-2024-002', driftType: 'verify', severity: 'red', detectedAt: '2024-12-12T09:15:00Z', episodeId: 'EP-042', evidenceRefs: ['CLAIM-2024-0001'], recommendedPatchType: 'verification_change', fingerprint: { key: 'escort-policy-unverified', version: '1' }, notes: 'Escort policy challenged, verification failed' },
+                { driftId: 'DS-2024-003', driftType: 'freshness', severity: 'yellow', detectedAt: '2024-12-15T11:00:00Z', episodeId: 'EP-043', evidenceRefs: ['CLAIM-2024-0005'], recommendedPatchType: 'ttl_change', fingerprint: { key: 'badge-ttl-stale', version: '1' }, notes: 'Visitor badge validity assumption aging' },
+                { driftId: 'DS-2024-004', driftType: 'outcome', severity: 'yellow', detectedAt: '2024-12-18T16:45:00Z', episodeId: 'EP-044', evidenceRefs: ['CLAIM-2024-0007'], recommendedPatchType: 'manual_review', fingerprint: { key: 'after-hours-outcome-drift', version: '1' }, notes: 'After-hours access outcomes diverging from policy' },
+                { driftId: 'DS-2024-005', driftType: 'contention', severity: 'yellow', detectedAt: '2024-12-20T08:30:00Z', episodeId: 'EP-045', evidenceRefs: ['CLAIM-2024-0001', 'CLAIM-2024-0009'], recommendedPatchType: 'action_scope_tighten', fingerprint: { key: 'escort-ar190-contention', version: '1' }, notes: 'Contention between escort policy and AR 190-13 interpretation' },
+                { driftId: 'DS-2024-006', driftType: 'time', severity: 'green', detectedAt: '2024-12-22T13:00:00Z', episodeId: 'EP-046', evidenceRefs: ['CLAIM-2024-0013'], recommendedPatchType: 'dte_change', fingerprint: { key: 'response-time-drift', version: '1' }, notes: 'Response time assumption within tolerance' },
+                { driftId: 'DS-2024-007', driftType: 'bypass', severity: 'red', detectedAt: '2024-12-28T10:20:00Z', episodeId: 'EP-047', evidenceRefs: ['CLAIM-2024-0019'], recommendedPatchType: 'routing_change', fingerprint: { key: 'forensics-bypass', version: '1' }, notes: 'Investigation closed without forensics completion' },
+                { driftId: 'DS-2024-008', driftType: 'fallback', severity: 'green', detectedAt: '2025-01-02T09:00:00Z', episodeId: 'EP-048', evidenceRefs: ['CLAIM-2024-0022'], recommendedPatchType: 'cache_bundle_change', fingerprint: { key: 'training-fallback', version: '1' }, notes: 'Training completion using fallback metric' }
             ],
             claims: [
-                // Physical Security - Goal 1
-                { id: 'DLR-2024-089', type: 'DLR', statement: 'Contractors with valid DBIDS do not require escort in Zone B during business hours', owner: 'CPT Rodriguez', status: 'challenged', goal: 'Goal 1', expires: '15 MAR 25', rationale: 'DBIDS verification provides sufficient identity assurance for Zone B access without physical escort.', confidence: 72, thread: 'Access Control', alignment: 'Authorizes', task: 'Contractor Entry Processing', dependencies: ['ASM-2024-012', 'TRM-2024-034', 'AUT-2024-003'] },
-                { id: 'ASM-2024-012', type: 'ASM', statement: 'DBIDS verification completes within 24 hours for standard requests', owner: 'CPT Rodriguez', status: 'expiring', goal: 'Goal 1', expires: '15 FEB 25', rationale: 'Based on historical processing times from 2023-2024 data showing 94% completion within 24hrs.', confidence: 85, thread: 'Badge Operations', alignment: 'Assumes', task: 'Badge Issuance Timeline' },
-                { id: 'TRM-2024-034', type: 'TRM', statement: 'Zone B = Administrative areas accessible to credentialed personnel only', owner: 'CPT Rodriguez', status: 'active', goal: 'Goal 1', expires: '01 JUN 25', rationale: 'Army Regulation 190-13 defines access control zones for installation security.', confidence: 95, thread: 'Perimeter Security', alignment: 'Defines', task: 'Zone Classification' },
-                { id: 'DLR-2024-091', type: 'DLR', statement: 'Installation access badges issued within 72 hours of approval', owner: 'MAJ Thompson', status: 'active', goal: 'Goal 1', expires: '20 MAR 25', rationale: 'Badge production capacity supports this timeline based on current equipment.', confidence: 88, thread: 'Badge Operations', alignment: 'Enables', task: 'New Employee Onboarding', dependencies: ['ASM-2024-012', 'DEP-2024-018'] },
-                { id: 'ASM-2024-045', type: 'ASM', statement: 'Visitor badges valid for single day entry only', owner: 'SFC Williams', status: 'expiring', goal: 'Goal 1', expires: '03 FEB 25', rationale: 'Security requirement per installation policy memorandum 2024-03.', confidence: 90, thread: 'Visitor Management', alignment: 'Constrains', task: 'Visitor Processing' },
-                { id: 'TRM-2024-056', type: 'TRM', statement: 'Red Zone = Restricted areas requiring SECRET clearance minimum', owner: 'MAJ Thompson', status: 'active', goal: 'Goal 1', expires: '15 JUL 25', rationale: 'Defined per DoD 5200.08-R Physical Security Program.', confidence: 98, thread: 'Perimeter Security', alignment: 'Defines', task: 'Clearance Verification' },
-                { id: 'DLR-2024-078', type: 'DLR', statement: 'After-hours access requires supervisor pre-authorization and log entry', owner: 'CPT Rodriguez', status: 'challenged', goal: 'Goal 1', expires: '28 FEB 25', rationale: 'Balances operational need with security requirements per AR 190-13.', confidence: 65, thread: 'Access Control', alignment: 'Requires', task: 'After-Hours Entry' },
-                { id: 'DEP-2024-018', type: 'DEP', statement: 'Badge issuance timeline depends on DBIDS verification completion', owner: 'SFC Williams', status: 'active', goal: 'Goal 1', expires: '01 APR 25', rationale: 'Sequential process dependency - badges cannot issue before identity verification.', confidence: 92, thread: 'Badge Operations', alignment: 'Constrains', task: 'Badge Production Queue', dependencies: ['ASM-2024-012'] },
-                { id: 'AUT-2024-003', type: 'AUT', statement: 'AR 190-13 governs all physical security access control decisions', owner: 'MAJ Thompson', status: 'active', goal: 'Goal 1', expires: '31 DEC 25', rationale: 'Primary regulatory authority for Army installation physical security.', confidence: 100, thread: 'Policy & Compliance', alignment: 'Authorizes', task: 'Policy Development' },
-                { id: 'ASM-2024-067', type: 'ASM', statement: 'Peak gate traffic occurs 0700-0830 and 1630-1730 daily', owner: 'SFC Williams', status: 'active', goal: 'Goal 1', expires: '30 APR 25', rationale: 'Based on 6-month traffic analysis from gate sensors.', confidence: 91, thread: 'Access Control', alignment: 'Assumes', task: 'Gate Staffing Schedule' },
-                
-                // Law Enforcement - Goal 2
-                { id: 'DLR-2024-102', type: 'DLR', statement: 'All traffic stops require body camera activation before approach', owner: 'CW3 Martinez', status: 'active', goal: 'Goal 2', expires: '15 MAY 25', rationale: 'Policy implemented per HQDA guidance on law enforcement recording.', confidence: 96, thread: 'Traffic Enforcement', alignment: 'Requires', task: 'Traffic Stop Procedure' },
-                { id: 'TRM-2024-089', type: 'TRM', statement: 'Use of Force = Any physical technique to control, restrain, or overcome resistance', owner: 'CW3 Martinez', status: 'active', goal: 'Goal 2', expires: '01 AUG 25', rationale: 'Definition aligned with DoD Law Enforcement Use of Force policy.', confidence: 97, thread: 'Patrol Operations', alignment: 'Defines', task: 'Use of Force Reporting' },
-                { id: 'ASM-2024-098', type: 'ASM', statement: 'Average patrol response time under 5 minutes for Priority 1 calls', owner: 'MSG Patterson', status: 'active', goal: 'Goal 2', expires: '30 JUN 25', rationale: 'Based on 2024 Q1-Q3 response time data showing 4.2 minute average.', confidence: 87, thread: 'Emergency Response', alignment: 'Assumes', task: 'Dispatch Prioritization' },
-                { id: 'DLR-2024-115', type: 'DLR', statement: 'Two-officer minimum for domestic disturbance responses', owner: 'CW3 Martinez', status: 'active', goal: 'Goal 2', expires: '01 SEP 25', rationale: 'Officer safety requirement based on incident analysis.', confidence: 94, thread: 'Patrol Operations', alignment: 'Requires', task: 'Call Response Assignment' },
-                { id: 'NAR-2024-012', type: 'NAR', statement: 'Community policing initiative reduced complaints by 34% in FY24', owner: 'MSG Patterson', status: 'active', goal: 'Goal 2', expires: '31 DEC 25', rationale: 'Narrative supported by complaint tracking data comparison FY23 vs FY24.', confidence: 89, thread: 'Patrol Operations', alignment: 'Enables', task: 'Community Engagement Program' },
-                
-                // Corrections - Goal 3
-                { id: 'DLR-2024-134', type: 'DLR', statement: 'Confinement facility inspections conducted monthly minimum', owner: 'MSG Patterson', status: 'active', goal: 'Goal 3', expires: '01 MAR 25', rationale: 'Compliance requirement per AR 190-47 Army Corrections System.', confidence: 93, thread: 'Policy & Compliance', alignment: 'Requires', task: 'Facility Inspection Schedule' },
-                { id: 'ASM-2024-145', type: 'ASM', statement: 'Current confinement capacity sufficient for projected needs through FY26', owner: 'MSG Patterson', status: 'draft', goal: 'Goal 3', expires: '30 SEP 25', rationale: 'Based on trend analysis and population projections.', confidence: 71, thread: 'Resource Management', alignment: 'Assumes', task: 'Capacity Planning' },
-                { id: 'TRM-2024-112', type: 'TRM', statement: 'Maximum custody = Highest security classification requiring constant supervision', owner: 'MSG Patterson', status: 'active', goal: 'Goal 3', expires: '01 NOV 25', rationale: 'Definition per AR 190-47 custody classification standards.', confidence: 98, thread: 'Policy & Compliance', alignment: 'Defines', task: 'Inmate Classification' },
-                
-                // Criminal Investigation - Goal 4
-                { id: 'DLR-2024-156', type: 'DLR', statement: 'Evidence chain of custody documented within 2 hours of collection', owner: 'CW3 Martinez', status: 'active', goal: 'Goal 4', expires: '15 APR 25', rationale: 'Ensures evidence integrity for prosecution viability.', confidence: 95, thread: 'Evidence Management', alignment: 'Requires', task: 'Evidence Intake' },
-                { id: 'ASM-2024-167', type: 'ASM', statement: 'Digital forensics backlog cleared within 30 days of submission', owner: 'CW3 Martinez', status: 'active', goal: 'Goal 4', expires: '01 JUL 25', rationale: 'Based on current staffing and caseload analysis.', confidence: 78, thread: 'Criminal Investigations', alignment: 'Assumes', task: 'Forensics Lab Scheduling' },
-                { id: 'DEP-2024-019', type: 'DEP', statement: 'Investigation timelines depend on digital forensics completion', owner: 'CW3 Martinez', status: 'expiring', goal: 'Goal 4', expires: '28 FEB 26', rationale: 'Many cases require device analysis before closure.', confidence: 84, thread: 'Criminal Investigations', alignment: 'Constrains', task: 'Case Closure Timeline', dependencies: ['ASM-2024-167'] },
-                
-                // Workforce Development - Goal 5  
-                { id: 'DLR-2024-178', type: 'DLR', statement: 'All new MPs complete 40-hour installation orientation within 30 days', owner: 'MSG Patterson', status: 'active', goal: 'Goal 5', expires: '01 JUN 25', rationale: 'Ensures operational readiness and local policy familiarity.', confidence: 91, thread: 'Training & Readiness', alignment: 'Requires', task: 'New MP Onboarding' },
-                { id: 'ASM-2024-189', type: 'ASM', statement: 'Annual training completion rate will exceed 95% by end of FY25', owner: 'MSG Patterson', status: 'draft', goal: 'Goal 5', expires: '30 SEP 25', rationale: 'Based on current trajectory and training schedule.', confidence: 68, thread: 'Training & Readiness', alignment: 'Assumes', task: 'Training Metrics Dashboard' },
-                { id: 'TRM-2024-145', type: 'TRM', statement: 'Certified = Completion of all mandatory training with passing scores', owner: 'MSG Patterson', status: 'active', goal: 'Goal 5', expires: '31 DEC 25', rationale: 'Standard definition for personnel readiness reporting.', confidence: 96, thread: 'Policy & Compliance', alignment: 'Defines', task: 'Readiness Reporting' },
-                { id: 'NAR-2024-023', type: 'NAR', statement: 'Cross-training program increased multi-role qualified personnel by 28%', owner: 'MSG Patterson', status: 'active', goal: 'Goal 5', expires: '30 JUN 25', rationale: 'Supported by personnel qualification database comparison.', confidence: 86, thread: 'Training & Readiness', alignment: 'Enables', task: 'Cross-Training Initiative' },
-                { id: 'DLR-2025-001', type: 'DLR', statement: 'Badge renewal requires updated background check if >3 years since last', owner: 'CPT Rodriguez', status: 'active', goal: 'Goal 1', expires: '01 DEC 25', rationale: 'Risk mitigation for personnel with outdated vetting.', confidence: 93, thread: 'Badge Operations', alignment: 'Requires', task: 'Badge Renewal Process' }
+                // ── Physical Security claims ──
+                { claimId: 'CLAIM-2024-0001', statement: 'Contractors with valid DBIDS do not require escort in Zone B during business hours', scope: { where: 'Installation Zone B', when: 'FY25', context: 'Business hours 0700-1700' }, truthType: 'inference', confidence: { score: 0.72, explanation: 'DBIDS verification provides identity assurance but escort policy challenged by MAJ Thompson' }, statusLight: 'yellow', sources: [{ ref: 'AR-190-13', type: 'document', reliability: 'high' }], evidence: [{ ref: 'dbids-completion-rate-2024', type: 'record', summary: '94% completion within 24hrs' }], owner: 'CPT Rodriguez', halfLife: { value: 30, unit: 'days', expiresAt: '2025-03-15T00:00:00Z', refreshTrigger: 'contradiction' }, graph: { dependsOn: ['CLAIM-2024-0002', 'CLAIM-2024-0003', 'CLAIM-2024-0009'], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:a1b2c3d4e5f6', sealedAt: '2024-11-15T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['access-control', 'zone-b', 'contractor'], _thread: 'Access Control', _created: '2024-11-15T10:00:00Z' },
+                { claimId: 'CLAIM-2024-0002', statement: 'DBIDS verification completes within 24 hours for standard requests', scope: { where: 'Installation', when: 'FY25' }, truthType: 'assumption', confidence: { score: 0.85, explanation: 'Based on 2023-2024 processing data showing 94% within 24hrs' }, statusLight: 'green', sources: [{ ref: 'dbids-metrics-2024', type: 'record', reliability: 'high' }], evidence: [{ ref: 'processing-time-analysis', type: 'record', summary: '94% completion rate' }], owner: 'CPT Rodriguez', halfLife: { value: 14, unit: 'days', expiresAt: '2025-02-28T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: ['CLAIM-2024-0001'], patches: [] }, seal: { hash: 'sha256:b2c3d4e5f6a7', sealedAt: '2024-10-20T08:30:00Z', version: 1 }, classificationTag: 'internal', tags: ['badge-ops', 'dbids'], _thread: 'Badge Operations', _created: '2024-10-20T08:30:00Z' },
+                { claimId: 'CLAIM-2024-0003', statement: 'Zone B = Administrative areas accessible to credentialed personnel only', scope: { where: 'Installation', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 0.95, explanation: 'AR 190-13 defines access control zones' }, statusLight: 'green', sources: [{ ref: 'AR-190-13', type: 'document', reliability: 'high' }], evidence: [{ ref: 'ar-190-13-ch4', type: 'document', summary: 'Zone classification standards' }], owner: 'CPT Rodriguez', halfLife: { value: 180, unit: 'days', expiresAt: '2025-06-01T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: ['CLAIM-2024-0001'], patches: [] }, seal: { hash: 'sha256:c3d4e5f6a7b8', sealedAt: '2024-09-15T14:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['perimeter', 'zone-b'], _thread: 'Perimeter Security', _created: '2024-09-15T14:00:00Z' },
+                { claimId: 'CLAIM-2024-0004', statement: 'Installation access badges issued within 72 hours of approval', scope: { where: 'Installation Badge Office', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.88, explanation: 'Badge production capacity supports timeline based on current equipment' }, statusLight: 'green', sources: [{ ref: 'badge-production-logs', type: 'record', reliability: 'high' }], evidence: [{ ref: 'production-capacity-report', type: 'record', summary: 'Current capacity supports 72hr timeline' }], owner: 'MAJ Thompson', halfLife: { value: 60, unit: 'days', expiresAt: '2025-05-20T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: ['CLAIM-2024-0002', 'CLAIM-2024-0008'], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:d4e5f6a7b8c9', sealedAt: '2024-10-25T11:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['badge-ops'], _thread: 'Badge Operations', _created: '2024-10-25T11:00:00Z' },
+                { claimId: 'CLAIM-2024-0005', statement: 'Visitor badges valid for single day entry only', scope: { where: 'All gates', when: 'FY25' }, truthType: 'norm', confidence: { score: 0.90, explanation: 'Installation policy memorandum 2024-03' }, statusLight: 'green', sources: [{ ref: 'policy-memo-2024-03', type: 'document', reliability: 'high' }], evidence: [{ ref: 'visitor-badge-policy', type: 'document', summary: 'Single-day validity requirement' }], owner: 'SFC Williams', halfLife: { value: 7, unit: 'days', expiresAt: '2025-02-27T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:e5f6a7b8c9d0', sealedAt: '2024-11-01T09:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['visitor-mgmt'], _thread: 'Visitor Management', _created: '2024-11-01T09:00:00Z' },
+                { claimId: 'CLAIM-2024-0006', statement: 'Red Zone = Restricted areas requiring SECRET clearance minimum', scope: { where: 'Installation', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 0.98, explanation: 'Defined per DoD 5200.08-R Physical Security Program' }, statusLight: 'green', sources: [{ ref: 'DoD-5200.08-R', type: 'document', reliability: 'high' }], evidence: [{ ref: 'dod-5200-08r-sec3', type: 'document', summary: 'Clearance zone requirements' }], owner: 'MAJ Thompson', halfLife: { value: 365, unit: 'days', expiresAt: '2025-07-15T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:f6a7b8c9d0e1', sealedAt: '2024-08-01T10:00:00Z', version: 1 }, classificationTag: 'restricted', tags: ['perimeter', 'red-zone', 'clearance'], _thread: 'Perimeter Security', _created: '2024-08-01T10:00:00Z' },
+                { claimId: 'CLAIM-2024-0007', statement: 'After-hours access requires supervisor pre-authorization and log entry', scope: { where: 'Installation', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.65, explanation: 'Balances operational need with security, but challenged by CW3 Martinez' }, statusLight: 'yellow', sources: [{ ref: 'AR-190-13', type: 'document', reliability: 'high' }], evidence: [{ ref: 'after-hours-incident-log', type: 'record', summary: 'Incident analysis supports requirement' }], owner: 'CPT Rodriguez', halfLife: { value: 30, unit: 'days', expiresAt: '2025-03-28T00:00:00Z', refreshTrigger: 'contradiction' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:a7b8c9d0e1f2', sealedAt: '2024-11-20T13:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['access-control', 'after-hours'], _thread: 'Access Control', _created: '2024-11-20T13:00:00Z' },
+                { claimId: 'CLAIM-2024-0008', statement: 'Badge issuance timeline depends on DBIDS verification completion', scope: { where: 'Badge Office', when: 'FY25' }, truthType: 'constraint', confidence: { score: 0.92, explanation: 'Sequential process dependency — badges cannot issue before identity verification' }, statusLight: 'green', sources: [{ ref: 'badge-process-sop', type: 'document', reliability: 'high' }], evidence: [{ ref: 'process-flow-diagram', type: 'document', summary: 'Sequential dependency documented' }], owner: 'SFC Williams', halfLife: { value: 90, unit: 'days', expiresAt: '2025-04-01T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: ['CLAIM-2024-0002'], contradicts: [], supersedes: null, supports: ['CLAIM-2024-0004'], patches: [] }, seal: { hash: 'sha256:b8c9d0e1f2a3', sealedAt: '2024-10-10T15:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['badge-ops', 'dependency'], _thread: 'Badge Operations', _created: '2024-10-10T15:00:00Z' },
+                { claimId: 'CLAIM-2024-0009', statement: 'AR 190-13 governs all physical security access control decisions', scope: { where: 'All Army installations', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 1.00, explanation: 'Primary regulatory authority for Army installation physical security' }, statusLight: 'green', sources: [{ ref: 'AR-190-13', type: 'document', reliability: 'high' }], evidence: [{ ref: 'hqda-policy-letter', type: 'document', summary: 'Regulatory authority confirmed' }], owner: 'MAJ Thompson', halfLife: { value: 365, unit: 'days', expiresAt: '2025-12-31T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: ['CLAIM-2024-0001'], patches: [] }, seal: { hash: 'sha256:c9d0e1f2a3b4', sealedAt: '2024-07-01T08:00:00Z', version: 1 }, classificationTag: 'public', tags: ['policy', 'ar-190-13'], _thread: 'Policy & Compliance', _created: '2024-07-01T08:00:00Z' },
+                { claimId: 'CLAIM-2024-0010', statement: 'Peak gate traffic occurs 0700-0830 and 1630-1730 daily', scope: { where: 'All gates', when: 'FY25' }, truthType: 'observation', confidence: { score: 0.91, explanation: 'Based on 6-month traffic analysis from gate sensors' }, statusLight: 'green', sources: [{ ref: 'gate-sensor-data-2024', type: 'record', reliability: 'high' }], evidence: [{ ref: 'traffic-analysis-q1q2', type: 'record', summary: '6-month sensor data analysis' }], owner: 'SFC Williams', halfLife: { value: 60, unit: 'days', expiresAt: '2025-04-30T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:d0e1f2a3b4c5', sealedAt: '2024-11-05T12:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['access-control', 'traffic'], _thread: 'Access Control', _created: '2024-11-05T12:00:00Z' },
+                // ── Law Enforcement claims ──
+                { claimId: 'CLAIM-2024-0011', statement: 'All traffic stops require body camera activation before approach', scope: { where: 'Installation roadways', when: 'FY25' }, truthType: 'norm', confidence: { score: 0.96, explanation: 'HQDA guidance on law enforcement recording' }, statusLight: 'green', sources: [{ ref: 'hqda-le-recording-policy', type: 'document', reliability: 'high' }], evidence: [{ ref: 'bodycam-compliance-audit', type: 'record', summary: '98% compliance rate' }], owner: 'CW3 Martinez', halfLife: { value: 180, unit: 'days', expiresAt: '2025-05-15T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:e1f2a3b4c5d6', sealedAt: '2024-09-20T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['traffic', 'bodycam'], _thread: 'Traffic Enforcement', _created: '2024-09-20T10:00:00Z' },
+                { claimId: 'CLAIM-2024-0012', statement: 'Use of Force = Any physical technique to control, restrain, or overcome resistance', scope: { where: 'Installation', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 0.97, explanation: 'Aligned with DoD Law Enforcement Use of Force policy' }, statusLight: 'green', sources: [{ ref: 'dod-le-uof-policy', type: 'document', reliability: 'high' }], evidence: [{ ref: 'uof-policy-review', type: 'document', summary: 'Definition aligned with DoD standard' }], owner: 'CW3 Martinez', halfLife: { value: 365, unit: 'days', expiresAt: '2025-08-01T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:f2a3b4c5d6e7', sealedAt: '2024-08-15T14:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['patrol', 'use-of-force'], _thread: 'Patrol Operations', _created: '2024-08-15T14:00:00Z' },
+                { claimId: 'CLAIM-2024-0013', statement: 'Average patrol response time under 5 minutes for Priority 1 calls', scope: { where: 'Installation', when: 'FY25' }, truthType: 'assumption', confidence: { score: 0.87, explanation: 'Based on 2024 Q1-Q3 data showing 4.2 minute average' }, statusLight: 'green', sources: [{ ref: 'dispatch-response-data', type: 'record', reliability: 'high' }], evidence: [{ ref: 'response-time-q1q3', type: 'record', summary: '4.2 min average response' }], owner: 'MSG Patterson', halfLife: { value: 30, unit: 'days', expiresAt: '2025-06-30T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:a3b4c5d6e7f8', sealedAt: '2024-10-01T09:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['patrol', 'response-time'], _thread: 'Emergency Response', _created: '2024-10-01T09:00:00Z' },
+                { claimId: 'CLAIM-2024-0014', statement: 'Two-officer minimum for domestic disturbance responses', scope: { where: 'Installation housing', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.94, explanation: 'Officer safety requirement based on incident analysis' }, statusLight: 'green', sources: [{ ref: 'incident-analysis-2024', type: 'record', reliability: 'high' }], evidence: [{ ref: 'domestic-incident-review', type: 'record', summary: 'Safety analysis supports 2-officer minimum' }], owner: 'CW3 Martinez', halfLife: { value: 90, unit: 'days', expiresAt: '2025-09-01T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:b4c5d6e7f8a9', sealedAt: '2024-09-10T11:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['patrol', 'domestic'], _thread: 'Patrol Operations', _created: '2024-09-10T11:00:00Z' },
+                { claimId: 'CLAIM-2024-0015', statement: 'Community policing initiative reduced complaints by 34% in FY24', scope: { where: 'Installation', when: 'FY24' }, truthType: 'observation', confidence: { score: 0.89, explanation: 'Complaint tracking data comparison FY23 vs FY24' }, statusLight: 'green', sources: [{ ref: 'complaint-tracking-db', type: 'record', reliability: 'high' }], evidence: [{ ref: 'fy24-complaint-comparison', type: 'record', summary: '34% reduction documented' }], owner: 'MSG Patterson', halfLife: { value: 180, unit: 'days', expiresAt: '2025-12-31T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:c5d6e7f8a9b0', sealedAt: '2024-10-15T10:00:00Z', version: 1 }, classificationTag: 'public', tags: ['community', 'complaints'], _thread: 'Patrol Operations', _created: '2024-10-15T10:00:00Z' },
+                // ── Corrections claims ──
+                { claimId: 'CLAIM-2024-0016', statement: 'Confinement facility inspections conducted monthly minimum', scope: { where: 'Confinement facility', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.93, explanation: 'Compliance requirement per AR 190-47' }, statusLight: 'green', sources: [{ ref: 'AR-190-47', type: 'document', reliability: 'high' }], evidence: [{ ref: 'inspection-log-2024', type: 'record', summary: 'Monthly inspections completed on schedule' }], owner: 'MSG Patterson', halfLife: { value: 30, unit: 'days', expiresAt: '2025-03-01T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:d6e7f8a9b0c1', sealedAt: '2024-11-10T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['corrections', 'inspection'], _thread: 'Policy & Compliance', _created: '2024-11-10T10:00:00Z' },
+                { claimId: 'CLAIM-2024-0017', statement: 'Current confinement capacity sufficient for projected needs through FY26', scope: { where: 'Confinement facility', when: 'FY25-FY26' }, truthType: 'forecast', confidence: { score: 0.71, explanation: 'Based on trend analysis and population projections' }, statusLight: 'yellow', sources: [{ ref: 'population-projection-2024', type: 'record', reliability: 'medium' }], evidence: [{ ref: 'capacity-trend-analysis', type: 'record', summary: 'Trend analysis supports projection' }], owner: 'MSG Patterson', halfLife: { value: 60, unit: 'days', expiresAt: '2025-09-30T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:e7f8a9b0c1d2', sealedAt: '2024-11-25T14:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['corrections', 'capacity'], _thread: 'Resource Management', _created: '2024-11-25T14:00:00Z' },
+                { claimId: 'CLAIM-2024-0018', statement: 'Maximum custody = Highest security classification requiring constant supervision', scope: { where: 'Confinement facility', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 0.98, explanation: 'Per AR 190-47 custody classification standards' }, statusLight: 'green', sources: [{ ref: 'AR-190-47', type: 'document', reliability: 'high' }], evidence: [{ ref: 'custody-classification-guide', type: 'document', summary: 'Standard definition documented' }], owner: 'MSG Patterson', halfLife: { value: 365, unit: 'days', expiresAt: '2025-11-01T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:f8a9b0c1d2e3', sealedAt: '2024-08-20T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['corrections', 'classification'], _thread: 'Policy & Compliance', _created: '2024-08-20T10:00:00Z' },
+                // ── Criminal Investigation claims ──
+                { claimId: 'CLAIM-2024-0019', statement: 'Evidence chain of custody documented within 2 hours of collection', scope: { where: 'Evidence room', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.95, explanation: 'Ensures evidence integrity for prosecution viability' }, statusLight: 'green', sources: [{ ref: 'evidence-sop-2024', type: 'document', reliability: 'high' }], evidence: [{ ref: 'evidence-intake-audit', type: 'record', summary: '97% compliance with 2hr window' }], owner: 'CW3 Martinez', halfLife: { value: 90, unit: 'days', expiresAt: '2025-04-15T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:a9b0c1d2e3f4', sealedAt: '2024-10-05T11:00:00Z', version: 1 }, classificationTag: 'restricted', tags: ['evidence', 'chain-of-custody'], _thread: 'Evidence Management', _created: '2024-10-05T11:00:00Z' },
+                { claimId: 'CLAIM-2024-0020', statement: 'Digital forensics backlog cleared within 30 days of submission', scope: { where: 'Forensics lab', when: 'FY25' }, truthType: 'assumption', confidence: { score: 0.78, explanation: 'Based on current staffing and caseload analysis' }, statusLight: 'yellow', sources: [{ ref: 'forensics-workload-report', type: 'record', reliability: 'medium' }], evidence: [{ ref: 'backlog-trend-q3', type: 'record', summary: 'Current backlog trending within 30d' }], owner: 'CW3 Martinez', halfLife: { value: 30, unit: 'days', expiresAt: '2025-07-01T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:b0c1d2e3f4a5', sealedAt: '2024-10-20T13:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['forensics', 'backlog'], _thread: 'Criminal Investigations', _created: '2024-10-20T13:00:00Z' },
+                { claimId: 'CLAIM-2024-0021', statement: 'Investigation timelines depend on digital forensics completion', scope: { where: 'CID office', when: 'FY25' }, truthType: 'constraint', confidence: { score: 0.84, explanation: 'Many cases require device analysis before closure' }, statusLight: 'yellow', sources: [{ ref: 'case-closure-analysis', type: 'record', reliability: 'medium' }], evidence: [{ ref: 'case-dependency-report', type: 'record', summary: '68% of cases require forensic analysis' }], owner: 'CW3 Martinez', halfLife: { value: 60, unit: 'days', expiresAt: '2025-03-10T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: ['CLAIM-2024-0020'], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:c1d2e3f4a5b6', sealedAt: '2024-11-01T15:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['investigations', 'forensics'], _thread: 'Criminal Investigations', _created: '2024-11-01T15:00:00Z' },
+                // ── Workforce Development claims ──
+                { claimId: 'CLAIM-2024-0022', statement: 'All new MPs complete 40-hour installation orientation within 30 days', scope: { where: 'Installation', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.91, explanation: 'Ensures operational readiness and local policy familiarity' }, statusLight: 'green', sources: [{ ref: 'training-sop-2024', type: 'document', reliability: 'high' }], evidence: [{ ref: 'onboarding-completion-rate', type: 'record', summary: '96% completion within 30d window' }], owner: 'MSG Patterson', halfLife: { value: 90, unit: 'days', expiresAt: '2025-06-01T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:d2e3f4a5b6c7', sealedAt: '2024-10-01T09:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['training', 'onboarding'], _thread: 'Training & Readiness', _created: '2024-10-01T09:00:00Z' },
+                { claimId: 'CLAIM-2024-0023', statement: 'Annual training completion rate will exceed 95% by end of FY25', scope: { where: 'Installation', when: 'FY25' }, truthType: 'forecast', confidence: { score: 0.48, explanation: 'Based on current trajectory but staffing gaps create risk' }, statusLight: 'red', sources: [{ ref: 'training-tracker-2024', type: 'record', reliability: 'medium' }], evidence: [{ ref: 'completion-trajectory', type: 'record', summary: 'Current rate 82%, trending up' }], owner: 'MSG Patterson', halfLife: { value: 30, unit: 'days', expiresAt: '2025-09-30T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:e3f4a5b6c7d8', sealedAt: '2024-11-15T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['training', 'forecast'], _thread: 'Training & Readiness', _created: '2024-11-15T10:00:00Z' },
+                { claimId: 'CLAIM-2024-0024', statement: 'Certified = Completion of all mandatory training with passing scores', scope: { where: 'Installation', when: 'Ongoing' }, truthType: 'norm', confidence: { score: 0.96, explanation: 'Standard definition for personnel readiness reporting' }, statusLight: 'green', sources: [{ ref: 'readiness-reporting-guide', type: 'document', reliability: 'high' }], evidence: [{ ref: 'certification-standards', type: 'document', summary: 'Definition documented in readiness guide' }], owner: 'MSG Patterson', halfLife: { value: 365, unit: 'days', expiresAt: '2025-12-31T00:00:00Z', refreshTrigger: 'new_source' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:f4a5b6c7d8e9', sealedAt: '2024-07-15T08:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['training', 'certification'], _thread: 'Policy & Compliance', _created: '2024-07-15T08:00:00Z' },
+                { claimId: 'CLAIM-2024-0025', statement: 'Cross-training program increased multi-role qualified personnel by 28%', scope: { where: 'Installation', when: 'FY24' }, truthType: 'observation', confidence: { score: 0.86, explanation: 'Personnel qualification database comparison' }, statusLight: 'green', sources: [{ ref: 'personnel-qual-db', type: 'record', reliability: 'high' }], evidence: [{ ref: 'cross-training-metrics', type: 'record', summary: '28% increase documented in qual DB' }], owner: 'MSG Patterson', halfLife: { value: 180, unit: 'days', expiresAt: '2025-06-30T00:00:00Z', refreshTrigger: 'schedule' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:a5b6c7d8e9f0', sealedAt: '2024-10-10T14:00:00Z', version: 1 }, classificationTag: 'public', tags: ['training', 'cross-training'], _thread: 'Training & Readiness', _created: '2024-10-10T14:00:00Z' },
+                { claimId: 'CLAIM-2025-0001', statement: 'Badge renewal requires updated background check if >3 years since last', scope: { where: 'Badge Office', when: 'FY25' }, truthType: 'inference', confidence: { score: 0.93, explanation: 'Risk mitigation for personnel with outdated vetting' }, statusLight: 'green', sources: [{ ref: 'vetting-policy-2025', type: 'document', reliability: 'high' }], evidence: [{ ref: 'background-check-gap-analysis', type: 'record', summary: '12% of renewals have >3yr gap' }], owner: 'CPT Rodriguez', halfLife: { value: 90, unit: 'days', expiresAt: '2025-12-01T00:00:00Z', refreshTrigger: 'expiry' }, graph: { dependsOn: [], contradicts: [], supersedes: null, supports: [], patches: [] }, seal: { hash: 'sha256:b6c7d8e9f0a1', sealedAt: '2025-01-05T10:00:00Z', version: 1 }, classificationTag: 'internal', tags: ['badge-ops', 'background-check'], _thread: 'Badge Operations', _created: '2025-01-05T10:00:00Z' }
             ],
-            ciTrend: [82,83,81,84,83,85,84,86,85,84,86,87,86,85,87,86,85,86,87,86,85,86,87,86,87,88,87,86,87,87.6],
-            blastNodes: {
-                'ASM-2024-012': {
-                    root: { id: 'ASM-2024-012', label: 'DBIDS Reliability', x: 250, y: 140 },
-                    level1: [
-                        { id: 'DLR-089', label: 'Escort Policy', x: 100, y: 60 },
-                        { id: 'DLR-091', label: 'Badge Issuance', x: 250, y: 40 },
-                        { id: 'DLR-095', label: 'Access Review', x: 400, y: 60 }
-                    ],
-                    level2: [
-                        { id: 'DLR-093', label: 'Patrol Tempo', x: 50, y: 200 },
-                        { id: 'ASM-019', label: 'Workload', x: 150, y: 220 },
-                        { id: 'DLR-097', label: 'Gate Staff', x: 350, y: 220 },
-                        { id: 'ASM-022', label: 'Forecast', x: 450, y: 200 }
-                    ]
-                }
-            },
-            expiryDays: [3, 7, 15, 22, 28]
+            ciTrend: [78,79,78,80,79,81,80,82,81,80,82,83,82,81,83,82,81,82,83,82,81,82,83,82,83,84,83,82,83,82.4],
+            expiryDays: [3, 7, 14, 21, 28]
         };
 
         let notificationsEnabled = true;
@@ -3537,6 +3798,12 @@
         function init() {
             loadState();
 
+            // Recompute statusLight for all claims
+            data.claims.forEach(function(c) { c.statusLight = deriveStatusLight(c); });
+            // Recompute status counts
+            data.statusCounts = { green: 0, yellow: 0, red: 0 };
+            data.claims.forEach(function(c) { data.statusCounts[c.statusLight] = (data.statusCounts[c.statusLight] || 0) + 1; });
+
             updateTimestamp();
             setInterval(updateTimestamp, 1000);
 
@@ -3544,20 +3811,21 @@
             renderActivity();
             renderBarChart();
             renderDonutChart();
-            renderGoals();
+            renderDimensions();
             renderAlerts();
             renderClaimsTable();
             renderTrendChart();
             renderCalendar();
+            renderDriftPanel();
             populateBlastSelect();
             renderBlastRadius();
 
             animateDashboard();
             setupEventListeners();
             setupDependencySearch();
-            
+
             // Demo notification
-            setTimeout(() => showToast('info', 'Dashboard Loaded', 'All systems operational'), 1000);
+            setTimeout(() => showToast('info', 'Dashboard v2.0', 'DeepSigma-aligned coherence engine active'), 1000);
         }
 
         function updateTimestamp() {
@@ -3605,58 +3873,96 @@
             `).join('');
         }
 
-        function renderGoals() {
-            document.getElementById('goalsList').innerHTML = data.goals.map(g => `
-                <div class="goal-row" onclick="showGoalDetail('${g.name}')">
-                    <div class="goal-header">
-                        <div class="goal-name">
-                            <div class="goal-dot ${g.status}"></div>
-                            <span class="goal-title">${g.name}</span>
-                        </div>
-                        <span class="goal-pct ${g.status}">${g.pct}%</span>
-                    </div>
-                    <div class="goal-bar">
-                        <div class="goal-fill ${g.status}" data-width="${g.pct}"></div>
-                    </div>
-                    <div class="goal-meta">
-                        <span>${g.claims} claims</span>
-                        <span>${g.note}</span>
-                    </div>
-                </div>
-            `).join('');
+        function renderDimensions() {
+            var dims = data.coherenceReport.dimensions;
+            document.getElementById('dimensionsList').innerHTML = dims.map(function(d) {
+                var color = d.score >= 80 ? 'green' : d.score >= 60 ? 'yellow' : 'red';
+                return '<div class="dimension-row" onclick="showDimensionDetail(\'' + escapeHtml(d.name) + '\')">' +
+                    '<div class="dimension-header">' +
+                        '<div class="dimension-name">' +
+                            '<span>' + escapeHtml(d.label) + '</span>' +
+                            '<span class="dimension-weight">w=' + d.weight.toFixed(2) + '</span>' +
+                        '</div>' +
+                        '<span class="dimension-score" style="color:var(--' + (color === 'green' ? 'success' : color === 'yellow' ? 'warning' : 'danger') + ')">' + d.score.toFixed(1) + '</span>' +
+                    '</div>' +
+                    '<div class="dimension-bar">' +
+                        '<div class="dimension-fill ' + color + '" data-width="' + d.score + '"></div>' +
+                    '</div>' +
+                '</div>';
+            }).join('');
         }
 
         function renderAlerts() {
-            document.getElementById('alertsList').innerHTML = data.alerts.map(a => `
-                <div class="alert-item ${a.type}" onclick="showAlertDetail('${a.title}')">
-                    <span class="alert-icon">${a.icon}</span>
-                    <div class="alert-content">
-                        <div class="alert-title">${a.title}</div>
-                        <div class="alert-desc">${a.desc}</div>
-                        <div class="alert-meta">${a.meta}</div>
-                    </div>
-                    <div class="alert-actions">
-                        <button class="alert-btn alert-btn-primary" onclick="event.stopPropagation(); handleAction('review')">Review</button>
-                    </div>
-                </div>
-            `).join('');
+            // Derive alerts from drift signals + half-life warnings + contradictions
+            var alerts = [];
+
+            // Red drift signals → critical alerts
+            data.driftSignals.forEach(function(ds) {
+                if (ds.severity === 'red') {
+                    alerts.push({ type: 'critical', icon: '🔴', title: ds.driftId + ' ' + ds.driftType.toUpperCase(), desc: ds.notes, meta: 'Patch: ' + ds.recommendedPatchType });
+                }
+            });
+
+            // Yellow drift signals → warnings
+            data.driftSignals.forEach(function(ds) {
+                if (ds.severity === 'yellow') {
+                    alerts.push({ type: 'warning', icon: '🟡', title: ds.driftId + ' ' + ds.driftType, desc: ds.notes, meta: 'Patch: ' + ds.recommendedPatchType });
+                }
+            });
+
+            // Claims near half-life expiry
+            data.claims.forEach(function(c) {
+                var daysLeft = halfLifeDaysRemaining(c);
+                if (daysLeft <= 14 && daysLeft > 0) {
+                    alerts.push({ type: 'warning', icon: '⏳', title: c.claimId + ' HALF-LIFE ' + daysLeft + 'D', desc: c.statement.substring(0, 50) + '...', meta: 'Owner: ' + c.owner });
+                }
+            });
+
+            // Claims with contradictions
+            data.claims.forEach(function(c) {
+                if (c.graph.contradicts && c.graph.contradicts.length > 0) {
+                    alerts.push({ type: 'critical', icon: '⚔️', title: c.claimId + ' CONTRADICTION', desc: 'Contradicts: ' + c.graph.contradicts.join(', '), meta: c.owner });
+                }
+            });
+
+            // Sort: critical first
+            alerts.sort(function(a, b) { return a.type === 'critical' && b.type !== 'critical' ? -1 : 1; });
+
+            var countEl = document.getElementById('alertCount');
+            if (countEl) countEl.textContent = alerts.length;
+
+            document.getElementById('alertsList').innerHTML = alerts.slice(0, 8).map(function(a) {
+                return '<div class="alert-item ' + a.type + '" onclick="showAlertDetail(\'' + escapeHtml(a.title) + '\')">' +
+                    '<span class="alert-icon">' + a.icon + '</span>' +
+                    '<div class="alert-content">' +
+                        '<div class="alert-title">' + escapeHtml(a.title) + '</div>' +
+                        '<div class="alert-desc">' + escapeHtml(a.desc) + '</div>' +
+                        '<div class="alert-meta">' + escapeHtml(a.meta) + '</div>' +
+                    '</div>' +
+                    '<div class="alert-actions">' +
+                        '<button class="alert-btn alert-btn-primary" onclick="event.stopPropagation(); handleAction(\'review\')">Review</button>' +
+                    '</div>' +
+                '</div>';
+            }).join('');
         }
 
         function renderClaimsTable() {
-            document.getElementById('claimsTable').innerHTML = data.claims.map(c => `
-                <tr onclick="showClaimDetail('${escapeHtml(c.id)}')">
-                    <td><span class="claim-id">${escapeHtml(c.id)}</span></td>
-                    <td><span class="claim-type ${escapeHtml(c.type)}">${escapeHtml(c.type)}</span></td>
-                    <td>${escapeHtml(c.statement.substring(0, 45))}...</td>
-                    <td>${escapeHtml(c.owner)}</td>
-                    <td><span class="claim-status ${escapeHtml(c.status)}">${escapeHtml(c.status)}</span></td>
-                    <td>${escapeHtml(c.goal)}</td>
-                    <td>${escapeHtml(c.expires)}</td>
-                    <td>
-                        <button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); handleAction('extend', '${escapeHtml(c.id)}')" title="Extend">📅</button>
-                    </td>
-                </tr>
-            `).join('');
+            document.getElementById('claimsTable').innerHTML = data.claims.map(function(c) {
+                var daysLeft = halfLifeDaysRemaining(c);
+                var hlClass = daysLeft <= 7 ? 'urgent' : daysLeft <= 30 ? 'warning' : 'ok';
+                var hlText = daysLeft === Infinity ? '—' : daysLeft + 'd';
+                var confColor = c.confidence.score >= 0.80 ? 'var(--success)' : c.confidence.score >= 0.50 ? 'var(--warning)' : 'var(--danger)';
+                return '<tr onclick="showClaimDetail(\'' + escapeHtml(c.claimId) + '\')">' +
+                    '<td><span class="claim-id">' + escapeHtml(c.claimId) + '</span></td>' +
+                    '<td><span class="claim-type ' + escapeHtml(c.truthType) + '">' + escapeHtml(truthTypeShort(c.truthType)) + '</span></td>' +
+                    '<td>' + escapeHtml(c.statement.substring(0, 45)) + '...</td>' +
+                    '<td>' + escapeHtml(c.owner) + '</td>' +
+                    '<td><span class="status-light ' + escapeHtml(c.statusLight) + '">' + escapeHtml(c.statusLight) + '</span></td>' +
+                    '<td><div class="conf-bar"><div class="conf-bar-track"><div class="conf-bar-fill" style="width:' + (c.confidence.score * 100) + '%;background:' + confColor + '"></div></div><span class="conf-bar-value">' + c.confidence.score.toFixed(2) + '</span></div></td>' +
+                    '<td><span class="halflife-badge ' + hlClass + '">' + escapeHtml(hlText) + '</span></td>' +
+                    '<td><button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); showClaimDetail(\'' + escapeHtml(c.claimId) + '\')" title="View">👁️</button></td>' +
+                '</tr>';
+            }).join('');
         }
 
         function renderTrendChart() {
@@ -3685,61 +3991,129 @@
             const startDay = new Date(year, month, 1).getDay();
             const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
 
-            // Update title
             var titleEl = document.getElementById('calendarTitle');
-            if (titleEl) titleEl.textContent = 'Expiry Calendar - ' + monthNames[month] + ' ' + year;
+            if (titleEl) titleEl.textContent = 'Half-Life Calendar - ' + monthNames[month] + ' ' + year;
 
-            // Build expiry days from claim data
+            // Build half-life expiry days from claim data
             var expiryDaysSet = {};
             data.claims.forEach(function(c) {
-                if (!c.expires) return;
-                var parsed = parseClaimDate(c.expires);
+                if (!c.halfLife || !c.halfLife.expiresAt) return;
+                var parsed = new Date(c.halfLife.expiresAt);
                 if (parsed && parsed.getFullYear() === year && parsed.getMonth() === month) {
                     var d = parsed.getDate();
                     if (!expiryDaysSet[d]) expiryDaysSet[d] = [];
-                    expiryDaysSet[d].push(c.id);
+                    expiryDaysSet[d].push({ claimId: c.claimId, statusLight: c.statusLight });
                 }
             });
 
             const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
-            let html = days.map(d => `<div class="calendar-header">${d}</div>`).join('');
+            let html = days.map(d => '<div class="calendar-header">' + d + '</div>').join('');
 
             for (let i = 0; i < startDay; i++) {
-                html += `<div class="calendar-day muted"></div>`;
+                html += '<div class="calendar-day muted"></div>';
             }
 
             for (let d = 1; d <= daysInMonth; d++) {
                 const isToday = d === todayDate;
-                const hasExpiry = !!expiryDaysSet[d];
-                html += `<div class="calendar-day ${isToday ? 'today' : ''} ${hasExpiry ? 'has-expiry' : ''}" onclick="showDayDetail(${d})">${d}</div>`;
+                const dayData = expiryDaysSet[d];
+                const hasExpiry = !!dayData;
+                // Color dot by worst statusLight on that day
+                var dotColor = '';
+                if (dayData) {
+                    if (dayData.some(function(x) { return x.statusLight === 'red'; })) dotColor = 'red';
+                    else if (dayData.some(function(x) { return x.statusLight === 'yellow'; })) dotColor = 'yellow';
+                    else dotColor = 'green';
+                }
+                html += '<div class="calendar-day ' + (isToday ? 'today' : '') + ' ' + (hasExpiry ? 'has-expiry' : '') + '" ' +
+                    'onclick="showDayDetail(' + d + ')" ' +
+                    (dotColor ? 'style="border-bottom: 2px solid var(--' + (dotColor === 'green' ? 'success' : dotColor === 'yellow' ? 'warning' : 'danger') + ')"' : '') +
+                    '>' + d + '</div>';
             }
 
             document.getElementById('calendar').innerHTML = html;
         }
 
-        function parseClaimDate(str) {
-            if (!str || str === 'TBD') return null;
-            // Handle formats like "15 MAR 25", "15 MAR 2025", or ISO dates
-            var months = {JAN:0,FEB:1,MAR:2,APR:3,MAY:4,JUN:5,JUL:6,AUG:7,SEP:8,OCT:9,NOV:10,DEC:11};
-            var m = str.match(/(\d{1,2})\s+([A-Z]{3})\s+(\d{2,4})/);
-            if (m) {
-                var y = parseInt(m[3]);
-                if (y < 100) y += 2000;
-                return new Date(y, months[m[2]] || 0, parseInt(m[1]));
+        function renderDriftPanel() {
+            var signals = data.driftSignals;
+            if (!signals || signals.length === 0) return;
+
+            // Summary grid
+            var byType = {};
+            var bySeverity = { green: 0, yellow: 0, red: 0 };
+            signals.forEach(function(ds) {
+                byType[ds.driftType] = (byType[ds.driftType] || 0) + 1;
+                bySeverity[ds.severity] = (bySeverity[ds.severity] || 0) + 1;
+            });
+
+            var totalBadge = document.getElementById('driftTotalBadge');
+            if (totalBadge) totalBadge.textContent = signals.length;
+
+            var summaryGrid = document.getElementById('driftSummaryGrid');
+            if (summaryGrid) {
+                summaryGrid.innerHTML =
+                    '<div class="drift-summary-card"><div class="drift-summary-value">' + signals.length + '</div><div class="drift-summary-label">Total Signals</div></div>' +
+                    '<div class="drift-summary-card"><div class="drift-summary-value" style="color:var(--danger)">' + bySeverity.red + '</div><div class="drift-summary-label">Red (Critical)</div></div>' +
+                    '<div class="drift-summary-card"><div class="drift-summary-value" style="color:var(--warning)">' + bySeverity.yellow + '</div><div class="drift-summary-label">Yellow</div></div>' +
+                    '<div class="drift-summary-card"><div class="drift-summary-value" style="color:var(--success)">' + bySeverity.green + '</div><div class="drift-summary-label">Green</div></div>';
             }
-            var d = new Date(str);
-            return isNaN(d.getTime()) ? null : d;
+
+            // Drift type bar chart
+            var driftTypeChart = document.getElementById('driftTypeChart');
+            if (driftTypeChart) {
+                var allTypes = ['time','freshness','fallback','bypass','verify','outcome','fanout','contention'];
+                var maxVal = Math.max.apply(null, allTypes.map(function(t) { return byType[t] || 0; }));
+                if (maxVal === 0) maxVal = 1;
+                driftTypeChart.innerHTML = allTypes.map(function(t) {
+                    var val = byType[t] || 0;
+                    return '<div class="bar-row">' +
+                        '<span class="bar-label">' + t + '</span>' +
+                        '<div class="bar-track"><div class="bar-fill orange" data-width="' + ((val / maxVal) * 100) + '"></div></div>' +
+                        '<span class="bar-value">' + val + '</span>' +
+                    '</div>';
+                }).join('');
+            }
+
+            // Drift signal list
+            var driftList = document.getElementById('driftList');
+            if (driftList) {
+                driftList.innerHTML = signals.map(function(ds) {
+                    return '<div class="drift-signal severity-' + ds.severity + '" onclick="showDriftDetail(\'' + escapeHtml(ds.driftId) + '\')">' +
+                        '<div class="drift-severity ' + ds.severity + '"></div>' +
+                        '<div class="drift-content">' +
+                            '<div class="drift-title">' + escapeHtml(ds.driftId) + ' <span class="drift-type-badge">' + escapeHtml(ds.driftType) + '</span></div>' +
+                            '<div class="drift-meta">' + escapeHtml(ds.notes) + '</div>' +
+                        '</div>' +
+                        '<span class="drift-patch-badge">' + escapeHtml(ds.recommendedPatchType) + '</span>' +
+                    '</div>';
+                }).join('');
+            }
         }
 
         function buildDependencyGraph() {
-            // Build reverse adjacency: for each claim, who depends on it?
-            var dependents = {}; // claimId -> [claimIds that list it as a dependency]
+            // Build full graph adjacency from claim.graph edges
+            var dependents = {}; // claimId -> [claimIds that depend on it]
+            var allEdges = []; // { from, to, kind }
             data.claims.forEach(function(c) {
-                (c.dependencies || []).forEach(function(depId) {
+                var g = c.graph || {};
+                (g.dependsOn || []).forEach(function(depId) {
                     if (!dependents[depId]) dependents[depId] = [];
-                    dependents[depId].push(c.id);
+                    dependents[depId].push(c.claimId);
+                    allEdges.push({ from: c.claimId, to: depId, kind: 'dependsOn' });
+                });
+                (g.supports || []).forEach(function(supId) {
+                    allEdges.push({ from: c.claimId, to: supId, kind: 'supports' });
+                });
+                (g.contradicts || []).forEach(function(conId) {
+                    allEdges.push({ from: c.claimId, to: conId, kind: 'contradicts' });
+                });
+                if (g.supersedes) {
+                    allEdges.push({ from: c.claimId, to: g.supersedes, kind: 'supersedes' });
+                }
+                (g.patches || []).forEach(function(pId) {
+                    allEdges.push({ from: c.claimId, to: pId, kind: 'patches' });
                 });
             });
+            dependents._allEdges = allEdges;
             return dependents;
         }
 
@@ -3748,16 +4122,20 @@
             if (!select) return;
             var depGraph = buildDependencyGraph();
 
-            // Include claims that have dependents OR have dependencies
+            // Include claims that have graph edges
             var candidates = data.claims.filter(function(c) {
-                return (depGraph[c.id] && depGraph[c.id].length > 0) || (c.dependencies && c.dependencies.length > 0);
+                var g = c.graph || {};
+                return (depGraph[c.claimId] && depGraph[c.claimId].length > 0) ||
+                    (g.dependsOn && g.dependsOn.length > 0) ||
+                    (g.supports && g.supports.length > 0) ||
+                    (g.contradicts && g.contradicts.length > 0) ||
+                    g.supersedes;
             });
 
-            // Fallback: if no dependency data, show all claims
             if (candidates.length === 0) candidates = data.claims.slice(0, 10);
 
             select.innerHTML = candidates.map(function(c) {
-                return '<option value="' + escapeHtml(c.id) + '">' + escapeHtml(c.id) + ' - ' + escapeHtml(c.statement.substring(0, 30)) + '</option>';
+                return '<option value="' + escapeHtml(c.claimId) + '">' + escapeHtml(c.claimId) + ' - ' + escapeHtml(c.statement.substring(0, 30)) + '</option>';
             }).join('');
 
             select.addEventListener('change', function() {
@@ -3771,32 +4149,38 @@
 
             if (!rootId) {
                 var select = document.getElementById('blastSelect');
-                rootId = select ? select.value : (data.claims[0] || {}).id;
+                rootId = select ? select.value : (data.claims[0] || {}).claimId;
             }
             if (!rootId) { container.innerHTML = '<p style="color:var(--text-muted);text-align:center;padding:40px;">No claims available</p>'; return; }
 
             var depGraph = buildDependencyGraph();
+            var allEdges = depGraph._allEdges || [];
 
-            // Level 1: claims that depend on rootId + claims rootId depends on
-            var rootClaim = data.claims.find(function(c) { return c.id === rootId; });
+            // Gather neighbors (all edge types)
+            var rootClaim = data.claims.find(function(c) { return c.claimId === rootId; });
             var level1Set = {};
             // Dependents of root
             (depGraph[rootId] || []).forEach(function(id) { level1Set[id] = true; });
-            // Dependencies of root
-            if (rootClaim && rootClaim.dependencies) {
-                rootClaim.dependencies.forEach(function(id) { level1Set[id] = true; });
+            // All graph edges from root
+            if (rootClaim && rootClaim.graph) {
+                var g = rootClaim.graph;
+                (g.dependsOn || []).forEach(function(id) { level1Set[id] = true; });
+                (g.supports || []).forEach(function(id) { level1Set[id] = true; });
+                (g.contradicts || []).forEach(function(id) { level1Set[id] = true; });
+                if (g.supersedes) level1Set[g.supersedes] = true;
+                (g.patches || []).forEach(function(id) { level1Set[id] = true; });
             }
             var level1 = Object.keys(level1Set);
 
-            // Level 2: dependents/dependencies of level1 (excluding root and level1)
+            // Level 2
             var level2Set = {};
             level1.forEach(function(l1Id) {
                 (depGraph[l1Id] || []).forEach(function(id) {
                     if (id !== rootId && !level1Set[id]) level2Set[id] = true;
                 });
-                var l1Claim = data.claims.find(function(c) { return c.id === l1Id; });
-                if (l1Claim && l1Claim.dependencies) {
-                    l1Claim.dependencies.forEach(function(id) {
+                var l1Claim = data.claims.find(function(c) { return c.claimId === l1Id; });
+                if (l1Claim && l1Claim.graph) {
+                    (l1Claim.graph.dependsOn || []).forEach(function(id) {
                         if (id !== rootId && !level1Set[id]) level2Set[id] = true;
                     });
                 }
@@ -3804,7 +4188,7 @@
             var level2 = Object.keys(level2Set);
 
             // Layout
-            var cx = 250, cy = 140, r1 = 100, r2 = 130;
+            var cx = 250, cy = 140, r1 = 100, r2 = 140;
             var rootNode = { id: rootId, x: cx, y: cy };
 
             function circlePos(arr, radius, centerX, centerY) {
@@ -3816,57 +4200,73 @@
 
             var l1Nodes = circlePos(level1, r1, cx, cy);
             var l2Nodes = circlePos(level2, r2, cx, cy);
+            var allNodesMap = {};
+            allNodesMap[rootId] = rootNode;
+            l1Nodes.forEach(function(n) { allNodesMap[n.id] = n; });
+            l2Nodes.forEach(function(n) { allNodesMap[n.id] = n; });
+
+            // Edge color classes
+            var edgeClass = { dependsOn: 'blast-edge-depends', contradicts: 'blast-edge-contradicts', supersedes: 'blast-edge-supersedes', supports: 'blast-edge-supports', patches: 'blast-edge-patches' };
 
             // SVG
             var svg = '<svg class="blast-svg" viewBox="0 0 500 280">';
 
-            // Lines: root → level1
+            // Draw edges with typed colors
+            allEdges.forEach(function(e) {
+                var fromNode = allNodesMap[e.from];
+                var toNode = allNodesMap[e.to];
+                if (!fromNode || !toNode) return;
+                var cls = edgeClass[e.kind] || 'blast-line';
+                svg += '<line class="blast-line ' + cls + '" x1="' + fromNode.x + '" y1="' + fromNode.y + '" x2="' + toNode.x + '" y2="' + toNode.y + '" stroke-width="2"/>';
+            });
+
+            // Fallback lines for nodes without typed edges
             l1Nodes.forEach(function(n) {
-                svg += '<line class="blast-line" x1="' + rootNode.x + '" y1="' + rootNode.y + '" x2="' + n.x + '" y2="' + n.y + '"/>';
-            });
-
-            // Lines: level1 → level2 (connect each l2 to nearest l1)
-            l2Nodes.forEach(function(l2n) {
-                var nearest = l1Nodes[0];
-                var minDist = Infinity;
-                l1Nodes.forEach(function(l1n) {
-                    var d = Math.hypot(l1n.x - l2n.x, l1n.y - l2n.y);
-                    if (d < minDist) { minDist = d; nearest = l1n; }
+                var hasEdge = allEdges.some(function(e) {
+                    return (e.from === rootId && e.to === n.id) || (e.from === n.id && e.to === rootId);
                 });
-                svg += '<line class="blast-line" x1="' + nearest.x + '" y1="' + nearest.y + '" x2="' + l2n.x + '" y2="' + l2n.y + '"/>';
+                if (!hasEdge) {
+                    svg += '<line class="blast-line blast-edge-depends" x1="' + rootNode.x + '" y1="' + rootNode.y + '" x2="' + n.x + '" y2="' + n.y + '" stroke-width="2"/>';
+                }
             });
 
-            // Level 2 nodes (blue)
+            // Level 2 nodes
             l2Nodes.forEach(function(n) {
                 svg += '<g class="blast-node" onclick="showClaimDetail(\'' + escapeHtml(n.id) + '\')">' +
                     '<circle class="node-circle" cx="' + n.x + '" cy="' + n.y + '" r="22" fill="#3b82f6"/>' +
-                    '<text class="node-text" x="' + n.x + '" y="' + n.y + '">' + escapeHtml(n.id.split('-')[0]) + '</text>' +
-                    '<text class="node-label" x="' + n.x + '" y="' + (n.y + 35) + '">' + escapeHtml(n.id) + '</text>' +
+                    '<text class="node-text" x="' + n.x + '" y="' + (n.y + 1) + '" style="font-size:7px">' + escapeHtml(n.id.replace('CLAIM-','')) + '</text>' +
                 '</g>';
             });
 
-            // Level 1 nodes (yellow)
+            // Level 1 nodes
             l1Nodes.forEach(function(n) {
                 svg += '<g class="blast-node" onclick="showClaimDetail(\'' + escapeHtml(n.id) + '\')">' +
                     '<circle class="node-circle" cx="' + n.x + '" cy="' + n.y + '" r="26" fill="#eab308"/>' +
-                    '<text class="node-text" x="' + n.x + '" y="' + n.y + '">' + escapeHtml(n.id.split('-')[0]) + '</text>' +
-                    '<text class="node-label" x="' + n.x + '" y="' + (n.y + 38) + '">' + escapeHtml(n.id) + '</text>' +
+                    '<text class="node-text" x="' + n.x + '" y="' + (n.y + 1) + '" style="font-size:7px">' + escapeHtml(n.id.replace('CLAIM-','')) + '</text>' +
                 '</g>';
             });
 
-            // Root node (red)
+            // Root node
             svg += '<g class="blast-node" onclick="showClaimDetail(\'' + escapeHtml(rootNode.id) + '\')">' +
                 '<circle class="node-circle" cx="' + rootNode.x + '" cy="' + rootNode.y + '" r="35" fill="#ef4444"/>' +
-                '<text class="node-text" x="' + rootNode.x + '" y="' + (rootNode.y - 6) + '">' + escapeHtml(rootId.split('-')[0]) + '</text>' +
-                '<text class="node-text" x="' + rootNode.x + '" y="' + (rootNode.y + 8) + '" style="font-size:8px">' + escapeHtml(rootId.split('-').slice(1).join('-')) + '</text>' +
+                '<text class="node-text" x="' + rootNode.x + '" y="' + (rootNode.y - 4) + '" style="font-size:7px">' + escapeHtml(rootId.replace('CLAIM-','').split('-')[0]) + '</text>' +
+                '<text class="node-text" x="' + rootNode.x + '" y="' + (rootNode.y + 8) + '" style="font-size:7px">' + escapeHtml(rootId.replace('CLAIM-','').split('-')[1] || '') + '</text>' +
             '</g>';
 
             svg += '</svg>';
 
+            // Legend with edge types
             svg += '<div class="blast-legend">' +
                 '<div class="blast-legend-item"><div class="blast-legend-dot root"></div>Source</div>' +
                 '<div class="blast-legend-item"><div class="blast-legend-dot level1"></div>Direct (' + level1.length + ')</div>' +
                 '<div class="blast-legend-item"><div class="blast-legend-dot level2"></div>Indirect (' + level2.length + ')</div>' +
+            '</div>' +
+            '<div class="blast-legend" style="margin-top:6px;">' +
+                '<div class="blast-legend-edge"><div class="blast-legend-line" style="background:var(--info)"></div>dependsOn</div>' +
+                '<div class="blast-legend-edge"><div class="blast-legend-line" style="background:var(--success)"></div>supports</div>' +
+                '<div class="blast-legend-edge"><div class="blast-legend-line" style="background:var(--danger)"></div>contradicts</div>' +
+                '<div class="blast-legend-edge"><div class="blast-legend-line" style="background:var(--accent)"></div>supersedes</div>' +
+                '<div class="blast-legend-edge"><div class="blast-legend-line" style="background:var(--purple)"></div>patches</div>' +
             '</div>';
 
             container.innerHTML = svg;
@@ -3878,10 +4278,22 @@
 
         // Animation
         function animateDashboard() {
-            // CI Gauge
+            var ciScore = data.coherenceReport.overall;
+            var grade = data.coherenceReport.grade;
+
+            // CI Gauge + Grade
             setTimeout(() => {
-                document.getElementById('ciGauge').style.strokeDashoffset = 201 * (1 - data.ci / 100);
-                animateNumber(document.getElementById('ciValue'), data.ci, 2000);
+                document.getElementById('ciGauge').style.strokeDashoffset = 201 * (1 - ciScore / 100);
+                animateNumber(document.getElementById('ciValue'), ciScore, 2000);
+                var gradeEl = document.getElementById('ciGrade');
+                if (gradeEl) { gradeEl.textContent = grade; gradeEl.className = 'grade-badge ' + grade; }
+                var statusText = document.getElementById('ciStatusText');
+                if (statusText) statusText.textContent = ciScore >= 75 ? 'System Healthy' : ciScore >= 60 ? 'Needs Attention' : 'Critical';
+                var badge = document.getElementById('ciBadge');
+                if (badge) {
+                    badge.textContent = ciScore >= 75 ? 'Healthy' : ciScore >= 60 ? 'Warning' : 'Critical';
+                    badge.className = 'card-badge ' + (ciScore >= 75 ? 'badge-success' : ciScore >= 60 ? 'badge-warning' : 'badge-danger');
+                }
             }, 300);
 
             // Metrics
@@ -3898,20 +4310,26 @@
                 });
             }, 600);
 
-            // Donut
-            const total = Object.values(data.status).reduce((a, b) => a + b, 0);
+            // Donut (statusLight: green/yellow/red)
+            const total = Object.values(data.statusCounts).reduce((a, b) => a + b, 0);
             const circumference = 2 * Math.PI * 50;
             setTimeout(() => {
                 animateNumber(document.getElementById('donutTotal'), total, 1500);
+                // Update legend
+                var pct = function(v) { return total > 0 ? Math.round(v / total * 100) : 0; };
+                var lg = document.getElementById('legendGreen'); if (lg) lg.textContent = data.statusCounts.green + ' (' + pct(data.statusCounts.green) + '%)';
+                var ly = document.getElementById('legendYellow'); if (ly) ly.textContent = data.statusCounts.yellow + ' (' + pct(data.statusCounts.yellow) + '%)';
+                var lr = document.getElementById('legendRed'); if (lr) lr.textContent = data.statusCounts.red + ' (' + pct(data.statusCounts.red) + '%)';
+
                 let offset = 0;
                 [
-                    { id: 'donutActive', value: data.status.active },
-                    { id: 'donutDraft', value: data.status.draft },
-                    { id: 'donutChallenged', value: data.status.challenged },
-                    { id: 'donutExpired', value: data.status.expired }
+                    { id: 'donutGreen', value: data.statusCounts.green },
+                    { id: 'donutYellow', value: data.statusCounts.yellow },
+                    { id: 'donutRed', value: data.statusCounts.red }
                 ].forEach((seg, i) => {
                     setTimeout(() => {
                         const el = document.getElementById(seg.id);
+                        if (!el) return;
                         const len = circumference * (seg.value / total);
                         el.style.strokeDasharray = `${len} ${circumference}`;
                         el.style.strokeDashoffset = -offset;
@@ -3920,9 +4338,9 @@
                 });
             }, 700);
 
-            // Goals
+            // Dimension bars
             setTimeout(() => {
-                document.querySelectorAll('.goal-fill[data-width]').forEach((f, i) => {
+                document.querySelectorAll('.dimension-fill[data-width]').forEach((f, i) => {
                     setTimeout(() => f.style.width = f.dataset.width + '%', i * 100);
                 });
             }, 900);
@@ -4013,12 +4431,13 @@
                     undoLastAction();
                 }
                 // Number keys for tabs (when not in input)
-                if (!e.target.matches('input, select')) {
+                if (!e.target.matches('input, select, textarea')) {
                     if (e.key === '1') switchTab('overview');
                     if (e.key === '2') switchTab('claims');
-                    if (e.key === '3') switchTab('analysis');
-                    if (e.key === '4') switchTab('blast');
-                    if (e.key === '5') switchTab('compare');
+                    if (e.key === '3') switchTab('drift');
+                    if (e.key === '4') switchTab('analysis');
+                    if (e.key === '5') switchTab('blast');
+                    if (e.key === '6') switchTab('compare');
                     if (e.key === 'r') refreshDashboard();
                     if (e.key === 't') document.getElementById('themeToggle').click();
                     if (e.key === 'F11') { e.preventDefault(); toggleFullscreen(); }
@@ -4037,8 +4456,8 @@
             document.getElementById('searchInput').addEventListener('input', function() {
                 const query = this.value.toLowerCase();
                 if (query.length >= 2) {
-                    const results = data.claims.filter(c => 
-                        c.id.toLowerCase().includes(query) || 
+                    const results = data.claims.filter(c =>
+                        c.claimId.toLowerCase().includes(query) ||
                         c.statement.toLowerCase().includes(query)
                     );
                     if (results.length > 0) {
@@ -4053,6 +4472,7 @@
             document.querySelectorAll('.content').forEach(c => c.classList.remove('active'));
             document.getElementById(tab + 'Content').classList.add('active');
             if (tab === 'newclaim') loadDraft();
+            if (tab === 'drift') renderDriftPanel();
         }
 
         // Actions
@@ -4061,7 +4481,7 @@
             icon.style.animation = 'spin 1s linear infinite';
             
             document.querySelectorAll('.bar-fill').forEach(b => b.style.width = '0');
-            document.querySelectorAll('.goal-fill').forEach(g => g.style.width = '0');
+            document.querySelectorAll('.dimension-fill').forEach(g => g.style.width = '0');
             document.getElementById('ciGauge').style.strokeDashoffset = 201;
             
             setTimeout(() => {
@@ -4085,18 +4505,19 @@
         }
 
         function exportData() {
-            const csv = ['ID,Type,Statement,Owner,Status,Goal,Expires'];
+            const csv = ['ClaimID,TruthType,Statement,Owner,StatusLight,Confidence,HalfLifeDays,Scope'];
             data.claims.forEach(c => {
-                csv.push(`${c.id},${c.type},"${c.statement}",${c.owner},${c.status},${c.goal},${c.expires}`);
+                var hlDays = halfLifeDaysRemaining(c);
+                csv.push(c.claimId + ',' + c.truthType + ',"' + c.statement.replace(/"/g, '""') + '",' + c.owner + ',' + c.statusLight + ',' + c.confidence.score + ',' + (hlDays === Infinity ? '' : hlDays) + ',"' + (c.scope.where || '') + ' / ' + (c.scope.when || '') + '"');
             });
-            
+
             const blob = new Blob([csv.join('\n')], { type: 'text/csv' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
             a.download = 'edge_claims_export.csv';
             a.click();
-            
+
             showToast('success', 'Export Complete', 'Claims exported to CSV');
         }
 
@@ -4113,50 +4534,38 @@
 
         // Modals
         function showClaimDetail(id) {
-            const claim = data.claims.find(c => c.id === id) || { id, type: 'DLR', statement: 'Sample claim statement', owner: 'Unknown', status: 'active', goal: 'Goal 1', expires: 'TBD', rationale: 'No rationale provided' };
-            
-            document.getElementById('modalTitle').textContent = claim.id;
-            document.getElementById('modalBody').innerHTML = `
-                <div class="claim-detail-grid">
-                    <div class="detail-item">
-                        <div class="detail-label">Type</div>
-                        <div class="detail-value"><span class="claim-type ${escapeHtml(claim.type)}">${escapeHtml(claim.type)}</span></div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Status</div>
-                        <div class="detail-value"><span class="claim-status ${escapeHtml(claim.status)}">${escapeHtml(claim.status)}</span></div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Expires</div>
-                        <div class="detail-value">${escapeHtml(claim.expires)}</div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Owner</div>
-                        <div class="detail-value">${escapeHtml(claim.owner)}</div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">PMG Goal</div>
-                        <div class="detail-value">${escapeHtml(claim.goal)}</div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Dependencies</div>
-                        <div class="detail-value">${(claim.dependencies || []).length || '—'} claims</div>
-                    </div>
-                </div>
-                <div class="claim-statement">
-                    <div class="claim-statement-label">Statement</div>
-                    <div class="claim-statement-text">${escapeHtml(claim.statement)}</div>
-                </div>
-                <div class="claim-statement" style="border-left-color: var(--info);">
-                    <div class="claim-statement-label">Rationale</div>
-                    <div class="claim-statement-text">${escapeHtml(claim.rationale || 'No rationale provided')}</div>
-                </div>
-            `;
-            document.getElementById('modalFooter').innerHTML = `
-                <button class="btn btn-secondary" onclick="handleAction('archive', '${escapeHtml(claim.id)}'); closeModal();">Archive</button>
-                <button class="btn btn-secondary" onclick="handleAction('challenge', '${escapeHtml(claim.id)}'); closeModal();">Challenge</button>
-                <button class="btn btn-primary" onclick="handleAction('extend', '${escapeHtml(claim.id)}'); closeModal();">Extend 30 Days</button>
-            `;
+            var claim = data.claims.find(function(c) { return c.claimId === id; });
+            if (!claim) {
+                claim = { claimId: id, truthType: 'observation', statement: 'Claim not found', owner: 'Unknown', statusLight: 'yellow', confidence: { score: 0, explanation: '' }, halfLife: { value: 30, unit: 'days' }, scope: {}, graph: { dependsOn: [], contradicts: [], supports: [] }, sources: [], evidence: [], seal: {} };
+            }
+
+            var daysLeft = halfLifeDaysRemaining(claim);
+            var hlText = daysLeft === Infinity ? '—' : daysLeft + ' days remaining';
+            var graphEdges = [];
+            if (claim.graph.dependsOn && claim.graph.dependsOn.length) graphEdges.push('Depends on: ' + claim.graph.dependsOn.join(', '));
+            if (claim.graph.supports && claim.graph.supports.length) graphEdges.push('Supports: ' + claim.graph.supports.join(', '));
+            if (claim.graph.contradicts && claim.graph.contradicts.length) graphEdges.push('Contradicts: ' + claim.graph.contradicts.join(', '));
+            if (claim.graph.supersedes) graphEdges.push('Supersedes: ' + claim.graph.supersedes);
+
+            document.getElementById('modalTitle').textContent = claim.claimId;
+            document.getElementById('modalBody').innerHTML =
+                '<div class="claim-detail-grid">' +
+                    '<div class="detail-item"><div class="detail-label">Truth Type</div><div class="detail-value"><span class="claim-type ' + escapeHtml(claim.truthType) + '">' + escapeHtml(claim.truthType) + '</span></div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Status Light</div><div class="detail-value"><span class="status-light ' + escapeHtml(claim.statusLight) + '">' + escapeHtml(claim.statusLight) + '</span></div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Confidence</div><div class="detail-value" style="font-weight:700;color:' + (claim.confidence.score >= 0.80 ? 'var(--success)' : claim.confidence.score >= 0.50 ? 'var(--warning)' : 'var(--danger)') + '">' + claim.confidence.score.toFixed(2) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Owner</div><div class="detail-value">' + escapeHtml(claim.owner) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Half-Life</div><div class="detail-value">' + escapeHtml(claim.halfLife.value + ' ' + claim.halfLife.unit) + ' (' + escapeHtml(hlText) + ')</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Scope</div><div class="detail-value">' + escapeHtml((claim.scope.where || '') + ' / ' + (claim.scope.when || '')) + '</div></div>' +
+                '</div>' +
+                '<div class="claim-statement"><div class="claim-statement-label">Statement</div><div class="claim-statement-text">' + escapeHtml(claim.statement) + '</div></div>' +
+                '<div class="claim-statement" style="border-left-color: var(--info);"><div class="claim-statement-label">Confidence Explanation</div><div class="claim-statement-text">' + escapeHtml(claim.confidence.explanation || '—') + '</div></div>' +
+                (graphEdges.length > 0 ? '<div class="claim-statement" style="border-left-color: var(--purple);"><div class="claim-statement-label">Graph Edges</div><div class="claim-statement-text">' + graphEdges.map(function(e) { return escapeHtml(e); }).join('<br>') + '</div></div>' : '') +
+                (claim.sources && claim.sources.length > 0 ? '<div class="claim-statement" style="border-left-color: var(--success);"><div class="claim-statement-label">Sources</div><div class="claim-statement-text">' + claim.sources.map(function(s) { return escapeHtml(s.ref) + ' (' + escapeHtml(s.reliability) + ')'; }).join('<br>') + '</div></div>' : '') +
+                '<div style="margin-top:8px;font-size:10px;color:var(--text-muted);">Seal: ' + escapeHtml((claim.seal || {}).hash || '—') + ' | v' + ((claim.seal || {}).version || 1) + ' | ' + escapeHtml(claim.classificationTag || 'internal') + '</div>';
+
+            document.getElementById('modalFooter').innerHTML =
+                '<button class="btn btn-secondary" onclick="handleAction(\'archive\', \'' + escapeHtml(claim.claimId) + '\'); closeModal();">Archive</button>' +
+                '<button class="btn btn-primary" onclick="closeModal();">Close</button>';
             document.getElementById('modalOverlay').classList.add('active');
         }
 
@@ -4167,26 +4576,42 @@
             document.getElementById('modalOverlay').classList.add('active');
         }
 
-        function showGoalDetail(name) {
-            const goal = data.goals.find(g => g.name === name);
-            document.getElementById('modalTitle').textContent = name;
-            document.getElementById('modalBody').innerHTML = `
-                <div class="claim-detail-grid">
-                    <div class="detail-item">
-                        <div class="detail-label">Coverage</div>
-                        <div class="detail-value" style="color: var(--${escapeHtml(goal.status)});">${escapeHtml(goal.pct)}%</div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Claims</div>
-                        <div class="detail-value">${escapeHtml(goal.claims)}</div>
-                    </div>
-                    <div class="detail-item">
-                        <div class="detail-label">Status</div>
-                        <div class="detail-value">${escapeHtml(goal.note)}</div>
-                    </div>
-                </div>
-            `;
-            document.getElementById('modalFooter').innerHTML = `<button class="btn btn-primary" onclick="switchTab('claims'); closeModal();">View Claims</button>`;
+        function showDimensionDetail(name) {
+            var dim = data.coherenceReport.dimensions.find(function(d) { return d.name === name; });
+            if (!dim) return;
+            var detailHtml = Object.keys(dim.details).map(function(k) {
+                return '<div class="detail-item"><div class="detail-label">' + escapeHtml(k) + '</div><div class="detail-value">' + escapeHtml(String(dim.details[k])) + '</div></div>';
+            }).join('');
+            document.getElementById('modalTitle').textContent = dim.label;
+            document.getElementById('modalBody').innerHTML =
+                '<div class="claim-detail-grid">' +
+                    '<div class="detail-item"><div class="detail-label">Score</div><div class="detail-value" style="font-size:20px;font-weight:800;">' + dim.score.toFixed(1) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Weight</div><div class="detail-value">' + dim.weight.toFixed(2) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Weighted Contribution</div><div class="detail-value">' + (dim.score * dim.weight).toFixed(1) + '</div></div>' +
+                    detailHtml +
+                '</div>';
+            document.getElementById('modalFooter').innerHTML = '<button class="btn btn-primary" onclick="closeModal()">Close</button>';
+            document.getElementById('modalOverlay').classList.add('active');
+        }
+
+        function showDriftDetail(driftId) {
+            var ds = data.driftSignals.find(function(d) { return d.driftId === driftId; });
+            if (!ds) return;
+            document.getElementById('modalTitle').textContent = 'Drift Signal: ' + driftId;
+            document.getElementById('modalBody').innerHTML =
+                '<div class="claim-detail-grid">' +
+                    '<div class="detail-item"><div class="detail-label">Type</div><div class="detail-value"><span class="drift-type-badge">' + escapeHtml(ds.driftType) + '</span></div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Severity</div><div class="detail-value"><span class="drift-severity ' + ds.severity + '" style="display:inline-block;width:10px;height:10px;"></span> ' + escapeHtml(ds.severity) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Detected</div><div class="detail-value">' + escapeHtml(new Date(ds.detectedAt).toLocaleDateString()) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Episode</div><div class="detail-value">' + escapeHtml(ds.episodeId) + '</div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Recommended Patch</div><div class="detail-value"><span class="drift-patch-badge">' + escapeHtml(ds.recommendedPatchType) + '</span></div></div>' +
+                    '<div class="detail-item"><div class="detail-label">Fingerprint</div><div class="detail-value">' + escapeHtml(ds.fingerprint.key) + '</div></div>' +
+                '</div>' +
+                '<div class="claim-statement"><div class="claim-statement-label">Notes</div><div class="claim-statement-text">' + escapeHtml(ds.notes) + '</div></div>' +
+                '<div class="claim-statement" style="border-left-color:var(--info);"><div class="claim-statement-label">Affected Claims</div><div class="claim-statement-text">' + (ds.evidenceRefs || []).map(function(r) { return escapeHtml(r); }).join(', ') + '</div></div>';
+            document.getElementById('modalFooter').innerHTML =
+                '<button class="btn btn-secondary" onclick="closeModal()">Close</button>' +
+                '<button class="btn btn-primary" onclick="showToast(\'info\', \'Patch\', \'Applying ' + escapeHtml(ds.recommendedPatchType) + '\'); closeModal();">Apply Patch</button>';
             document.getElementById('modalOverlay').classList.add('active');
         }
 
@@ -4206,16 +4631,20 @@
             var month = now.getMonth();
             var monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
 
-            // Find claims expiring on this day
+            // Find claims whose half-life expires on this day
             var expiring = data.claims.filter(function(c) {
-                var parsed = parseClaimDate(c.expires);
+                if (!c.halfLife || !c.halfLife.expiresAt) return false;
+                var parsed = new Date(c.halfLife.expiresAt);
                 return parsed && parsed.getFullYear() === year && parsed.getMonth() === month && parsed.getDate() === day;
             });
 
             document.getElementById('modalTitle').textContent = monthNames[month] + ' ' + day + ', ' + year;
             document.getElementById('modalBody').innerHTML = expiring.length > 0
-                ? '<p>⚠️ Claims expiring on this day:</p><ul>' + expiring.map(function(c) { return '<li>' + escapeHtml(c.id) + ' — ' + escapeHtml(c.statement.substring(0, 40)) + '...</li>'; }).join('') + '</ul>'
-                : '<p>No claims expiring on this day.</p>';
+                ? '<p>⏳ Claims reaching half-life on this day:</p><ul>' + expiring.map(function(c) {
+                    return '<li><span class="status-light ' + escapeHtml(c.statusLight) + '">' + escapeHtml(c.statusLight) + '</span> ' +
+                        escapeHtml(c.claimId) + ' — ' + escapeHtml(c.statement.substring(0, 40)) + '... (conf: ' + c.confidence.score.toFixed(2) + ')</li>';
+                }).join('') + '</ul>'
+                : '<p>No claims reaching half-life on this day.</p>';
             document.getElementById('modalFooter').innerHTML = '<button class="btn btn-primary" onclick="closeModal()">Close</button>';
             document.getElementById('modalOverlay').classList.add('active');
         }
@@ -4271,9 +4700,10 @@
         const commandItems = [
             { icon: '📊', text: 'Go to Overview', key: '1', action: () => switchTab('overview') },
             { icon: '📋', text: 'Go to Claims', key: '2', action: () => switchTab('claims') },
-            { icon: '🔬', text: 'Go to Analysis', key: '3', action: () => switchTab('analysis') },
-            { icon: '💥', text: 'Go to Blast Radius', key: '4', action: () => switchTab('blast') },
-            { icon: '⚖️', text: 'Go to Compare', key: '5', action: () => switchTab('compare') },
+            { icon: '⚡', text: 'Go to Drift', key: '3', action: () => switchTab('drift') },
+            { icon: '🔬', text: 'Go to Analysis', key: '4', action: () => switchTab('analysis') },
+            { icon: '💥', text: 'Go to Blast Radius', key: '5', action: () => switchTab('blast') },
+            { icon: '⚖️', text: 'Go to Compare', key: '6', action: () => switchTab('compare') },
             { icon: '⟳', text: 'Refresh Dashboard', key: 'R', action: refreshDashboard },
             { icon: '🌙', text: 'Toggle Theme', key: 'T', action: () => document.getElementById('themeToggle').click() },
             { icon: '📥', text: 'Export CSV', key: 'E', action: exportData },
@@ -4296,45 +4726,132 @@
             const q = query.toLowerCase();
             let html = '';
 
-            // Commands section
-            const filteredCommands = commandItems.filter(c => c.text.toLowerCase().includes(q));
-            if (filteredCommands.length > 0) {
-                html += '<div class="cmd-group"><div class="cmd-group-label">Commands</div>';
-                filteredCommands.forEach((cmd, i) => {
-                    html += `<div class="cmd-item" onclick="runCommand(${i})">
-                        <span class="cmd-item-icon">${cmd.icon}</span>
-                        <span class="cmd-item-text">${cmd.text}</span>
-                        <span class="cmd-item-meta">${cmd.key}</span>
-                    </div>`;
-                });
-                html += '</div>';
-            }
-
-            // Claims section (only if query has content)
-            if (q.length >= 2) {
-                const filteredClaims = data.claims.filter(c => 
-                    c.id.toLowerCase().includes(q) || 
-                    c.statement.toLowerCase().includes(q) ||
-                    c.owner.toLowerCase().includes(q)
-                );
-                if (filteredClaims.length > 0) {
-                    html += '<div class="cmd-group"><div class="cmd-group-label">Claims</div>';
-                    filteredClaims.forEach(claim => {
-                        html += `<div class="cmd-item" onclick="showClaimDetail('${escapeHtml(claim.id)}'); closeCommandPalette();">
-                            <span class="cmd-item-icon">📋</span>
-                            <span class="cmd-item-text">${escapeHtml(claim.id)} - ${escapeHtml(claim.statement.substring(0, 35))}...</span>
-                            <span class="claim-type ${escapeHtml(claim.type)}">${escapeHtml(claim.type)}</span>
-                        </div>`;
+            // IRIS query support
+            if (q.startsWith('why ')) {
+                html += renderIRISQuery('why', q.substring(4).trim());
+            } else if (q.startsWith('drift ')) {
+                html += renderIRISQuery('drift', q.substring(6).trim());
+            } else if (q.startsWith('status ')) {
+                html += renderIRISQuery('status', q.substring(7).trim());
+            } else if (q.startsWith('changed ')) {
+                html += renderIRISQuery('changed', q.substring(8).trim());
+            } else if (q.startsWith('recall ')) {
+                html += renderIRISQuery('recall', q.substring(7).trim());
+            } else {
+                // Commands section
+                const filteredCommands = commandItems.filter(c => c.text.toLowerCase().includes(q));
+                if (filteredCommands.length > 0) {
+                    html += '<div class="cmd-group"><div class="cmd-group-label">Commands</div>';
+                    filteredCommands.forEach((cmd, i) => {
+                        html += '<div class="cmd-item" onclick="runCommand(' + i + ')">' +
+                            '<span class="cmd-item-icon">' + cmd.icon + '</span>' +
+                            '<span class="cmd-item-text">' + cmd.text + '</span>' +
+                            '<span class="cmd-item-meta">' + cmd.key + '</span>' +
+                        '</div>';
                     });
                     html += '</div>';
+                }
+
+                // Claims section
+                if (q.length >= 2) {
+                    const filteredClaims = data.claims.filter(c =>
+                        c.claimId.toLowerCase().includes(q) ||
+                        c.statement.toLowerCase().includes(q) ||
+                        c.owner.toLowerCase().includes(q)
+                    );
+                    if (filteredClaims.length > 0) {
+                        html += '<div class="cmd-group"><div class="cmd-group-label">Claims</div>';
+                        filteredClaims.forEach(claim => {
+                            html += '<div class="cmd-item" onclick="showClaimDetail(\'' + escapeHtml(claim.claimId) + '\'); closeCommandPalette();">' +
+                                '<span class="cmd-item-icon">📋</span>' +
+                                '<span class="cmd-item-text">' + escapeHtml(claim.claimId) + ' - ' + escapeHtml(claim.statement.substring(0, 35)) + '...</span>' +
+                                '<span class="claim-type ' + escapeHtml(claim.truthType) + '">' + escapeHtml(truthTypeShort(claim.truthType)) + '</span>' +
+                            '</div>';
+                        });
+                        html += '</div>';
+                    }
                 }
             }
 
             if (!html) {
-                html = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">No results found</div>';
+                html = '<div style="padding: 40px; text-align: center; color: var(--text-muted);">No results. Try: why CLAIM-2024-0001, drift CLAIM-2024-0012, status, recall keyword</div>';
             }
 
             document.getElementById('cmdResults').innerHTML = html;
+        }
+
+        function renderIRISQuery(type, term) {
+            var html = '<div class="cmd-group"><div class="cmd-group-label">IRIS: ' + escapeHtml(type.toUpperCase()) + '</div>';
+            var t = term.toLowerCase();
+
+            if (type === 'why') {
+                var claim = data.claims.find(function(c) { return c.claimId.toLowerCase().includes(t); });
+                if (claim) {
+                    var evList = (claim.evidence || []).map(function(e) { return escapeHtml(e.summary || e.ref); }).join(', ') || 'No evidence';
+                    var srcList = (claim.sources || []).map(function(s) { return escapeHtml(s.ref) + ' (' + escapeHtml(s.reliability) + ')'; }).join(', ') || 'No sources';
+                    html += '<div class="iris-result">' +
+                        '<div style="font-weight:600;">' + escapeHtml(claim.claimId) + ': ' + escapeHtml(claim.statement.substring(0, 60)) + '</div>' +
+                        '<div style="margin-top:4px;font-size:11px;"><strong>Evidence:</strong> ' + evList + '</div>' +
+                        '<div style="margin-top:2px;font-size:11px;"><strong>Sources:</strong> ' + srcList + '</div>' +
+                        '<div style="margin-top:2px;font-size:11px;"><strong>Confidence:</strong> ' + claim.confidence.score.toFixed(2) + ' — ' + escapeHtml(claim.confidence.explanation) + '</div>' +
+                    '</div>';
+                } else {
+                    html += '<div class="iris-result">No claim matching "' + escapeHtml(term) + '"</div>';
+                }
+            } else if (type === 'drift') {
+                var signals = data.driftSignals.filter(function(d) {
+                    return (d.evidenceRefs || []).some(function(r) { return r.toLowerCase().includes(t); }) || d.driftId.toLowerCase().includes(t);
+                });
+                if (signals.length > 0) {
+                    signals.forEach(function(ds) {
+                        html += '<div class="iris-result" onclick="showDriftDetail(\'' + escapeHtml(ds.driftId) + '\'); closeCommandPalette();" style="cursor:pointer;">' +
+                            '<span class="drift-severity ' + ds.severity + '" style="display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px;"></span>' +
+                            '<strong>' + escapeHtml(ds.driftId) + '</strong> ' + escapeHtml(ds.driftType) + ' — ' + escapeHtml(ds.notes) +
+                        '</div>';
+                    });
+                } else {
+                    html += '<div class="iris-result">No drift signals matching "' + escapeHtml(term) + '"</div>';
+                }
+            } else if (type === 'status') {
+                var counts = { green: 0, yellow: 0, red: 0 };
+                data.claims.forEach(function(c) { counts[c.statusLight] = (counts[c.statusLight] || 0) + 1; });
+                html += '<div class="iris-result">' +
+                    '<div><span class="status-light green">green</span> ' + counts.green + ' claims</div>' +
+                    '<div><span class="status-light yellow">yellow</span> ' + counts.yellow + ' claims</div>' +
+                    '<div><span class="status-light red">red</span> ' + counts.red + ' claims</div>' +
+                    '<div style="margin-top:4px;">Overall coherence: <strong>' + data.coherenceReport.overall + '</strong> (' + data.coherenceReport.grade + ')</div>' +
+                '</div>';
+            } else if (type === 'changed') {
+                var changedClaims = data.claims.filter(function(c) {
+                    return c.graph.supersedes || (c.graph.patches && c.graph.patches.length > 0);
+                });
+                if (changedClaims.length > 0) {
+                    changedClaims.forEach(function(c) {
+                        html += '<div class="iris-result" onclick="showClaimDetail(\'' + escapeHtml(c.claimId) + '\'); closeCommandPalette();" style="cursor:pointer;">' +
+                            escapeHtml(c.claimId) + ' — ' + (c.graph.supersedes ? 'supersedes ' + escapeHtml(c.graph.supersedes) : 'has patches') +
+                        '</div>';
+                    });
+                } else {
+                    html += '<div class="iris-result">No changed claims found</div>';
+                }
+            } else if (type === 'recall') {
+                var matches = data.claims.filter(function(c) {
+                    return c.claimId.toLowerCase().includes(t) ||
+                        c.statement.toLowerCase().includes(t) ||
+                        c.owner.toLowerCase().includes(t) ||
+                        (c.tags || []).some(function(tag) { return tag.toLowerCase().includes(t); });
+                });
+                matches.forEach(function(c) {
+                    html += '<div class="iris-result" onclick="showClaimDetail(\'' + escapeHtml(c.claimId) + '\'); closeCommandPalette();" style="cursor:pointer;">' +
+                        '<span class="status-light ' + escapeHtml(c.statusLight) + '" style="font-size:9px;">' + escapeHtml(c.statusLight) + '</span> ' +
+                        escapeHtml(c.claimId) + ' — ' + escapeHtml(c.statement.substring(0, 50)) +
+                    '</div>';
+                });
+                if (matches.length === 0) html += '<div class="iris-result">No results for "' + escapeHtml(term) + '"</div>';
+            }
+
+            html += '</div>';
+            return html;
         }
 
         function runCommand(index) {
@@ -4428,20 +4945,19 @@
         function goToCompare() {
             if (compareSelection.length !== 2) return;
 
-            const claim1 = data.claims.find(c => c.id === compareSelection[0]);
-            const claim2 = data.claims.find(c => c.id === compareSelection[1]);
+            const claim1 = data.claims.find(c => c.claimId === compareSelection[0]);
+            const claim2 = data.claims.find(c => c.claimId === compareSelection[1]);
 
             if (!claim1 || !claim2) return;
 
-            // Update Compare View
-            document.getElementById('compare1Title').textContent = claim1.id;
-            document.getElementById('compare1Type').textContent = claim1.type;
-            document.getElementById('compare1Type').className = `claim-type ${claim1.type}`;
+            document.getElementById('compare1Title').textContent = claim1.claimId;
+            document.getElementById('compare1Type').textContent = truthTypeShort(claim1.truthType);
+            document.getElementById('compare1Type').className = 'claim-type ' + claim1.truthType;
             document.getElementById('compare1Body').innerHTML = renderCompareCard(claim1, claim2);
 
-            document.getElementById('compare2Title').textContent = claim2.id;
-            document.getElementById('compare2Type').textContent = claim2.type;
-            document.getElementById('compare2Type').className = `claim-type ${claim2.type}`;
+            document.getElementById('compare2Title').textContent = claim2.claimId;
+            document.getElementById('compare2Type').textContent = truthTypeShort(claim2.truthType);
+            document.getElementById('compare2Type').className = 'claim-type ' + claim2.truthType;
             document.getElementById('compare2Body').innerHTML = renderCompareCard(claim2, claim1);
 
             switchTab('compare');
@@ -4449,31 +4965,41 @@
         }
 
         function renderCompareCard(claim, otherClaim) {
-            const diff = (a, b) => a !== b ? 'compare-diff' : '';
-            return `
-                <div class="compare-row">
-                    <span class="compare-label">Status</span>
-                    <span class="compare-value ${diff(claim.status, otherClaim.status)}">
-                        <span class="claim-status ${escapeHtml(claim.status)}">${escapeHtml(claim.status)}</span>
-                    </span>
-                </div>
-                <div class="compare-row">
-                    <span class="compare-label">Owner</span>
-                    <span class="compare-value ${diff(claim.owner, otherClaim.owner)}">${escapeHtml(claim.owner)}</span>
-                </div>
-                <div class="compare-row">
-                    <span class="compare-label">Goal</span>
-                    <span class="compare-value ${diff(claim.goal, otherClaim.goal)}">${escapeHtml(claim.goal)}</span>
-                </div>
-                <div class="compare-row">
-                    <span class="compare-label">Expires</span>
-                    <span class="compare-value ${diff(claim.expires, otherClaim.expires)}">${escapeHtml(claim.expires)}</span>
-                </div>
-                <div style="margin-top: 16px; padding: 14px; background: var(--bg-secondary); border-radius: 8px; border-left: 3px solid var(--accent);">
-                    <div style="font-size: 10px; color: var(--text-muted); text-transform: uppercase; margin-bottom: 8px;">Statement</div>
-                    <div style="font-size: 13px; line-height: 1.5;">${escapeHtml(claim.statement)}</div>
-                </div>
-            `;
+            var diff = function(a, b) { return a !== b ? 'compare-diff' : ''; };
+            var hlA = halfLifeDaysRemaining(claim);
+            var hlB = halfLifeDaysRemaining(otherClaim);
+            return '<div class="compare-row">' +
+                    '<span class="compare-label">Status Light</span>' +
+                    '<span class="compare-value ' + diff(claim.statusLight, otherClaim.statusLight) + '">' +
+                        '<span class="status-light ' + escapeHtml(claim.statusLight) + '">' + escapeHtml(claim.statusLight) + '</span>' +
+                    '</span>' +
+                '</div>' +
+                '<div class="compare-row">' +
+                    '<span class="compare-label">Truth Type</span>' +
+                    '<span class="compare-value ' + diff(claim.truthType, otherClaim.truthType) + '">' +
+                        '<span class="claim-type ' + escapeHtml(claim.truthType) + '">' + escapeHtml(claim.truthType) + '</span>' +
+                    '</span>' +
+                '</div>' +
+                '<div class="compare-row">' +
+                    '<span class="compare-label">Confidence</span>' +
+                    '<span class="compare-value ' + diff(claim.confidence.score, otherClaim.confidence.score) + '">' + claim.confidence.score.toFixed(2) + '</span>' +
+                '</div>' +
+                '<div class="compare-row">' +
+                    '<span class="compare-label">Owner</span>' +
+                    '<span class="compare-value ' + diff(claim.owner, otherClaim.owner) + '">' + escapeHtml(claim.owner) + '</span>' +
+                '</div>' +
+                '<div class="compare-row">' +
+                    '<span class="compare-label">Half-Life</span>' +
+                    '<span class="compare-value ' + diff(hlA, hlB) + '">' + (hlA === Infinity ? '—' : hlA + 'd') + '</span>' +
+                '</div>' +
+                '<div class="compare-row">' +
+                    '<span class="compare-label">Scope</span>' +
+                    '<span class="compare-value">' + escapeHtml((claim.scope.where || '') + ' / ' + (claim.scope.when || '')) + '</span>' +
+                '</div>' +
+                '<div style="margin-top: 16px; padding: 14px; background: var(--bg-secondary); border-radius: 8px; border-left: 3px solid var(--accent);">' +
+                    '<div style="font-size: 10px; color: var(--text-muted); text-transform: uppercase; margin-bottom: 8px;">Statement</div>' +
+                    '<div style="font-size: 13px; line-height: 1.5;">' + escapeHtml(claim.statement) + '</div>' +
+                '</div>';
         }
 
         // Undo System
@@ -4540,25 +5066,27 @@
         renderClaimsTable = function(claimsToRender) {
             var claims = claimsToRender || filteredClaims.length > 0 ? filteredClaims : data.claims;
             if (!claimsToRender && filteredClaims.length === 0) claims = data.claims;
-            
+
             document.getElementById('claimsTable').innerHTML = claims.map(function(c) {
-                var isSelected = bulkSelected.indexOf(c.id) >= 0;
-                return '<tr class="' + (isSelected ? 'selected' : '') + '" data-id="' + escapeHtml(c.id) + '">' +
-                    '<td class="th-checkbox"><input type="checkbox" class="row-checkbox" ' + (isSelected ? 'checked' : '') + ' onclick="toggleRowSelect(event, \'' + escapeHtml(c.id) + '\')"></td>' +
-                    '<td><span class="claim-id">' + escapeHtml(c.id) + '</span></td>' +
-                    '<td><span class="claim-type ' + escapeHtml(c.type) + '">' + escapeHtml(c.type) + '</span></td>' +
+                var isSelected = bulkSelected.indexOf(c.claimId) >= 0;
+                var hlDays = halfLifeDaysRemaining(c);
+                var hlLabel = hlDays === Infinity ? '—' : hlDays + 'd';
+                return '<tr class="' + (isSelected ? 'selected' : '') + '" data-id="' + escapeHtml(c.claimId) + '" oncontextmenu="showContextMenu(event, \'' + escapeHtml(c.claimId) + '\')" onclick="showClaimDetail(\'' + escapeHtml(c.claimId) + '\')">' +
+                    '<td class="th-checkbox"><input type="checkbox" class="row-checkbox" ' + (isSelected ? 'checked' : '') + ' onclick="toggleRowSelect(event, \'' + escapeHtml(c.claimId) + '\')"></td>' +
+                    '<td><span class="claim-id">' + escapeHtml(c.claimId) + '</span></td>' +
+                    '<td><span class="claim-type ' + escapeHtml(c.truthType) + '">' + escapeHtml(truthTypeShort(c.truthType)) + '</span></td>' +
                     '<td>' + escapeHtml(c.statement.substring(0, 50)) + '...</td>' +
                     '<td>' + escapeHtml(c.owner) + '</td>' +
-                    '<td><span class="claim-status ' + escapeHtml(c.status) + '">' + escapeHtml(c.status) + '</span></td>' +
-                    '<td>' + escapeHtml(c.goal.replace('Goal ', 'G')) + '</td>' +
-                    '<td>' + escapeHtml(c.expires) + '</td>' +
+                    '<td><span class="status-light ' + escapeHtml(c.statusLight) + '">' + escapeHtml(c.statusLight) + '</span></td>' +
+                    '<td><div class="conf-bar" title="' + c.confidence.score.toFixed(2) + '"><div class="conf-bar-fill" style="width:' + (c.confidence.score * 100) + '%;background:' + (c.confidence.score >= 0.80 ? 'var(--success)' : c.confidence.score >= 0.50 ? 'var(--warning)' : 'var(--danger)') + ';"></div></div></td>' +
+                    '<td><span class="halflife-badge ' + (hlDays <= 14 ? 'expiring' : '') + '">' + escapeHtml(hlLabel) + '</span></td>' +
                     '<td style="white-space:nowrap;">' +
-                        '<button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); showClaimDetail(\'' + escapeHtml(c.id) + '\')" title="View">👁️</button> ' +
-                        '<button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); editClaim(\'' + escapeHtml(c.id) + '\')" title="Edit">✏️</button>' +
+                        '<button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); showClaimDetail(\'' + escapeHtml(c.claimId) + '\')" title="View">👁️</button> ' +
+                        '<button class="btn btn-secondary btn-icon" onclick="event.stopPropagation(); editClaim(\'' + escapeHtml(c.claimId) + '\')" title="Edit">✏️</button>' +
                     '</td>' +
                 '</tr>';
             }).join('');
-            
+
             updateTableInfo(claims.length);
             updateBulkBar();
         };
@@ -4586,12 +5114,23 @@
             var claims = filteredClaims.length > 0 ? filteredClaims.slice() : data.claims.slice();
             
             claims.sort(function(a, b) {
-                var valA = a[column] || '';
-                var valB = b[column] || '';
-                
+                var valA, valB;
+                if (column === 'confidence') {
+                    valA = a.confidence.score;
+                    valB = b.confidence.score;
+                } else if (column === 'halflife') {
+                    valA = halfLifeDaysRemaining(a);
+                    valB = halfLifeDaysRemaining(b);
+                    if (valA === Infinity) valA = 99999;
+                    if (valB === Infinity) valB = 99999;
+                } else {
+                    valA = a[column] || '';
+                    valB = b[column] || '';
+                }
+
                 if (typeof valA === 'string') valA = valA.toLowerCase();
                 if (typeof valB === 'string') valB = valB.toLowerCase();
-                
+
                 if (valA < valB) return currentSort.direction === 'asc' ? -1 : 1;
                 if (valA > valB) return currentSort.direction === 'asc' ? 1 : -1;
                 return 0;
@@ -4607,12 +5146,12 @@
             var statusVal = document.getElementById('statusFilter').value;
 
             filteredClaims = data.claims.filter(function(c) {
-                var matchSearch = !searchVal || 
-                    c.id.toLowerCase().indexOf(searchVal) >= 0 ||
+                var matchSearch = !searchVal ||
+                    c.claimId.toLowerCase().indexOf(searchVal) >= 0 ||
                     c.statement.toLowerCase().indexOf(searchVal) >= 0 ||
                     c.owner.toLowerCase().indexOf(searchVal) >= 0;
-                var matchType = !typeVal || c.type === typeVal;
-                var matchStatus = !statusVal || c.status === statusVal;
+                var matchType = !typeVal || c.truthType === typeVal;
+                var matchStatus = !statusVal || c.statusLight === statusVal;
                 return matchSearch && matchType && matchStatus;
             });
 
@@ -4637,7 +5176,7 @@
             var claims = filteredClaims.length > 0 ? filteredClaims : data.claims;
             
             if (selectAllCheckbox.checked) {
-                bulkSelected = claims.map(function(c) { return c.id; });
+                bulkSelected = claims.map(function(c) { return c.claimId; });
             } else {
                 bulkSelected = [];
             }
@@ -4693,7 +5232,7 @@
                     showToast('warning', 'Bulk Archive', 'Archived ' + count + ' claims');
                     doUndoableAction('Archived ' + count + ' claims');
                     // Remove from data
-                    data.claims = data.claims.filter(function(c) { return bulkSelected.indexOf(c.id) < 0; });
+                    data.claims = data.claims.filter(function(c) { return bulkSelected.indexOf(c.claimId) < 0; });
                     clearBulkSelection();
                     filterClaimsTable();
                     break;
@@ -4701,116 +5240,104 @@
         }
 
         function exportSelectedClaims() {
-            var selected = data.claims.filter(function(c) { return bulkSelected.indexOf(c.id) >= 0; });
-            var csv = ['ID,Type,Statement,Owner,Status,Goal,Expires,Confidence'];
+            var selected = data.claims.filter(function(c) { return bulkSelected.indexOf(c.claimId) >= 0; });
+            var csv = ['ClaimID,TruthType,Statement,Owner,StatusLight,Confidence,HalfLifeDays'];
             selected.forEach(function(c) {
-                csv.push(c.id + ',"' + c.type + '","' + c.statement.replace(/"/g, '""') + '",' + c.owner + ',' + c.status + ',' + c.goal + ',' + c.expires + ',' + (c.confidence || 'N/A'));
+                var hlDays = halfLifeDaysRemaining(c);
+                csv.push(c.claimId + ',' + c.truthType + ',"' + c.statement.replace(/"/g, '""') + '",' + c.owner + ',' + c.statusLight + ',' + c.confidence.score + ',' + (hlDays === Infinity ? '' : hlDays));
             });
-            
+
             var blob = new Blob([csv.join('\n')], { type: 'text/csv' });
             var url = URL.createObjectURL(blob);
             var a = document.createElement('a');
             a.href = url;
             a.download = 'edge_claims_selected_' + bulkSelected.length + '.csv';
             a.click();
-            
+
             showToast('success', 'Export Complete', 'Exported ' + bulkSelected.length + ' claims');
         }
 
         // Edit Claim
         function editClaim(claimId) {
-            var claim = data.claims.find(function(c) { return c.id === claimId; });
+            var claim = data.claims.find(function(c) { return c.claimId === claimId; });
             if (!claim) return;
-            
+
             editingClaimId = claimId;
-            
-            document.getElementById('modalTitle').textContent = '✏️ Edit Claim: ' + claimId;
-            document.getElementById('modalBody').innerHTML = 
+            var truthTypes = ['observation','inference','assumption','forecast','norm','constraint'];
+            var ttOptions = truthTypes.map(function(tt) {
+                return '<option value="' + tt + '"' + (claim.truthType === tt ? ' selected' : '') + '>' + tt + '</option>';
+            }).join('');
+
+            var owners = ['CPT Rodriguez','MAJ Thompson','SFC Williams','CW3 Martinez','MSG Patterson'];
+            var ownerOptions = owners.map(function(o) {
+                return '<option value="' + o + '"' + (claim.owner === o ? ' selected' : '') + '>' + o + '</option>';
+            }).join('');
+
+            var confPct = Math.round(claim.confidence.score * 100);
+
+            document.getElementById('modalTitle').textContent = 'Edit Claim: ' + claimId;
+            document.getElementById('modalBody').innerHTML =
                 '<div class="edit-form-grid">' +
                     '<div class="edit-field">' +
-                        '<label class="edit-label">Type</label>' +
-                        '<select class="edit-select" id="editType">' +
-                            '<option value="DLR"' + (claim.type === 'DLR' ? ' selected' : '') + '>DLR - Decision</option>' +
-                            '<option value="TRM"' + (claim.type === 'TRM' ? ' selected' : '') + '>TRM - Term</option>' +
-                            '<option value="ASM"' + (claim.type === 'ASM' ? ' selected' : '') + '>ASM - Assumption</option>' +
-                            '<option value="DEP"' + (claim.type === 'DEP' ? ' selected' : '') + '>DEP - Dependency</option>' +
-                            '<option value="AUT"' + (claim.type === 'AUT' ? ' selected' : '') + '>AUT - Authority</option>' +
-                            '<option value="NAR"' + (claim.type === 'NAR' ? ' selected' : '') + '>NAR - Narrative</option>' +
-                        '</select>' +
+                        '<label class="edit-label">Truth Type</label>' +
+                        '<select class="edit-select" id="editType">' + ttOptions + '</select>' +
                     '</div>' +
                     '<div class="edit-field">' +
-                        '<label class="edit-label">Status</label>' +
-                        '<select class="edit-select" id="editStatus">' +
-                            '<option value="active"' + (claim.status === 'active' ? ' selected' : '') + '>Active</option>' +
-                            '<option value="draft"' + (claim.status === 'draft' ? ' selected' : '') + '>Draft</option>' +
-                            '<option value="challenged"' + (claim.status === 'challenged' ? ' selected' : '') + '>Challenged</option>' +
-                            '<option value="expiring"' + (claim.status === 'expiring' ? ' selected' : '') + '>Expiring</option>' +
-                        '</select>' +
+                        '<label class="edit-label">Owner</label>' +
+                        '<select class="edit-select" id="editOwner">' + ownerOptions + '</select>' +
                     '</div>' +
                     '<div class="edit-field form-full">' +
                         '<label class="edit-label">Statement</label>' +
                         '<textarea class="edit-textarea" id="editStatement" rows="3">' + escapeHtml(claim.statement) + '</textarea>' +
                     '</div>' +
                     '<div class="edit-field form-full">' +
-                        '<label class="edit-label">Rationale</label>' +
-                        '<textarea class="edit-textarea" id="editRationale" rows="3">' + escapeHtml(claim.rationale || '') + '</textarea>' +
+                        '<label class="edit-label">Confidence Explanation</label>' +
+                        '<textarea class="edit-textarea" id="editConfExplanation" rows="2">' + escapeHtml(claim.confidence.explanation || '') + '</textarea>' +
                     '</div>' +
                     '<div class="edit-field">' +
-                        '<label class="edit-label">Owner</label>' +
-                        '<select class="edit-select" id="editOwner">' +
-                            '<option value="CPT Rodriguez"' + (claim.owner === 'CPT Rodriguez' ? ' selected' : '') + '>CPT Rodriguez</option>' +
-                            '<option value="MAJ Thompson"' + (claim.owner === 'MAJ Thompson' ? ' selected' : '') + '>MAJ Thompson</option>' +
-                            '<option value="SFC Williams"' + (claim.owner === 'SFC Williams' ? ' selected' : '') + '>SFC Williams</option>' +
-                            '<option value="CW3 Martinez"' + (claim.owner === 'CW3 Martinez' ? ' selected' : '') + '>CW3 Martinez</option>' +
-                            '<option value="MSG Patterson"' + (claim.owner === 'MSG Patterson' ? ' selected' : '') + '>MSG Patterson</option>' +
-                        '</select>' +
-                    '</div>' +
-                    '<div class="edit-field">' +
-                        '<label class="edit-label">PMG Goal</label>' +
-                        '<select class="edit-select" id="editGoal">' +
-                            '<option value="Goal 1"' + (claim.goal === 'Goal 1' ? ' selected' : '') + '>Goal 1: Physical Security</option>' +
-                            '<option value="Goal 2"' + (claim.goal === 'Goal 2' ? ' selected' : '') + '>Goal 2: Law Enforcement</option>' +
-                            '<option value="Goal 3"' + (claim.goal === 'Goal 3' ? ' selected' : '') + '>Goal 3: Corrections</option>' +
-                            '<option value="Goal 4"' + (claim.goal === 'Goal 4' ? ' selected' : '') + '>Goal 4: Criminal Investigation</option>' +
-                            '<option value="Goal 5"' + (claim.goal === 'Goal 5' ? ' selected' : '') + '>Goal 5: Workforce Dev</option>' +
-                        '</select>' +
-                    '</div>' +
-                    '<div class="edit-field">' +
-                        '<label class="edit-label">Expires</label>' +
-                        '<input type="text" class="edit-input" id="editExpires" value="' + escapeHtml(claim.expires) + '">' +
-                    '</div>' +
-                    '<div class="edit-field">' +
-                        '<label class="edit-label">Confidence</label>' +
+                        '<label class="edit-label">Confidence (0-100%)</label>' +
                         '<div class="confidence-bar">' +
-                            '<input type="range" min="0" max="100" value="' + (claim.confidence || 75) + '" id="editConfidence" oninput="document.getElementById(\'editConfVal\').textContent = this.value + \'%\'">' +
-                            '<span class="confidence-bar-value" id="editConfVal">' + (claim.confidence || 75) + '%</span>' +
+                            '<input type="range" min="0" max="100" value="' + confPct + '" id="editConfidence" oninput="document.getElementById(\'editConfVal\').textContent = this.value + \'%\'">' +
+                            '<span class="confidence-bar-value" id="editConfVal">' + confPct + '%</span>' +
                         '</div>' +
                     '</div>' +
+                    '<div class="edit-field">' +
+                        '<label class="edit-label">Half-Life (days)</label>' +
+                        '<input type="number" class="edit-input" id="editHalfLife" value="' + (claim.halfLife.value || 30) + '" min="1">' +
+                    '</div>' +
+                    '<div class="edit-field">' +
+                        '<label class="edit-label">Scope: Where</label>' +
+                        '<input type="text" class="edit-input" id="editScopeWhere" value="' + escapeHtml(claim.scope.where || '') + '">' +
+                    '</div>' +
+                    '<div class="edit-field">' +
+                        '<label class="edit-label">Scope: When</label>' +
+                        '<input type="text" class="edit-input" id="editScopeWhen" value="' + escapeHtml(claim.scope.when || '') + '">' +
+                    '</div>' +
                 '</div>';
-            
-            document.getElementById('modalFooter').innerHTML = 
+
+            document.getElementById('modalFooter').innerHTML =
                 '<button class="btn btn-secondary" onclick="closeModal()">Cancel</button>' +
-                '<button class="btn btn-primary" onclick="saveClaimEdit()">💾 Save Changes</button>';
-            
+                '<button class="btn btn-primary" onclick="saveClaimEdit()">Save Changes</button>';
+
             document.getElementById('modalOverlay').classList.add('active');
         }
 
         function saveClaimEdit() {
             if (!editingClaimId) return;
-            
-            var claim = data.claims.find(function(c) { return c.id === editingClaimId; });
+
+            var claim = data.claims.find(function(c) { return c.claimId === editingClaimId; });
             if (!claim) return;
-            
-            // Update claim
-            claim.type = document.getElementById('editType').value;
-            claim.status = document.getElementById('editStatus').value;
-            claim.statement = document.getElementById('editStatement').value;
-            claim.rationale = document.getElementById('editRationale').value;
+
+            claim.truthType = document.getElementById('editType').value;
             claim.owner = document.getElementById('editOwner').value;
-            claim.goal = document.getElementById('editGoal').value;
-            claim.expires = document.getElementById('editExpires').value;
-            claim.confidence = parseInt(document.getElementById('editConfidence').value);
-            
+            claim.statement = document.getElementById('editStatement').value;
+            claim.confidence.explanation = document.getElementById('editConfExplanation').value;
+            claim.confidence.score = parseInt(document.getElementById('editConfidence').value) / 100;
+            claim.halfLife.value = parseInt(document.getElementById('editHalfLife').value) || 30;
+            claim.scope.where = document.getElementById('editScopeWhere').value;
+            claim.scope.when = document.getElementById('editScopeWhen').value;
+            claim.statusLight = deriveStatusLight(claim);
+
             closeModal();
             filterClaimsTable();
             showToast('success', 'Claim Updated', editingClaimId + ' has been updated');
@@ -4823,18 +5350,19 @@
         // NEW CLAIM FORM FUNCTIONS
         // ══════════════════════════════════════════════════════════════════
 
-        // Claim counters for ID generation
-        const claimCounters = { DLR: 92, TRM: 35, ASM: 46, DEP: 23, AUT: 12, NAR: 8 };
+        // Claim counter for sequential ID generation
+        let claimCounter = 27; // next after 26 demo claims
         let selectedDependencies = [];
+        let selectedSupports = [];
+        let selectedContradicts = [];
 
         function generateClaimId() {
             const type = document.getElementById('newClaimType').value;
             const idField = document.getElementById('newClaimId');
-            
+
             if (type) {
-                const nextNum = (claimCounters[type] || 0) + 1;
                 const year = new Date().getFullYear();
-                idField.value = type + '-' + year + '-' + String(nextNum).padStart(3, '0');
+                idField.value = 'CLAIM-' + year + '-' + String(claimCounter).padStart(4, '0');
             } else {
                 idField.value = '';
             }
@@ -4843,98 +5371,72 @@
 
         function updateConfidenceDisplay() {
             const value = document.getElementById('newClaimConfidence').value;
-            document.getElementById('confidenceValue').textContent = value + '%';
+            document.getElementById('confidenceValue').textContent = (value / 100).toFixed(2);
             updateClaimPreview();
         }
 
         function updateClaimPreview() {
-            const type = document.getElementById('newClaimType').value;
-            const id = document.getElementById('newClaimId').value;
-            const statement = document.getElementById('newClaimStatement').value;
-            const owner = document.getElementById('newClaimOwner').value;
-            const goal = document.getElementById('newClaimGoal').value;
-            const expires = document.getElementById('newClaimExpires').value;
-            const confidence = document.getElementById('newClaimConfidence').value;
-            const status = document.querySelector('input[name="newClaimStatus"]:checked');
-            const statusValue = status ? status.value : 'draft';
-            
-            // Task Alignment fields
-            const thread = document.getElementById('newClaimThread') ? document.getElementById('newClaimThread').value : '';
-            const alignment = document.getElementById('newClaimAlignment') ? document.getElementById('newClaimAlignment').value : '';
-            const task = document.getElementById('newClaimTask') ? document.getElementById('newClaimTask').value : '';
+            var truthType = document.getElementById('newClaimType').value;
+            var id = document.getElementById('newClaimId').value;
+            var statement = document.getElementById('newClaimStatement').value;
+            var owner = document.getElementById('newClaimOwner').value;
+            var confVal = document.getElementById('newClaimConfidence').value;
+            var confScore = (confVal / 100).toFixed(2);
+            var hlValue = document.getElementById('newClaimHalfLifeValue') ? document.getElementById('newClaimHalfLifeValue').value : '';
+            var hlUnit = document.getElementById('newClaimHalfLifeUnit') ? document.getElementById('newClaimHalfLifeUnit').value : 'days';
+            var scopeWhere = document.getElementById('newClaimScopeWhere') ? document.getElementById('newClaimScopeWhere').value : '';
+            var scopeWhen = document.getElementById('newClaimScopeWhen') ? document.getElementById('newClaimScopeWhen').value : '';
 
-            const preview = document.getElementById('claimPreview');
+            var preview = document.getElementById('claimPreview');
 
-            if (!type && !statement) {
+            if (!truthType && !statement) {
                 preview.innerHTML = '<div class="preview-placeholder"><span style="font-size: 48px; opacity: 0.3;">📋</span><p>Fill in the form to preview your claim</p></div>';
                 return;
             }
 
-            const dateStr = expires ? formatDate(expires) : 'TBD';
-            const ownerShort = owner ? owner.split(' - ')[0] : '—';
-            const goalShort = goal ? goal.split(':')[0] : '—';
-            const alignIcon = alignment ? alignment.split(' ')[0] : '—';
+            var statusLight = confScore >= 0.80 ? 'green' : confScore < 0.50 ? 'red' : 'yellow';
 
             preview.innerHTML =
                 '<div class="preview-claim">' +
                     '<div class="preview-claim-header">' +
                         '<span class="preview-claim-id">' + escapeHtml(id || '[ID]') + '</span>' +
                         '<div style="display:flex;gap:6px;">' +
-                            '<span class="claim-type ' + escapeHtml(type || '') + '">' + escapeHtml(type || '?') + '</span>' +
-                            '<span class="claim-status ' + escapeHtml(statusValue) + '">' + escapeHtml(statusValue) + '</span>' +
+                            '<span class="claim-type ' + escapeHtml(truthType || '') + '">' + escapeHtml(truthType ? truthTypeShort(truthType) : '?') + '</span>' +
+                            '<span class="status-light ' + escapeHtml(statusLight) + '">' + escapeHtml(statusLight) + '</span>' +
                         '</div>' +
                     '</div>' +
                     '<div class="preview-claim-body">' +
                         '<div class="preview-claim-statement">' + (statement ? escapeHtml(statement) : '<em style="color:var(--text-muted)">Enter statement...</em>') + '</div>' +
-                        // Task Alignment Row
-                        (task || thread ?
-                        '<div class="preview-task-row">' +
-                            '<span class="preview-task-badge">' + escapeHtml(alignIcon) + ' ' + escapeHtml(alignment ? alignment.split(' - ')[0] : '?') + '</span>' +
-                            '<span class="preview-task-text">' + escapeHtml(task || 'Task TBD') + '</span>' +
-                            '<span class="preview-task-thread">' + escapeHtml(thread || '') + '</span>' +
-                        '</div>' : '') +
                         '<div class="preview-claim-meta">' +
-                            '<div class="preview-meta-item"><span class="preview-meta-label">Owner</span><span class="preview-meta-value">' + escapeHtml(ownerShort) + '</span></div>' +
-                            '<div class="preview-meta-item"><span class="preview-meta-label">Goal</span><span class="preview-meta-value">' + escapeHtml(goalShort) + '</span></div>' +
-                            '<div class="preview-meta-item"><span class="preview-meta-label">Expires</span><span class="preview-meta-value">' + escapeHtml(dateStr) + '</span></div>' +
-                            '<div class="preview-meta-item"><span class="preview-meta-label">Confidence</span><span class="preview-meta-value" style="color:' + getConfidenceColor(confidence) + '">' + escapeHtml(confidence) + '%</span></div>' +
+                            '<div class="preview-meta-item"><span class="preview-meta-label">Owner</span><span class="preview-meta-value">' + escapeHtml(owner || '—') + '</span></div>' +
+                            '<div class="preview-meta-item"><span class="preview-meta-label">Scope</span><span class="preview-meta-value">' + escapeHtml((scopeWhere || '?') + ' / ' + (scopeWhen || '?')) + '</span></div>' +
+                            '<div class="preview-meta-item"><span class="preview-meta-label">Half-Life</span><span class="preview-meta-value">' + escapeHtml((hlValue || '?') + ' ' + hlUnit) + '</span></div>' +
+                            '<div class="preview-meta-item"><span class="preview-meta-label">Confidence</span><span class="preview-meta-value" style="color:' + (confScore >= 0.80 ? 'var(--success)' : confScore >= 0.50 ? 'var(--warning)' : 'var(--danger)') + '">' + escapeHtml(confScore) + '</span></div>' +
                         '</div>' +
                     '</div>' +
                 '</div>';
-        }
-
-        function formatDate(dateStr) {
-            var d = new Date(dateStr);
-            var months = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
-            return d.getDate() + ' ' + months[d.getMonth()] + ' ' + String(d.getFullYear()).slice(2);
-        }
-
-        function getConfidenceColor(value) {
-            if (value >= 70) return 'var(--success)';
-            if (value >= 40) return 'var(--warning)';
-            return 'var(--danger)';
         }
 
         function resetNewClaimForm() {
             document.getElementById('newClaimType').value = '';
             document.getElementById('newClaimId').value = '';
             document.getElementById('newClaimStatement').value = '';
-            document.getElementById('newClaimRationale').value = '';
+            if (document.getElementById('newClaimConfExplanation')) document.getElementById('newClaimConfExplanation').value = '';
             document.getElementById('newClaimOwner').value = '';
-            document.getElementById('newClaimGoal').value = '';
-            document.getElementById('newClaimExpires').value = '';
             document.getElementById('newClaimConfidence').value = 75;
-            document.getElementById('confidenceValue').textContent = '75%';
-            document.getElementById('newClaimTags').value = '';
-            // Task Alignment fields
-            document.getElementById('newClaimThread').value = '';
-            document.getElementById('newClaimAlignment').value = '';
-            document.getElementById('newClaimTask').value = '';
-            document.getElementById('newClaimWorkProduct').value = '';
-            // Reset status and deps
-            document.querySelector('input[name="newClaimStatus"][value="draft"]').checked = true;
+            document.getElementById('confidenceValue').textContent = '0.75';
+            if (document.getElementById('newClaimTags')) document.getElementById('newClaimTags').value = '';
+            if (document.getElementById('newClaimScopeWhere')) document.getElementById('newClaimScopeWhere').value = '';
+            if (document.getElementById('newClaimScopeWhen')) document.getElementById('newClaimScopeWhen').value = '';
+            if (document.getElementById('newClaimHalfLifeValue')) document.getElementById('newClaimHalfLifeValue').value = '30';
+            if (document.getElementById('newClaimHalfLifeUnit')) document.getElementById('newClaimHalfLifeUnit').value = 'days';
+            if (document.getElementById('newClaimHalfLifeTrigger')) document.getElementById('newClaimHalfLifeTrigger').value = 'expiry';
+            if (document.getElementById('newClaimClassification')) document.getElementById('newClaimClassification').value = 'internal';
+            if (document.getElementById('newClaimSourceRef')) document.getElementById('newClaimSourceRef').value = '';
             selectedDependencies = [];
-            document.getElementById('selectedDeps').innerHTML = '';
+            selectedSupports = [];
+            selectedContradicts = [];
+            if (document.getElementById('selectedDeps')) document.getElementById('selectedDeps').innerHTML = '';
             updateClaimPreview();
             showToast('info', 'Form Reset', 'All fields cleared');
         }
@@ -4947,71 +5449,75 @@
         }
 
         function submitNewClaim() {
-            // Validate required fields
-            var type = document.getElementById('newClaimType').value;
+            var truthType = document.getElementById('newClaimType').value;
             var statement = document.getElementById('newClaimStatement').value;
-            var rationale = document.getElementById('newClaimRationale').value;
             var owner = document.getElementById('newClaimOwner').value;
-            var goal = document.getElementById('newClaimGoal').value;
-            var expires = document.getElementById('newClaimExpires').value;
-            // Task Alignment required fields
-            var thread = document.getElementById('newClaimThread').value;
-            var alignment = document.getElementById('newClaimAlignment').value;
-            var task = document.getElementById('newClaimTask').value;
+            var confVal = parseInt(document.getElementById('newClaimConfidence').value);
+            var confExplanation = document.getElementById('newClaimConfExplanation') ? document.getElementById('newClaimConfExplanation').value : '';
+            var scopeWhere = document.getElementById('newClaimScopeWhere') ? document.getElementById('newClaimScopeWhere').value : '';
+            var scopeWhen = document.getElementById('newClaimScopeWhen') ? document.getElementById('newClaimScopeWhen').value : '';
+            var hlValue = document.getElementById('newClaimHalfLifeValue') ? parseInt(document.getElementById('newClaimHalfLifeValue').value) : 30;
+            var hlUnit = document.getElementById('newClaimHalfLifeUnit') ? document.getElementById('newClaimHalfLifeUnit').value : 'days';
+            var hlTrigger = document.getElementById('newClaimHalfLifeTrigger') ? document.getElementById('newClaimHalfLifeTrigger').value : 'expiry';
+            var classification = document.getElementById('newClaimClassification') ? document.getElementById('newClaimClassification').value : 'internal';
+            var sourceRef = document.getElementById('newClaimSourceRef') ? document.getElementById('newClaimSourceRef').value : '';
 
-            if (!type || !statement || !rationale || !owner || !goal || !expires || !thread || !alignment || !task) {
-                showToast('error', 'Missing Fields', 'Please fill in all required fields including Task Alignment');
+            if (!truthType || !statement || !owner) {
+                showToast('error', 'Missing Fields', 'Please fill in Truth Type, Statement, and Owner');
                 return;
             }
 
             var id = document.getElementById('newClaimId').value;
-            var status = document.querySelector('input[name="newClaimStatus"]:checked').value;
-            var confidence = document.getElementById('newClaimConfidence').value;
-            var workProduct = document.getElementById('newClaimWorkProduct').value;
+            var confScore = confVal / 100;
 
-            // Tags
             var tagsRaw = document.getElementById('newClaimTags') ? document.getElementById('newClaimTags').value : '';
             var tags = tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean);
 
-            // Create new claim object with task alignment
+            // Compute half-life expiry
+            var now = new Date();
+            var msPerUnit = hlUnit === 'hours' ? 3600000 : hlUnit === 'days' ? 86400000 : 1;
+            var expiresAt = new Date(now.getTime() + hlValue * msPerUnit).toISOString();
+
+            // Compute seal hash stub
+            var sealInput = id + statement + truthType + confScore;
+            var sealHash = 'sha256:' + Array.from(sealInput).reduce(function(h, c) { return ((h << 5) - h + c.charCodeAt(0)) | 0; }, 0).toString(16).replace('-', 'a');
+
             var newClaim = {
-                id: id,
-                type: type,
+                claimId: id,
                 statement: statement,
-                rationale: rationale,
-                owner: owner.split(' - ')[0],
-                status: status,
-                goal: goal,
-                expires: formatDate(expires),
-                confidence: parseInt(confidence),
-                // Task Alignment
-                thread: thread,
-                alignment: alignment,
-                task: task,
-                workProduct: workProduct || null,
+                scope: { where: scopeWhere, when: scopeWhen },
+                truthType: truthType,
+                confidence: { score: confScore, explanation: confExplanation },
+                statusLight: 'yellow',
+                sources: sourceRef ? [{ ref: sourceRef, type: 'document', reliability: 'medium' }] : [],
+                evidence: [],
+                owner: owner,
+                halfLife: { value: hlValue, unit: hlUnit, expiresAt: expiresAt, refreshTrigger: hlTrigger },
+                graph: { dependsOn: selectedDependencies.slice(), contradicts: selectedContradicts.slice(), supersedes: null, supports: selectedSupports.slice(), patches: [] },
+                seal: { hash: sealHash, sealedAt: now.toISOString(), version: 1 },
+                classificationTag: classification,
                 tags: tags,
-                dependencies: selectedDependencies.slice()
+                _thread: '',
+                _created: now.toISOString()
             };
+            newClaim.statusLight = deriveStatusLight(newClaim);
 
-            // Add to data array
             data.claims.unshift(newClaim);
-            claimCounters[type] = (claimCounters[type] || 0) + 1;
+            claimCounter++;
 
-            // Update total claims metric
             data.metrics[0].value = data.claims.length;
 
             showToast('success', 'Claim Created', id + ' has been created');
             saveState();
             clearDraft();
 
-            // Reset form and switch to claims view
             resetNewClaimForm();
             switchTab('claims');
             renderClaimsTable();
             renderMetrics();
         }
 
-        // Add dependency handling
+        // Dependency/supports/contradicts search for new claim form
         function setupDependencySearch() {
             var input = document.getElementById('depSearchInput');
             var suggestions = document.getElementById('depSuggestions');
@@ -5026,14 +5532,14 @@
                 }
 
                 var matches = data.claims.filter(function(c) {
-                    return c.id.toLowerCase().indexOf(q) >= 0 || c.statement.toLowerCase().indexOf(q) >= 0;
+                    return c.claimId.toLowerCase().indexOf(q) >= 0 || c.statement.toLowerCase().indexOf(q) >= 0;
                 }).slice(0, 5);
 
                 if (matches.length > 0) {
                     suggestions.innerHTML = matches.map(function(c) {
-                        return '<div class="dep-suggestion" onclick="addDependency(\'' + escapeHtml(c.id) + '\')">' +
-                            '<span>' + escapeHtml(c.id) + '</span>' +
-                            '<span class="claim-type ' + escapeHtml(c.type) + '">' + escapeHtml(c.type) + '</span>' +
+                        return '<div class="dep-suggestion" onclick="addDependency(\'' + escapeHtml(c.claimId) + '\')">' +
+                            '<span>' + escapeHtml(c.claimId) + '</span>' +
+                            '<span class="claim-type ' + escapeHtml(c.truthType) + '">' + escapeHtml(truthTypeShort(c.truthType)) + '</span>' +
                         '</div>';
                     }).join('');
                     suggestions.classList.add('active');


### PR DESCRIPTION
## Summary
- Replace v1.1.0 ad-hoc data model with DeepSigma schema-aligned v2.0.0
- 6 epistemic truthTypes, structured confidence (0-1), statusLight, half-life decay, 4D coherence scoring, 8 drift signal types, typed claim graph edges, IRIS command palette queries
- +1261 / -755 lines (rename from v1.1.0 → v2.0.0, 60% similarity)

## Changes
- **Claim schema**: `CLAIM-YYYY-NNNN` IDs, `truthType` (observation/inference/assumption/forecast/norm/constraint), `confidence.score` (0-1) + explanation, `statusLight` (green/yellow/red), `halfLife` with decay model, `scope`, `seal`, `graph` with 5 typed edges
- **Coherence scoring**: 4-dimension model (policy_adherence w=0.25, outcome_health w=0.30, drift_control w=0.25, memory_completeness w=0.20) with A-F grading
- **Drift signals panel**: New tab with 8 canonical types, severity breakdown, fingerprint buckets, patch recommendations
- **IRIS queries**: Command palette supports `why`, `drift`, `status`, `changed`, `recall` prefixes
- **Blast radius**: Color-coded typed edges (blue=dependsOn, red=contradicts, green=supports, orange=supersedes, purple=patches)
- **New claim form**: truthType selector, confidence 0-1, scope, half-life config, classification tag, source reference
- **Edit/compare/export**: All updated for new schema

## Test plan
- [ ] Open v2.0.0 in browser — verify 4D coherence gauge with grade badge
- [ ] Claims table shows Claim ID, Truth Type, Status Light, Confidence bar, Half-Life
- [ ] Click claim → detail modal shows confidence object, half-life, scope, graph edges, sources
- [ ] Drift tab renders 8 signal types with severity and patch recommendations
- [ ] Blast radius shows color-coded typed edges with legend
- [ ] Cmd+K → type `why CLAIM-2024-0001` → evidence/source chain displayed
- [ ] New claim form generates CLAIM-YYYY-NNNN ID, uses 0-1 confidence slider
- [ ] Theme toggle, localStorage, notifications all persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)