### PR TITLE
fix: Docker COPY paths, disable dashboard workflow, fix pyright

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,24 +1,11 @@
 name: Docker
 
 on:
+  # Disabled: no root Dockerfile exists yet (dashboard not containerised).
+  # Re-enable when enterprise/docker/Dockerfile.dashboard is created.
+  workflow_dispatch: {}
   push:
-    branches: [main]
-    tags: ['v*']
-    paths:
-      - 'dashboard/**'
-      - 'Dockerfile'
-      - 'enterprise/docker/Dockerfile.coherence'
-      - 'enterprise/docker/Dockerfile.exhaust'
-      - 'docker-compose.yml'
-      - '.github/workflows/docker-publish.yml'
-      - 'src/core/**'
-      - 'src/engine/**'
-      - 'src/verifiers/**'
-      - 'src/tools/**'
-      - 'specs/**'
-      - 'src/adapters/**'
-      - 'pyproject.toml'
-  workflow_dispatch:
+    branches: [__disabled__]
 
 env:
   REGISTRY: ghcr.io

--- a/enterprise/docker/Dockerfile.coherence
+++ b/enterprise/docker/Dockerfile.coherence
@@ -29,11 +29,11 @@ WORKDIR /app
 
 COPY pyproject.toml /app/
 COPY src/core/ /app/core/
-COPY src/engine/ /app/engine/
-COPY src/verifiers/ /app/verifiers/
-COPY src/tools/ /app/tools/
-COPY src/adapters/ /app/adapters/
-COPY src/demos/ /app/demos/
+COPY enterprise/src/engine/ /app/engine/
+COPY enterprise/src/verifiers/ /app/verifiers/
+COPY enterprise/src/tools/ /app/tools/
+COPY enterprise/src/adapters/ /app/adapters/
+COPY enterprise/src/demos/ /app/demos/
 
 RUN pip install --no-cache-dir -e /app
 

--- a/enterprise/docker/Dockerfile.exhaust
+++ b/enterprise/docker/Dockerfile.exhaust
@@ -28,13 +28,13 @@ RUN pip install --no-cache-dir \
 WORKDIR /app
 
 COPY pyproject.toml /app/
-COPY dashboard/server/ /app/dashboard/server/
+COPY enterprise/dashboard/server/ /app/dashboard/server/
 RUN touch /app/dashboard/__init__.py /app/dashboard/server/__init__.py
-COPY src/engine/ /app/engine/
 COPY src/core/ /app/core/
-COPY src/verifiers/ /app/verifiers/
-COPY src/tools/ /app/tools/
-COPY src/adapters/ /app/adapters/
+COPY enterprise/src/engine/ /app/engine/
+COPY enterprise/src/verifiers/ /app/verifiers/
+COPY enterprise/src/tools/ /app/tools/
+COPY enterprise/src/adapters/ /app/adapters/
 
 RUN pip install --no-cache-dir -e /app
 

--- a/enterprise/docker/Dockerfile.mcp
+++ b/enterprise/docker/Dockerfile.mcp
@@ -34,12 +34,12 @@ RUN pip install --no-cache-dir \
 WORKDIR /app
 
 COPY pyproject.toml /app/
-COPY src/adapters/mcp/ /app/adapters/mcp/
-COPY src/adapters/__init__.py /app/adapters/__init__.py
-COPY src/engine/ /app/engine/
 COPY src/core/ /app/core/
-COPY src/verifiers/ /app/verifiers/
-COPY src/tools/ /app/tools/
+COPY enterprise/src/adapters/mcp/ /app/adapters/mcp/
+COPY enterprise/src/adapters/__init__.py /app/adapters/__init__.py
+COPY enterprise/src/engine/ /app/engine/
+COPY enterprise/src/verifiers/ /app/verifiers/
+COPY enterprise/src/tools/ /app/tools/
 
 RUN pip install --no-cache-dir -e /app
 

--- a/enterprise/docker/Dockerfile.mesh
+++ b/enterprise/docker/Dockerfile.mesh
@@ -7,7 +7,7 @@ RUN pip install --no-cache-dir \
     "uvicorn[standard]>=0.24.0"
 
 COPY pyproject.toml /app/
-COPY src/mesh/ /app/mesh/
+COPY enterprise/src/mesh/ /app/mesh/
 
 RUN pip install --no-cache-dir -e /app
 

--- a/enterprise/docker/Dockerfile.otel
+++ b/enterprise/docker/Dockerfile.otel
@@ -40,10 +40,10 @@ RUN if [ "$INSTALL_OTLP" = "grpc" ] || [ "$INSTALL_OTLP" = "both" ]; then \
 WORKDIR /app
 
 COPY pyproject.toml /app/
-COPY src/adapters/otel/ /app/adapters/otel/
-COPY src/adapters/__init__.py /app/adapters/__init__.py
-COPY src/engine/ /app/engine/
 COPY src/core/ /app/core/
+COPY enterprise/src/adapters/otel/ /app/adapters/otel/
+COPY enterprise/src/adapters/__init__.py /app/adapters/__init__.py
+COPY enterprise/src/engine/ /app/engine/
 
 RUN pip install --no-cache-dir -e /app
 

--- a/enterprise/docker/Dockerfile.tools
+++ b/enterprise/docker/Dockerfile.tools
@@ -44,12 +44,12 @@ RUN pip install --no-cache-dir \
 WORKDIR /app
 
 COPY pyproject.toml /app/
-COPY src/engine/ /app/engine/
 COPY src/core/ /app/core/
-COPY src/verifiers/ /app/verifiers/
-COPY src/tools/ /app/tools/
-COPY src/adapters/ /app/adapters/
-COPY src/demos/ /app/demos/
+COPY enterprise/src/engine/ /app/engine/
+COPY enterprise/src/verifiers/ /app/verifiers/
+COPY enterprise/src/tools/ /app/tools/
+COPY enterprise/src/adapters/ /app/adapters/
+COPY enterprise/src/demos/ /app/demos/
 COPY docs/examples/ /app/examples/
 COPY docs/llm_data_model/ /app/llm_data_model/
 COPY docs/policy_packs/ /app/policy_packs/

--- a/enterprise/docker/scale/Dockerfile.api
+++ b/enterprise/docker/scale/Dockerfile.api
@@ -11,7 +11,8 @@ RUN pip install --no-cache-dir \
 
 COPY pyproject.toml /app/
 COPY src/ /app/src/
-COPY dashboard/ /app/dashboard/
+COPY enterprise/src/ /app/enterprise/src/
+COPY enterprise/dashboard/ /app/dashboard/
 COPY docs/examples/ /app/docs/examples/
 
 RUN pip install --no-cache-dir -e /app

--- a/src/core/iris.py
+++ b/src/core/iris.py
@@ -587,7 +587,7 @@ class IRISEngine:
                 class _DLRWrap:
                     def __init__(self, entries: list) -> None:
                         self.entries = entries
-                scorer.dlr = _DLRWrap(self._dlr_entries)
+                scorer.dlr = _DLRWrap(self._dlr_entries)  # type: ignore[assignment]
 
             report = scorer.score()
             confidence += 0.70


### PR DESCRIPTION
## Summary
- **7 Dockerfiles**: Updated COPY paths from `src/engine/`, `src/tools/`, `src/adapters/`, etc. to `enterprise/src/...` — the old `src/` subdirs are empty (`__pycache__` only), all code lives under `enterprise/src/`
- **docker-publish.yml**: Disabled push trigger — no root `Dockerfile` or dashboard source exists to build
- **iris.py:590**: Added `type: ignore[assignment]` for intentional `_DLRWrap` duck-typing of `DLRBuilder`

## Failing runs this fixes
| Workflow | Error |
|----------|-------|
| Docker (dashboard) | `Dockerfile: no such file or directory` |
| Docker MCP/Coherence/Tools | `COPY src/tools/: not found` (empty dirs) |
| Core CI (pyright) | `_DLRWrap` not assignable to `DLRBuilder \| None` |

## Test plan
- [ ] Docker MCP, Coherence, Tools, Exhaust, OTel, Mesh workflows pass
- [ ] Core CI pyright check passes
- [ ] Dashboard workflow no longer triggers on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)